### PR TITLE
feat: adopt Supabase source of truth from next

### DIFF
--- a/.env.supabase.dev.local.example
+++ b/.env.supabase.dev.local.example
@@ -1,0 +1,3 @@
+# Copy to .env.supabase.dev.local and fill the real password locally.
+SUPABASE_DB_URL='postgresql://postgres.fotofiyqnuyvgtotswie:password@xxx.pooler.supabase.com:5432/postgres'
+SUPABASE_PROJECT_REF='fotofiyqnuyvgtotswie'

--- a/.env.supabase.main.local.example
+++ b/.env.supabase.main.local.example
@@ -1,0 +1,3 @@
+# Copy to .env.supabase.main.local and fill the real password locally.
+SUPABASE_DB_URL='postgresql://postgres.qgzvkongdjqiiamzbbts:password@xxx.pooler.supabase.com:5432/postgres'
+SUPABASE_PROJECT_REF='qgzvkongdjqiiamzbbts'

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -1,0 +1,31 @@
+name: Supabase Dev
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy-supabase-dev:
+    name: Deploy Supabase Migrations to Dev
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_DEV_PROJECT_ID }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link Supabase dev branch
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Push migrations to Supabase dev branch
+        run: supabase db push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.env.supabase*.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
+# database-engine
 
+`database-engine` is the Supabase database governance repository for the TianGong LCA workspace.
+
+It owns the checked-in database source of truth:
+
+- `supabase/config.toml`
+- `supabase/migrations/*.sql`
+- `supabase/seed.sql`
+- `supabase/seeds/*`
+- `supabase/tests/*.sql`
+- `.env.supabase.dev.local.example`
+- `.env.supabase.main.local.example`
+- Supabase branching and operations docs
+- the GitHub Actions flow that pushes committed migrations to the persistent Supabase `dev` branch
+
+It does **not** own:
+
+- frontend runtime env files such as `.env` or `.env.development`
+- app-side Supabase clients
+- Edge Function runtime code
+- ad-hoc manual dashboard changes as a long-term workflow
+
+Those stay in consumer repos such as:
+
+- `tiangong-lca-next` for frontend envs and app integration
+- `tiangong-lca-edge-functions` for Edge Function runtime code
+
+## Branch model
+
+- GitHub default branch: `main`
+- Daily trunk: `dev`
+- Routine PR target: `dev`
+- Promotion path: `dev -> main`
+
+## Quick start
+
+1. Start from the latest `dev`.
+2. Create a feature branch from `dev`.
+3. Use local Supabase for schema authoring and validation.
+4. Commit migrations, seeds, tests, and config changes together.
+5. Open the PR into `dev`.
+6. Validate the Supabase preview branch created for the PR.
+7. After merge, validate the persistent `dev` branch.
+8. Promote `dev` to `main` when ready to release.
+
+## Maintenance env files
+
+This repository keeps the operator-side Supabase branch-binding templates:
+
+- `.env.supabase.dev.local.example`
+- `.env.supabase.main.local.example`
+
+Copy them to `.env.supabase.dev.local` or `.env.supabase.main.local` for local-only credentials.
+Those real `.local` files are ignored by Git because they may contain remote database passwords.
+Frontend runtime env files stay in `tiangong-lca-next`.
+
+## Docs
+
+- English: `docs/agents/supabase-branching.md`
+- Chinese: `docs/agents/supabase-branching_CN.md`

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -1,0 +1,169 @@
+# Supabase Branching
+
+`database-engine` is the single Supabase source-of-truth repository for the TianGong LCA workspace.
+
+This repository owns:
+
+- `supabase/config.toml`
+- `supabase/migrations/*.sql`
+- `supabase/seed.sql`
+- `supabase/seeds/*`
+- `supabase/tests/*.sql`
+- `.env.supabase.dev.local.example`
+- `.env.supabase.main.local.example`
+- `.github/workflows/supabase-dev.yml`
+- branching and operations documentation for database delivery
+
+This repository does **not** own:
+
+- frontend runtime env files such as `.env` or `.env.development`
+- app-side Supabase client code
+- Edge Function runtime code
+
+Those stay in consumer repositories such as `tiangong-lca-next` and `tiangong-lca-edge-functions`.
+
+## Branch contract
+
+- Git `main` -> production baseline
+- Git `dev` -> persistent Supabase `dev` branch
+- PR / feature branches -> preview branches created by the Supabase GitHub integration
+
+Rules:
+
+- GitHub default branch remains `main` as a platform exception.
+- Daily trunk is Git `dev`.
+- Routine feature and fix branches start from `dev` and PR back into `dev`.
+- `dev -> main` is the promotion path.
+- Do not infer the working trunk from GitHub default-branch UI alone.
+
+## Repository contract
+
+- Keep one shared `supabase/` directory in Git.
+- Treat committed files in `supabase/migrations/` as the schema source of truth for production, `dev`, and preview branches.
+- Keep branch-specific overrides in `[remotes.<branch>]` inside `supabase/config.toml`.
+- Do not create a separate `supabase/` directory per Git branch.
+- Keep `.github/workflows/supabase-dev.yml` as the only GitHub Actions flow in this repo that runs `supabase db push` for the persistent Supabase `dev` branch.
+- Do not author normal schema changes by editing the remote database first and reconstructing migrations later.
+
+## Files to maintain
+
+- `supabase/config.toml`: shared baseline plus `[remotes.dev]`
+- `.github/workflows/supabase-dev.yml`: pushes committed migrations to the persistent Supabase `dev` branch on Git `dev`
+- `supabase/migrations/*.sql`: committed migration history
+- `supabase/seed.sql`: shared seed data
+- `supabase/seeds/dev.sql`: optional persistent-dev-only seed data
+- `supabase/tests/*.sql`: database assertions and safety checks
+- `.env.supabase.dev.local.example`: template for the persistent `dev` branch binding
+- `.env.supabase.main.local.example`: template for the `main` branch binding
+- `docs/agents/supabase-branching.md`: English branching workflow
+- `docs/agents/supabase-branching_CN.md`: Chinese branching workflow
+
+Frontend consumer-repo env files are intentionally **not** maintained here.
+
+## Operator env files
+
+Keep the branch-binding templates at the repository root:
+
+- `.env.supabase.dev.local.example`
+- `.env.supabase.main.local.example`
+
+Usage rules:
+
+- Copy them to `.env.supabase.dev.local` or `.env.supabase.main.local` for local-only secrets.
+- Do not commit the real `.local` files.
+- Use them for operator workflows that need `SUPABASE_PROJECT_REF` or `SUPABASE_DB_URL` for the persistent `dev` or `main` branches.
+- Frontend `.env` or `.env.development` files still belong in consumer repos such as `tiangong-lca-next`.
+
+## GitHub integration and secrets
+
+Supabase GitHub integration for the production project must point to:
+
+- repository: `tiangong-lca/database-engine`
+- relative path: `supabase`
+
+Repository configuration expected by `.github/workflows/supabase-dev.yml`:
+
+- variable `SUPABASE_DEV_PROJECT_ID`
+- secret `SUPABASE_ACCESS_TOKEN`
+- secret `SUPABASE_DEV_DB_PASSWORD`
+
+## Vault secret contract
+
+Database-side functions or triggers that call Edge Functions must read branch-specific Vault secrets.
+
+Current standard names:
+
+- `project_url`
+- `project_secret_key`
+- `project_x_key` only for the legacy `generate_flow_embedding()` compatibility path
+
+Rules:
+
+- Never hardcode branch URLs or service keys in SQL, migrations, or dumped baseline files.
+- Treat the values as branch-specific. `main`, persistent `dev`, and any preview branch that needs webhook execution must each have the required secrets.
+- If a branch is recreated or relinked, re-check the Vault entries before testing webhook-driven flows.
+
+## Default workflow
+
+### Routine schema change
+
+1. Sync local Git `dev`.
+2. Create a feature branch from `dev`.
+3. Start local Supabase.
+4. Make schema changes locally.
+5. Create a migration with `supabase migration new <name>` or `supabase db diff -f <name>`.
+6. Validate with `supabase db reset` and the relevant SQL tests.
+7. Commit migrations, seeds, tests, and config together.
+8. Open the PR into Git `dev`.
+9. Let Supabase create or update the preview branch for that PR.
+10. After merge, validate the persistent remote `dev` branch.
+11. Promote `dev` to `main` when ready to release.
+
+### Persistent `dev` branch deployment
+
+- Pushes to Git `dev` trigger `.github/workflows/supabase-dev.yml`.
+- That workflow links to the persistent Supabase `dev` branch and runs `supabase db push`.
+- Do not add a second automation path that pushes the same target.
+
+### Hotfix flow
+
+1. Branch from Git `main`.
+2. Fix the issue.
+3. Merge back to `main`.
+4. Back-merge `main` into `dev`.
+5. Keep migration history aligned across both long-lived branches.
+
+## Consumer repo boundaries
+
+Use `database-engine` for:
+
+- schema, policy, SQL function, trigger, seed, and config changes
+- preview / persistent branch behavior
+- database-side tests and migration recovery
+
+Use consumer repos for:
+
+- frontend env selection and app-side Supabase clients
+- Edge Function runtime implementation
+- app-level validation against `dev`, preview, or `main`
+
+If a task changes both database schema and application behavior, the database change still starts here.
+
+## Recovery rules
+
+- If local and remote migration histories diverge, inspect them with `supabase migration list` before changing anything else.
+- Use `supabase db pull` only to baseline an existing remote schema or to capture remote-only drift back into Git.
+- If a branch reaches `MIGRATIONS_FAILED`, fix the migration in Git and prefer recreating the failed branch over hand-editing remote state.
+- If remote history metadata is wrong, use `supabase migration repair` deliberately and then re-verify the result.
+
+## Local commands
+
+Use the Supabase CLI in this repository.
+
+- `supabase start`
+- `supabase db diff -f <name>`
+- `supabase migration new <name>`
+- `supabase db reset`
+- `supabase migration list`
+- `supabase link --project-ref <ref>`
+- `supabase db push`

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -1,0 +1,169 @@
+# Supabase Branching
+
+`database-engine` 是 TianGong LCA workspace 中唯一的 Supabase 真相源仓库。
+
+本仓库负责：
+
+- `supabase/config.toml`
+- `supabase/migrations/*.sql`
+- `supabase/seed.sql`
+- `supabase/seeds/*`
+- `supabase/tests/*.sql`
+- `.env.supabase.dev.local.example`
+- `.env.supabase.main.local.example`
+- `.github/workflows/supabase-dev.yml`
+- 数据库交付相关的 branching 与运维文档
+
+本仓库**不**负责：
+
+- 前端运行时 `.env` / `.env.development` 之类的环境文件
+- 应用侧 Supabase client 代码
+- Edge Function 运行时代码
+
+这些职责保留在 `tiangong-lca-next`、`tiangong-lca-edge-functions` 等消费者仓库中。
+
+## 分支契约
+
+- Git `main` -> 生产基线
+- Git `dev` -> 持久化 Supabase `dev` 分支
+- PR / feature 分支 -> 由 Supabase GitHub integration 自动创建的 preview branch
+
+规则：
+
+- GitHub default branch 继续保持 `main`，这是平台层例外。
+- 日常 trunk 是 Git `dev`。
+- routine feature / fix 分支从 `dev` 拉出，并向 `dev` 发起 PR。
+- `dev -> main` 是正式晋升路径。
+- 不要只根据 GitHub default-branch UI 推断实际工作 trunk。
+
+## 仓库契约
+
+- 在 Git 中只维护一套共享的 `supabase/` 目录。
+- 把 `supabase/migrations/` 中已提交的文件视为 production、`dev` 和 preview 分支共同遵循的 schema 真相源。
+- 分支差异放在 `supabase/config.toml` 的 `[remotes.<branch>]` 中。
+- 不要为不同 Git 分支复制多套 `supabase/` 目录。
+- 把 `.github/workflows/supabase-dev.yml` 作为本仓唯一会对持久化 Supabase `dev` 分支执行 `supabase db push` 的 GitHub Actions 流程。
+- 不要先手改远端数据库再回头补 migration。
+
+## 需要维护的文件
+
+- `supabase/config.toml`：共享基线加 `[remotes.dev]`
+- `.github/workflows/supabase-dev.yml`：在 Git `dev` 更新时，把已提交 migration 推送到持久化 Supabase `dev` 分支
+- `supabase/migrations/*.sql`：已提交的 migration 历史
+- `supabase/seed.sql`：共享 seed 数据
+- `supabase/seeds/dev.sql`：可选的持久化 dev 专属 seed 数据
+- `supabase/tests/*.sql`：数据库断言与安全检查
+- `.env.supabase.dev.local.example`：持久化 `dev` 分支绑定模板
+- `.env.supabase.main.local.example`：`main` 分支绑定模板
+- `docs/agents/supabase-branching.md`：英文 branching 文档
+- `docs/agents/supabase-branching_CN.md`：中文 branching 文档
+
+消费者仓的前端 env 文件不会放在这里维护。
+
+## 运维环境文件
+
+仓库根目录需要维护以下分支绑定模板：
+
+- `.env.supabase.dev.local.example`
+- `.env.supabase.main.local.example`
+
+使用规则：
+
+- 复制为 `.env.supabase.dev.local` 或 `.env.supabase.main.local` 后再填写本地真实密钥。
+- 真实 `.local` 文件禁止提交。
+- 这组文件用于需要 `SUPABASE_PROJECT_REF` 或 `SUPABASE_DB_URL` 的运维动作，对应持久化 `dev` 与 `main` 分支。
+- 前端 `.env` / `.env.development` 仍然归 `tiangong-lca-next` 等消费者仓维护。
+
+## GitHub integration 与密钥
+
+生产项目的 Supabase GitHub integration 应绑定到：
+
+- repository: `tiangong-lca/database-engine`
+- relative path: `supabase`
+
+`.github/workflows/supabase-dev.yml` 依赖以下仓库配置：
+
+- variable `SUPABASE_DEV_PROJECT_ID`
+- secret `SUPABASE_ACCESS_TOKEN`
+- secret `SUPABASE_DEV_DB_PASSWORD`
+
+## Vault secret 契约
+
+数据库侧函数或 trigger 调用 Edge Function 时，必须读取 branch-specific Vault secret。
+
+当前标准名称：
+
+- `project_url`
+- `project_secret_key`
+- `project_x_key` 仅用于兼容旧的 `generate_flow_embedding()` 路径
+
+规则：
+
+- 不要把 branch URL 或 service key 硬编码进 SQL、migration 或导出的 baseline 文件。
+- 这些值是 branch-specific 的。`main`、持久化 `dev`，以及任何需要执行 webhook 的 preview branch 都要各自提供所需 secret。
+- 如果 branch 被重建或重新关联，测试 webhook 之前要重新核对 Vault entries。
+
+## 默认工作流
+
+### 常规 schema 变更
+
+1. 同步本地 Git `dev`。
+2. 从 `dev` 创建 feature 分支。
+3. 启动本地 Supabase。
+4. 在本地完成 schema 变更。
+5. 用 `supabase migration new <name>` 或 `supabase db diff -f <name>` 生成 migration。
+6. 用 `supabase db reset` 和相关 SQL 测试完成验证。
+7. 把 migration、seed、测试和 config 一起提交。
+8. 向 Git `dev` 发起 PR。
+9. 让 Supabase 为该 PR 自动创建或更新 preview branch。
+10. 合并后，在持久化远端 `dev` 分支验证结果。
+11. 准备发布时，再把 `dev` 晋升到 `main`。
+
+### 持久化 `dev` 分支部署
+
+- 对 Git `dev` 的 push 会触发 `.github/workflows/supabase-dev.yml`。
+- 该 workflow 会连接持久化 Supabase `dev` 分支并执行 `supabase db push`。
+- 不要再增加第二条会对同一目标执行 push 的自动化链路。
+
+### Hotfix 流程
+
+1. 从 Git `main` 拉分支。
+2. 修复问题。
+3. 合并回 `main`。
+4. 再把 `main` 回合并到 `dev`。
+5. 保持两条长期分支上的 migration 历史一致。
+
+## 消费者仓边界
+
+以下变更应在 `database-engine` 完成：
+
+- schema、policy、SQL function、trigger、seed、config
+- preview / persistent branch 行为
+- 数据库侧测试与 migration 恢复
+
+以下内容保留在消费者仓完成：
+
+- 前端 env 选择与应用侧 Supabase client
+- Edge Function 运行时代码
+- 应用对 `dev`、preview、`main` 的联调验证
+
+如果一个需求同时改数据库和应用行为，数据库部分仍然从这里开始。
+
+## 恢复规则
+
+- 如果本地和远端 migration history 不一致，先用 `supabase migration list` 查清楚再继续。
+- `supabase db pull` 只用于为既有远端 schema 建 baseline，或把远端独有的 drift 回收到 Git。
+- 如果某个 branch 进入 `MIGRATIONS_FAILED`，优先在 Git 中修 migration 并重建失败分支，而不是手工硬改远端状态。
+- 如果远端 history 元数据本身错了，再有意识地执行 `supabase migration repair`，然后重新核对结果。
+
+## 本地命令
+
+在本仓内统一使用 Supabase CLI。
+
+- `supabase start`
+- `supabase db diff -f <name>`
+- `supabase migration new <name>`
+- `supabase db reset`
+- `supabase migration list`
+- `supabase link --project-ref <ref>`
+- `supabase db push`

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,9 @@
+# Supabase
+# Keep local CLI state out of Git. Config, migrations, seeds, and functions stay trackable.
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,438 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "database-engine"
+# Branching model for this repository:
+# - Git `main` -> primary production project using the shared baseline below
+# - Git `dev` -> persistent Supabase branch configured under [remotes.dev]
+# - Pull requests / feature branches -> ephemeral preview branches inheriting the shared baseline
+# Keep branch-specific overrides under [remotes.<branch>] instead of duplicating the `supabase/`
+# directory per Git branch.
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 55321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 55322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 55320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 55329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# Database-side edge-function webhooks use Vault secrets when configured.
+# Standard webhook auth uses `project_url` + `project_secret_key`.
+# Legacy `generate_flow_embedding()` compatibility additionally uses `project_x_key`.
+# [db.vault]
+# project_url = "env(SUPABASE_VAULT_PROJECT_URL)"
+# project_x_key = "env(SUPABASE_VAULT_PROJECT_X_KEY)"
+# project_secret_key = "env(SUPABASE_VAULT_PROJECT_SECRET_KEY)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 55323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 55324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "https://lca.tiangong.earth"
+# Production and preview branches currently support the hosted app plus local development.
+# Add a preview deployment wildcard here later if the frontend starts shipping per-PR preview URLs.
+additional_redirect_urls = [
+  "http://127.0.0.1:8000/*",
+  "http://localhost:8000/*",
+  "https://lca.tiangong.earth/*",
+]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 55327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./declarative"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+
+# Persistent branch overrides for Supabase Branching.
+# Keep this project ref synchronized with the actual persistent `dev` branch returned by
+# `npx supabase --experimental branches list --project-ref qgzvkongdjqiiamzbbts`.
+[remotes.dev]
+project_id = "fotofiyqnuyvgtotswie"
+
+[remotes.dev.auth]
+site_url = "http://localhost:8000"
+additional_redirect_urls = [
+  "http://127.0.0.1:8000/*",
+  "http://localhost:8000/*",
+]
+
+# Keep shared seed data in `seed.sql`. Put non-production fixtures here if the persistent `dev`
+# branch needs its own dataset.
+[remotes.dev.db.seed]
+enabled = true
+sql_paths = ["./seeds/dev.sql"]

--- a/supabase/migrations/20260404071514_main_public_baseline.sql
+++ b/supabase/migrations/20260404071514_main_public_baseline.sql
@@ -1,0 +1,6648 @@
+
+
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+
+CREATE EXTENSION IF NOT EXISTS "pg_cron" WITH SCHEMA "pg_catalog";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pg_net" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pgroonga" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pgsodium";
+
+
+
+
+
+
+COMMENT ON SCHEMA "public" IS 'standard public schema';
+
+
+
+CREATE SCHEMA IF NOT EXISTS "util";
+
+
+ALTER SCHEMA "util" OWNER TO "postgres";
+
+
+CREATE EXTENSION IF NOT EXISTS "hstore" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "http" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "hypopg" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "index_advisor" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pg_graphql" WITH SCHEMA "graphql";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pg_stat_statements" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "pgmq";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "supabase_vault" WITH SCHEMA "vault";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE EXTENSION IF NOT EXISTS "vector" WITH SCHEMA "extensions";
+
+
+
+
+
+
+CREATE TYPE "public"."filtered_row" AS (
+	"id" "uuid",
+	"embedding" "extensions"."vector"(1536)
+);
+
+
+ALTER TYPE "public"."filtered_row" OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."_navicat_temp_stored_proc"("query_text" "text", "query_embedding" "extensions"."vector", "filter_condition" "text" DEFAULT ''::"text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20, "full_text_weight" numeric DEFAULT 0.3, "extracted_text_weight" numeric DEFAULT 0.2, "semantic_weight" numeric DEFAULT 0.5, "rrf_k" integer DEFAULT 10, "data_source" "text" DEFAULT 'tg'::"text", "this_user_id" "text" DEFAULT ''::"text", "page_size" integer DEFAULT 10, "page_current" integer DEFAULT 1) RETURNS TABLE("id" "uuid", "json" "jsonb")
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$ BEGIN
+		RETURN QUERY WITH 
+		full_text AS (
+			SELECT
+				ps.RANK AS ps_rank,
+				ps.ID AS ps_id,
+				ps.JSON AS ps_json 
+			FROM
+				pgroonga_search_processes ( query_text, filter_condition, 20, -- page_size: 获取足够多候选
+					1, -- page_current: 第1页
+				data_source, this_user_id ) ps 
+		),
+		ex_text AS (
+    SELECT
+      ex.rank AS ex_rank,
+      ex.id   AS ex_id,
+      p.json  AS ex_json
+    FROM pgroonga_search_processes_text(
+           query_text,
+           20,          -- page_size
+           1,      -- page_current
+           data_source,
+           this_user_id
+         ) ex
+    JOIN public.processes p ON p.id = ex.id
+  ),
+		semantic AS (
+			SELECT
+				ss.RANK AS ss_rank,
+				ss.ID AS ss_id,
+				ss.JSON AS ss_json 
+			FROM
+				semantic_search_processes ( query_embedding, filter_condition, match_threshold, match_count, data_source, this_user_id ) ss 
+		) SELECT COALESCE
+		( full_text.ps_id, semantic.ss_id, ex_text.ex_id ) AS ID,
+		COALESCE ( full_text.ps_json, semantic.ss_json, ex_text.ex_json) AS JSON, 
+		COALESCE(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+      + COALESCE(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * text_weight
+      + COALESCE(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight
+      AS score
+		FROM
+			full_text
+			FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+			FULL OUTER JOIN ex_text ON ex_text.ex_id = COALESCE(full_text.ps_id, semantic.ss_id) 
+		ORDER BY
+			score DESC 
+			LIMIT page_size OFFSET ( page_current - 1 ) * page_size;
+		
+	END;
+$$;
+
+
+ALTER FUNCTION "public"."_navicat_temp_stored_proc"("query_text" "text", "query_embedding" "extensions"."vector", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" numeric, "extracted_text_weight" numeric, "semantic_weight" numeric, "rrf_k" integer, "data_source" "text", "this_user_id" "text", "page_size" integer, "page_current" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."_navicat_temp_stored_proc"("query_text" "text", "query_embedding" "text", "filter_condition" "text" DEFAULT ''::"text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20, "full_text_weight" numeric DEFAULT 0.3, "extracted_text_weight" numeric DEFAULT 0.2, "semantic_weight" numeric DEFAULT 0.5, "rrf_k" integer DEFAULT 10, "data_source" "text" DEFAULT 'tg'::"text", "this_user_id" "text" DEFAULT ''::"text", "page_size" integer DEFAULT 10, "page_current" integer DEFAULT 1) RETURNS TABLE("id" "uuid", "json" "jsonb")
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$ BEGIN
+		RETURN QUERY WITH 
+		full_text AS (
+			SELECT
+				ps.RANK AS ps_rank,
+				ps.ID AS ps_id,
+				ps.JSON AS ps_json 
+			FROM
+				pgroonga_search_processes ( query_text, filter_condition, 20, -- page_size: 获取足够多候选
+					1, -- page_current: 第1页
+				data_source, this_user_id ) ps 
+		),
+		ex_text AS (
+    SELECT
+      ex.rank AS ex_rank,
+      ex.id   AS ex_id,
+      p.json  AS ex_json
+    FROM pgroonga_search_processes_text(
+           query_text,
+           20,          -- page_size
+           1,      -- page_current
+           data_source,
+           this_user_id
+         ) ex
+    JOIN public.processes p ON p.id = ex.id
+  ),
+		semantic AS (
+			SELECT
+				ss.RANK AS ss_rank,
+				ss.ID AS ss_id,
+				ss.JSON AS ss_json 
+			FROM
+				semantic_search_processes ( query_embedding, filter_condition, match_threshold, match_count, data_source, this_user_id ) ss 
+		) SELECT COALESCE
+		( full_text.ps_id, semantic.ss_id, ex_text.ex_id ) AS ID,
+		COALESCE ( full_text.ps_json, semantic.ss_json, ex_text.ex_json) AS JSON, 
+		COALESCE(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+      + COALESCE(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * text_weight
+      + COALESCE(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight
+      AS score
+		FROM
+			full_text
+			FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+			FULL OUTER JOIN ex_text ON ex_text.ex_id = COALESCE(full_text.ps_id, semantic.ss_id) 
+		ORDER BY
+			score DESC 
+			LIMIT page_size OFFSET ( page_current - 1 ) * page_size;
+		
+	END;
+$$;
+
+
+ALTER FUNCTION "public"."_navicat_temp_stored_proc"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" numeric, "extracted_text_weight" numeric, "semantic_weight" numeric, "rrf_k" integer, "data_source" "text", "this_user_id" "text", "page_size" integer, "page_current" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."contacts_sync_jsonb_version"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb THEN
+        NEW.json := NEW.json_ordered;
+        NEW.version := COALESCE(
+            NEW.json->'contactDataSet'->'administrativeInformation'->'publicationAndOwnership'->>'common:dataSetVersion', 
+            ''
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."contacts_sync_jsonb_version"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."delete_lifecycle_model_bundle"("p_model_id" "uuid", "p_version" "text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $_$
+DECLARE
+    v_model_row lifecyclemodels%ROWTYPE;
+    v_submodel jsonb;
+    v_submodel_version text;
+    v_rows_affected integer;
+BEGIN
+    IF p_model_id IS NULL OR nullif(btrim(coalesce(p_version, '')), '') IS NULL THEN
+        RAISE EXCEPTION 'INVALID_PLAN';
+    END IF;
+
+    SELECT *
+      INTO v_model_row
+      FROM lifecyclemodels
+     WHERE id = p_model_id
+       AND version = p_version
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'MODEL_NOT_FOUND';
+    END IF;
+
+    FOR v_submodel IN
+        SELECT value
+          FROM jsonb_array_elements(coalesce(v_model_row.json_tg->'submodels', '[]'::jsonb))
+    LOOP
+        IF nullif(v_submodel->>'id', '') IS NOT NULL THEN
+            v_submodel_version := coalesce(
+                nullif(btrim(coalesce(v_submodel->>'version', '')), ''),
+                p_version
+            );
+
+            EXECUTE 'del' || 'ete from processes where id = $1 and version = $2 and model_id = $3'
+               USING (v_submodel->>'id')::uuid, v_submodel_version, p_model_id;
+
+            GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+            IF v_rows_affected = 0 THEN
+                RAISE EXCEPTION 'PROCESS_NOT_FOUND';
+            END IF;
+        END IF;
+    END LOOP;
+
+    EXECUTE 'del' || 'ete from lifecyclemodels where id = $1 and version = $2'
+       USING p_model_id, p_version;
+
+    GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+    IF v_rows_affected = 0 THEN
+        RAISE EXCEPTION 'MODEL_NOT_FOUND';
+    END IF;
+
+    RETURN jsonb_build_object(
+        'model_id', p_model_id,
+        'version', p_version
+    );
+END;
+$_$;
+
+
+ALTER FUNCTION "public"."delete_lifecycle_model_bundle"("p_model_id" "uuid", "p_version" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."flowproperties_sync_jsonb_version"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb THEN
+        NEW.json := NEW.json_ordered;
+        NEW.version := COALESCE( NEW.json->'flowPropertyDataSet'->'administrativeInformation'->'publicationAndOwnership'->>'common:dataSetVersion',
+					''
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."flowproperties_sync_jsonb_version"() OWNER TO "postgres";
+
+SET default_tablespace = '';
+
+SET default_table_access_method = "heap";
+
+
+CREATE TABLE IF NOT EXISTS "public"."flows" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "state_code" integer DEFAULT 0,
+    "version" character(9) NOT NULL,
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "embedding" "extensions"."halfvec"(384),
+    "embedding_at" timestamp(6) with time zone DEFAULT NULL::timestamp with time zone,
+    "extracted_text" "text",
+    "team_id" "uuid",
+    "review_id" "uuid",
+    "rule_verification" boolean,
+    "reviews" "jsonb",
+    "embedding_flag" smallint,
+    "embedding_ft_at" timestamp with time zone,
+    "extracted_md" "text",
+    "embedding_ft" "extensions"."vector"(1024)
+);
+
+
+ALTER TABLE "public"."flows" OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."flows_embedding_ft_input"("proc" "public"."flows") RETURNS "text"
+    LANGUAGE "plpgsql" IMMUTABLE
+    SET "search_path" TO 'public'
+    AS $$
+begin
+  return proc.extracted_md;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."flows_embedding_ft_input"("proc" "public"."flows") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."flows_embedding_input"("flow" "public"."flows") RETURNS "text"
+    LANGUAGE "plpgsql" IMMUTABLE
+    SET "search_path" TO 'public'
+    AS $$
+begin
+  return flow.extracted_text;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."flows_embedding_input"("flow" "public"."flows") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."flows_sync_jsonb_version"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb THEN
+        NEW.json := NEW.json_ordered;
+		NEW.version := COALESCE( NEW.json->'flowDataSet'->'administrativeInformation'->'publicationAndOwnership'->>'common:dataSetVersion',
+					''
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."flows_sync_jsonb_version"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."generate_flow_embedding"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+  request_url text;
+  legacy_x_key text;
+BEGIN
+  request_url := util.project_url();
+  legacy_x_key := util.project_x_key();
+
+  SELECT embedding, extracted_text INTO NEW.embedding, NEW.extracted_text
+  FROM supabase_functions.http_request(
+    request_url || '/functions/v1/flow_embedding',
+    'POST',
+    jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x_key', legacy_x_key,
+      'x_region', 'us-east-1'
+    )::text,
+    to_json(NEW.json_ordered)::text,
+    '1000'
+  );
+  RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."generate_flow_embedding"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_flows"("query_text" "text", "query_embedding" "text", "filter_condition" "text" DEFAULT ''::"text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20, "full_text_weight" double precision DEFAULT 0.3, "extracted_text_weight" double precision DEFAULT 0.2, "semantic_weight" double precision DEFAULT 0.5, "rrf_k" integer DEFAULT 10, "data_source" "text" DEFAULT 'tg'::"text", "page_size" integer DEFAULT 10, "page_current" integer DEFAULT 1) RETURNS TABLE("id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+ BEGIN
+		RETURN QUERY WITH full_text AS (
+			SELECT
+				ps.RANK AS ps_rank,
+				ps.ID AS ps_id,
+				ps.JSON AS ps_json 
+			FROM
+				pgroonga_search_flows_v1 ( query_text, filter_condition, '', 20, -- page_size: 获取足够多候选
+					1, -- page_current: 第1页
+				data_source ) ps 
+		),
+		ex_text AS (
+			SELECT
+				ex.RANK AS ex_rank,
+				ex.ID AS ex_id,
+				P.JSON AS ex_json 
+			FROM
+				pgroonga_search_flows_text_v1 ( query_text, 20, -- page_size
+					1, -- page_current
+				data_source ) ex
+				JOIN PUBLIC.flows P ON P.ID = ex.ID 
+		),
+		semantic AS (
+			SELECT
+				ss.RANK AS ss_rank,
+				ss.ID AS ss_id,
+				ss.JSON AS ss_json 
+			FROM
+				semantic_search_flows_v1 ( query_embedding, filter_condition, match_threshold, match_count, data_source ) ss 
+		), 
+		fused_raw as (
+		SELECT 
+			COALESCE ( full_text.ps_id, semantic.ss_id, ex_text.ex_id ) AS ID,
+			COALESCE ( full_text.ps_json, semantic.ss_json, ex_text.ex_json ) AS JSON,
+			COALESCE ( 1.0 / ( rrf_k + full_text.ps_rank ), 0.0 ) * full_text_weight
+			+ COALESCE ( 1.0 / ( rrf_k + ex_text.ex_rank ), 0.0 ) * extracted_text_weight
+			+ COALESCE ( 1.0 / ( rrf_k + semantic.ss_rank ), 0.0 ) * semantic_weight AS score 
+		FROM
+			full_text
+			FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+			FULL OUTER JOIN ex_text ON ex_text.ex_id = COALESCE ( full_text.ps_id, semantic.ss_id ) 
+		),
+		fused AS (
+			SELECT
+				fr.id AS fid,
+				SUM(fr.score) AS score
+			FROM fused_raw fr
+			WHERE fr.id IS NOT NULL
+			GROUP BY fr.id
+		)
+		SELECT
+			f.fid AS id,
+			fl.json,
+			fl.version,
+			fl.modified_at
+		FROM fused f
+		JOIN LATERAL (
+			SELECT fl.json, fl.version, fl.modified_at
+			FROM public.flows fl
+			WHERE fl.id = f.fid
+			ORDER BY fl.modified_at DESC
+			LIMIT 1
+		) fl ON true
+		ORDER BY f.score DESC
+		LIMIT page_size OFFSET ( page_current - 1 ) * page_size;
+		
+	END;
+$$;
+
+
+ALTER FUNCTION "public"."hybrid_search_flows"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_lifecyclemodels"("query_text" "text", "query_embedding" "text", "filter_condition" "text" DEFAULT ''::"text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20, "full_text_weight" double precision DEFAULT 0.3, "extracted_text_weight" double precision DEFAULT 0.2, "semantic_weight" double precision DEFAULT 0.5, "rrf_k" integer DEFAULT 10, "data_source" "text" DEFAULT 'tg'::"text", "page_size" integer DEFAULT 10, "page_current" integer DEFAULT 1) RETURNS TABLE("id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+ BEGIN
+		RETURN QUERY WITH full_text AS (
+			SELECT
+				ps.RANK AS ps_rank,
+				ps.ID AS ps_id,
+				ps.JSON AS ps_json
+			FROM
+			 	-- page_size: 获取足够多候选， page_current: 第1页
+				pgroonga_search_lifecyclemodels_v1 ( query_text, filter_condition, '', 20, 1, data_source ) ps 
+		),
+		ex_text AS (
+			SELECT
+				ex.RANK AS ex_rank,
+				ex.ID AS ex_id,
+				P.JSON AS ex_json
+			FROM
+				pgroonga_search_lifecyclemodels_text_v1( query_text, 20, 1, data_source ) ex
+				JOIN PUBLIC.lifecyclemodels P ON P.ID = ex.ID 
+		),
+		semantic AS (
+			SELECT
+				ss.RANK AS ss_rank,
+				ss.ID AS ss_id,
+				ss.JSON AS ss_json
+			FROM
+				semantic_search_lifecyclemodels_v1 ( query_embedding, filter_condition, match_threshold, match_count, data_source ) ss 
+		), 
+		fused_raw as (
+		SELECT 
+			COALESCE ( full_text.ps_id, semantic.ss_id, ex_text.ex_id ) AS ID,
+			COALESCE ( full_text.ps_json, semantic.ss_json, ex_text.ex_json ) AS JSON,
+			COALESCE ( 1.0 / ( rrf_k + full_text.ps_rank ), 0.0 ) * full_text_weight + COALESCE ( 1.0 / ( rrf_k + ex_text.ex_rank ), 0.0 ) * extracted_text_weight + COALESCE ( 1.0 / ( rrf_k + semantic.ss_rank ), 0.0 ) * semantic_weight AS score 
+		FROM
+			full_text
+			FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+			FULL OUTER JOIN ex_text ON ex_text.ex_id = COALESCE ( full_text.ps_id, semantic.ss_id ) 
+		),
+		fused AS (
+			SELECT
+				fr.id AS pid,
+				SUM(fr.score) AS score
+				-- 如果你不希望“多路径叠加加分”，把 SUM 改成 MAX
+			FROM fused_raw fr
+			WHERE fr.id IS NOT NULL
+			GROUP BY fr.id
+		)
+		SELECT
+			f.pid AS id,
+			p.json,
+			p.version,
+			p.modified_at
+		FROM fused f
+		JOIN LATERAL (
+			SELECT p.json, p.version, p.modified_at
+			FROM public.lifecyclemodels p
+			WHERE p.id = f.pid
+			ORDER BY p.modified_at DESC
+			LIMIT 1
+		) p ON true
+		ORDER BY f.score DESC
+		LIMIT page_size OFFSET ( page_current - 1 ) * page_size;
+		
+	END;
+$$;
+
+
+ALTER FUNCTION "public"."hybrid_search_lifecyclemodels"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_processes"("query_text" "text", "query_embedding" "text", "filter_condition" "text" DEFAULT ''::"text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20, "full_text_weight" double precision DEFAULT 0.3, "extracted_text_weight" double precision DEFAULT 0.2, "semantic_weight" double precision DEFAULT 0.5, "rrf_k" integer DEFAULT 10, "data_source" "text" DEFAULT 'tg'::"text", "page_size" integer DEFAULT 10, "page_current" integer DEFAULT 1) RETURNS TABLE("id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "model_id" "uuid")
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+ BEGIN
+		RETURN QUERY WITH full_text AS (
+			SELECT
+				ps.RANK AS ps_rank,
+				ps.ID AS ps_id,
+				ps.JSON AS ps_json
+			FROM
+			 	-- page_size: 获取足够多候选， page_current: 第1页
+				pgroonga_search_processes_v1 ( query_text, filter_condition, '', 20, 1, data_source ) ps 
+		),
+		ex_text AS (
+			SELECT
+				ex.RANK AS ex_rank,
+				ex.ID AS ex_id,
+				P.JSON AS ex_json
+			FROM
+				pgroonga_search_processes_text_v1( query_text, 20, 1, data_source ) ex
+				JOIN PUBLIC.processes P ON P.ID = ex.ID 
+		),
+		semantic AS (
+			SELECT
+				ss.RANK AS ss_rank,
+				ss.ID AS ss_id,
+				ss.JSON AS ss_json
+			FROM
+				semantic_search_processes_v1 ( query_embedding, filter_condition, match_threshold, match_count, data_source ) ss 
+		), 
+		fused_raw as (
+		SELECT 
+			COALESCE ( full_text.ps_id, semantic.ss_id, ex_text.ex_id ) AS ID,
+			COALESCE ( full_text.ps_json, semantic.ss_json, ex_text.ex_json ) AS JSON,
+			COALESCE ( 1.0 / ( rrf_k + full_text.ps_rank ), 0.0 ) * full_text_weight + COALESCE ( 1.0 / ( rrf_k + ex_text.ex_rank ), 0.0 ) * extracted_text_weight + COALESCE ( 1.0 / ( rrf_k + semantic.ss_rank ), 0.0 ) * semantic_weight AS score 
+		FROM
+			full_text
+			FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+			FULL OUTER JOIN ex_text ON ex_text.ex_id = COALESCE ( full_text.ps_id, semantic.ss_id ) 
+		),
+		fused AS (
+			SELECT
+				fr.id AS pid,
+				SUM(fr.score) AS score
+				-- 如果你不希望“多路径叠加加分”，把 SUM 改成 MAX
+			FROM fused_raw fr
+			WHERE fr.id IS NOT NULL
+			GROUP BY fr.id
+		)
+		SELECT
+			f.pid AS id,
+			p.json,
+			p.version,
+			p.modified_at,
+			p.model_id
+		FROM fused f
+		JOIN LATERAL (
+			SELECT p.json, p.version, p.modified_at, p.model_id
+			FROM public.processes p
+			WHERE p.id = f.pid
+			ORDER BY p.modified_at DESC
+			LIMIT 1
+		) p ON true
+		ORDER BY f.score DESC
+		LIMIT page_size OFFSET ( page_current - 1 ) * page_size;
+		
+	END;
+$$;
+
+
+ALTER FUNCTION "public"."hybrid_search_processes"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."ilcd_classification_get"("this_file_name" "text", "category_type" "text", "get_values" "text"[]) RETURNS SETOF "jsonb"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+  RETURN QUERY
+  SELECT cgs2.cg
+  FROM (
+  select 
+		cgs1.file_name,
+	  cgs1.cg->>'@dataType' as cg_type,
+      jsonb_array_elements(cgs1.cg -> 'category') AS cg
+from
+(
+    SELECT
+      ilcd.file_name,
+      jsonb_array_elements(ilcd.json -> 'CategorySystem' -> 'categories') AS cg
+    FROM
+      ilcd
+    WHERE ilcd.file_name = this_file_name
+	) as cgs1
+	where cgs1.cg->>'@dataType' = category_type
+	  ) as cgs2
+	  WHERE cgs2.cg->>'@name' = ANY(get_values) or cgs2.cg->>'@id' = ANY(get_values) or 'all' = ANY(get_values)
+	;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."ilcd_classification_get"("this_file_name" "text", "category_type" "text", "get_values" "text"[]) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."ilcd_flow_categorization_get"("this_file_name" "text", "get_values" "text"[]) RETURNS SETOF "jsonb"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+  RETURN QUERY
+  SELECT cg
+  FROM (
+    SELECT
+      ilcd.file_name,
+      jsonb_array_elements(ilcd.json -> 'CategorySystem' -> 'categories' -> 'category') AS cg
+    FROM
+      ilcd
+    WHERE ilcd.file_name = this_file_name
+  ) AS cgs
+  WHERE cgs.cg->>'@name' = ANY(get_values)  or cgs.cg->>'@id' = ANY(get_values) or 'all' = ANY(get_values);
+END;
+$$;
+
+
+ALTER FUNCTION "public"."ilcd_flow_categorization_get"("this_file_name" "text", "get_values" "text"[]) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."ilcd_location_get"("this_file_name" "text", "get_values" "text"[]) RETURNS SETOF "jsonb"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+  RETURN QUERY
+  SELECT lc
+  FROM (
+    SELECT
+      ilcd.file_name,
+      jsonb_array_elements(ilcd.json -> 'ILCDLocations' -> 'location') AS lc
+    FROM
+      ilcd
+    WHERE ilcd.file_name = this_file_name
+  ) AS lcs
+  WHERE lcs.lc->>'@value' = ANY(get_values);
+END;
+$$;
+
+
+ALTER FUNCTION "public"."ilcd_location_get"("this_file_name" "text", "get_values" "text"[]) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."lca_enqueue_job"("p_queue_name" "text", "p_message" "jsonb") RETURNS bigint
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'pgmq'
+    AS $$
+DECLARE
+    v_msg_id bigint;
+BEGIN
+    IF p_queue_name IS NULL OR btrim(p_queue_name) = '' THEN
+        RAISE EXCEPTION 'queue name is required';
+    END IF;
+
+    SELECT pgmq.send(p_queue_name, p_message)
+      INTO v_msg_id;
+
+    RETURN v_msg_id;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."lca_enqueue_job"("p_queue_name" "text", "p_message" "jsonb") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."lca_package_enqueue_job"("p_message" "jsonb") RETURNS bigint
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'pgmq'
+    AS $$
+DECLARE
+    v_msg_id bigint;
+BEGIN
+    SELECT pgmq.send('lca_package_jobs', p_message)
+      INTO v_msg_id;
+
+    RETURN v_msg_id;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."lca_package_enqueue_job"("p_message" "jsonb") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."lciamethods_sync_jsonb_version"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb THEN
+        NEW.json := NEW.json_ordered;
+        NEW.version := NEW.json->'LCIAMethodDataSet'->'administrativeInformation'->'publicationAndOwnership'->>'common:dataSetVersion';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."lciamethods_sync_jsonb_version"() OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lifecyclemodels" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp(6) with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "state_code" integer DEFAULT 0,
+    "version" character(9) NOT NULL,
+    "json_tg" "jsonb",
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "team_id" "uuid",
+    "rule_verification" boolean,
+    "reviews" "jsonb",
+    "extracted_text" "text",
+    "embedding" "extensions"."halfvec"(384),
+    "embedding_at" timestamp with time zone,
+    "embedding_flag" smallint,
+    "extracted_md" "text",
+    "embedding_ft_at" timestamp with time zone,
+    "embedding_ft" "extensions"."vector"(1024)
+);
+
+
+ALTER TABLE "public"."lifecyclemodels" OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."lifecyclemodels_embedding_ft_input"("proc" "public"."lifecyclemodels") RETURNS "text"
+    LANGUAGE "plpgsql" IMMUTABLE
+    SET "search_path" TO 'public'
+    AS $$
+begin
+  return proc.extracted_md;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."lifecyclemodels_embedding_ft_input"("proc" "public"."lifecyclemodels") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."lifecyclemodels_embedding_input"("models" "public"."lifecyclemodels") RETURNS "text"
+    LANGUAGE "plpgsql" IMMUTABLE
+    SET "search_path" TO 'public'
+    AS $$
+begin
+  return models.extracted_text;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."lifecyclemodels_embedding_input"("models" "public"."lifecyclemodels") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."lifecyclemodels_sync_jsonb_version"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb THEN
+        NEW.json := NEW.json_ordered;
+        NEW.version := NEW.json->'lifeCycleModelDataSet'->'administrativeInformation'->'publicationAndOwnership'->>'common:dataSetVersion';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."lifecyclemodels_sync_jsonb_version"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search"("query_text" "text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb")
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+BEGIN
+  RETURN QUERY
+		SELECT 
+			RANK () OVER (ORDER BY pgroonga_score(f.tableoid, f.ctid) DESC) AS rank, 
+			f.id, 
+			f.json
+		FROM flows f
+		WHERE f.extracted_text &@~ query_text
+		ORDER BY pgroonga_score(tableoid, ctid) DESC;
+END;$$;
+
+
+ALTER FUNCTION "public"."pgroonga_search"("query_text" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_contacts"("query_text" "text", "filter_condition" "text" DEFAULT ''::"text", "page_size" bigint DEFAULT 10, "page_current" bigint DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text", "this_user_id" "text" DEFAULT ''::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+    filter_condition_jsonb JSONB;
+BEGIN
+	filter_condition_jsonb := filter_condition::JSONB;
+  RETURN QUERY
+		SELECT 
+			RANK () OVER (ORDER BY pgroonga_score(f.tableoid, f.ctid) DESC) AS rank, 
+			f.id, 
+			f.json,
+			f.version,
+			f.modified_at,
+			COUNT(*) OVER() AS total_count
+		FROM contacts f
+		WHERE f.json @> filter_condition_jsonb AND f.json &@~ query_text AND ((data_source = 'tg' AND state_code = 100) or (data_source = 'my' AND user_id::text = this_user_id))
+		ORDER BY pgroonga_score(tableoid, ctid) DESC
+		LIMIT page_size
+		OFFSET (page_current -1) * page_size;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_contacts"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flowproperties"("query_text" "text", "filter_condition" "text" DEFAULT ''::"text", "page_size" bigint DEFAULT 10, "page_current" bigint DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text", "this_user_id" "text" DEFAULT ''::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+    filter_condition_jsonb JSONB;
+BEGIN
+	filter_condition_jsonb := filter_condition::JSONB;
+  RETURN QUERY
+		SELECT 
+			RANK () OVER (ORDER BY pgroonga_score(f.tableoid, f.ctid) DESC) AS rank, 
+			f.id, 
+			f.json,
+			f.version,
+			f.modified_at,
+			COUNT(*) OVER() AS total_count
+		FROM flowproperties f
+		WHERE f.json @> filter_condition_jsonb AND f.json &@~ query_text AND ((data_source = 'tg' AND state_code = 100) or (data_source = 'my' AND user_id::text = this_user_id))
+		ORDER BY pgroonga_score(tableoid, ctid) DESC
+		LIMIT page_size
+		OFFSET (page_current -1) * page_size;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_flowproperties"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flows_text_v1"("query_text" "text", "page_size" integer DEFAULT 10, "page_current" integer DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "extracted_text" "text", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+BEGIN
+  RETURN QUERY
+		SELECT 
+			RANK () OVER (ORDER BY pgroonga_score(f.tableoid, f.ctid) DESC) AS rank, 
+			f.id, 
+			f.extracted_text,
+			f.version,
+			f.modified_at,
+			COUNT(*) OVER() AS total_count
+		FROM public.flows AS f
+		WHERE f.extracted_text &@~ query_text AND ((data_source = 'tg' AND state_code = 100) or (data_source = 'co' AND state_code = 200) or (data_source = 'my' AND user_id = auth.uid())
+																			  or (data_source = 'te' and
+		EXISTS ( 
+						SELECT 1
+						FROM roles r
+						WHERE r.user_id = auth.uid() and r.team_id =  f.team_id
+						AND r.role::text IN ('admin', 'member', 'owner') 
+				)
+			)
+		)
+		ORDER BY pgroonga_score(tableoid, ctid) DESC
+		LIMIT page_size
+		OFFSET (page_current -1) * page_size;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_flows_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flows_v1"("query_text" "text", "filter_condition" "text" DEFAULT ''::"text", "order_by" "text" DEFAULT ''::"text", "page_size" bigint DEFAULT 10, "page_current" bigint DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $_$
+ 
+DECLARE 
+	filter_condition_jsonb JSONB;
+	flowType TEXT;
+	flowTypeArray TEXT[];
+	asInput BOOLEAN;
+	use_base_name_order boolean := false;
+	use_common_category_order boolean := false;
+	use_zh_icu_order boolean := false;
+	order_by_jsonb jsonb;
+	order_key text;
+	order_lang text;
+	order_dir text;
+	order_lang_norm text;
+BEGIN
+	-- order_by 输入格式（标准 JSON）：{"key":"baseName","lang":"zh","order":"asc"} 或 {"key":"common:category","order":"asc"}
+
+	filter_condition_jsonb := COALESCE(NULLIF(btrim(filter_condition), ''), '{}')::JSONB;
+
+	flowType := NULLIF(btrim(filter_condition_jsonb->>'flowType'), '');
+	IF flowType IS NOT NULL THEN
+		flowTypeArray := string_to_array(flowType, ',');
+	ELSE
+		flowTypeArray := NULL;
+	END IF;
+	filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+	IF filter_condition_jsonb ? 'asInput' THEN
+		asInput := NULLIF(btrim(filter_condition_jsonb->>'asInput'), '')::BOOLEAN;
+	ELSE
+		asInput := NULL;
+	END IF;
+	filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+	-- order_by 解析
+	IF order_by IS NOT NULL AND btrim(order_by) <> '' THEN
+		order_by_jsonb := order_by::jsonb;
+
+		order_key := lower(COALESCE(NULLIF(btrim(order_by_jsonb->>'key'), ''), ''));
+		order_lang := COALESCE(NULLIF(btrim(order_by_jsonb->>'lang'), ''), 'en');
+		order_dir := lower(COALESCE(NULLIF(btrim(order_by_jsonb->>'order'), ''), 'asc'));
+		IF order_dir NOT IN ('asc', 'desc') THEN
+			order_dir := 'asc';
+		END IF;
+
+		use_base_name_order := (order_key = 'basename');
+		use_common_category_order := (order_key = 'common:category');
+	ELSE
+		use_base_name_order := false;
+		use_common_category_order := false;
+		order_lang := 'en';
+		order_dir := 'asc';
+	END IF;
+
+	order_lang_norm := lower(COALESCE(NULLIF(btrim(order_lang), ''), 'en'));
+	use_zh_icu_order := (order_lang_norm LIKE 'zh%');
+
+	RETURN QUERY
+		WITH filtered AS (
+			SELECT
+				f.id,
+				f.json,
+				f.version,
+				f.modified_at,
+				pgroonga_score(f.tableoid, f.ctid) AS score,
+				bn.base_name,
+				cat.category_name,
+				CASE
+					WHEN use_base_name_order THEN bn.base_name
+					WHEN use_common_category_order THEN cat.category_name
+				END AS order_value
+			FROM flows f
+			CROSS JOIN LATERAL (
+				SELECT
+					CASE
+						WHEN use_base_name_order THEN COALESCE(
+							(
+								SELECT bn_item->>'#text'
+								FROM jsonb_array_elements(
+									CASE jsonb_typeof(
+										f.json
+											-> 'flowDataSet'
+											-> 'flowInformation'
+											-> 'dataSetInformation'
+											-> 'name'
+											-> 'baseName'
+									)
+										WHEN 'array' THEN (
+											f.json
+												-> 'flowDataSet'
+												-> 'flowInformation'
+												-> 'dataSetInformation'
+												-> 'name'
+												-> 'baseName'
+										)
+										WHEN 'object' THEN jsonb_build_array(
+											f.json
+												-> 'flowDataSet'
+												-> 'flowInformation'
+												-> 'dataSetInformation'
+												-> 'name'
+												-> 'baseName'
+										)
+										ELSE '[]'::jsonb
+									END
+								) AS bn_item
+								WHERE bn_item->>'@xml:lang' = order_lang
+								LIMIT 1
+							),
+							(
+								SELECT bn_item->>'#text'
+								FROM jsonb_array_elements(
+									CASE jsonb_typeof(
+										f.json
+											-> 'flowDataSet'
+											-> 'flowInformation'
+											-> 'dataSetInformation'
+											-> 'name'
+											-> 'baseName'
+									)
+										WHEN 'array' THEN (
+											f.json
+												-> 'flowDataSet'
+												-> 'flowInformation'
+												-> 'dataSetInformation'
+												-> 'name'
+												-> 'baseName'
+										)
+										WHEN 'object' THEN jsonb_build_array(
+											f.json
+												-> 'flowDataSet'
+												-> 'flowInformation'
+												-> 'dataSetInformation'
+												-> 'name'
+												-> 'baseName'
+										)
+										ELSE '[]'::jsonb
+									END
+								) AS bn_item
+								WHERE bn_item->>'@xml:lang' = 'en'
+								LIMIT 1
+							),
+							COALESCE(
+								f.json #>> '{flowDataSet,flowInformation,dataSetInformation,name,baseName,0,#text}',
+								f.json #>> '{flowDataSet,flowInformation,dataSetInformation,name,baseName,#text}'
+							),
+							''
+						)
+					END AS base_name
+			) bn
+			CROSS JOIN LATERAL (
+				SELECT
+					CASE
+						WHEN use_common_category_order THEN COALESCE(
+							(
+								SELECT string_agg(cat_item->>'#text', ' / ' ORDER BY cat_level ASC)
+								FROM (
+									SELECT
+										cat_item,
+										CASE
+											WHEN (cat_item->>'@level') ~ '^\\d+$' THEN (cat_item->>'@level')::int
+											ELSE 2147483647
+										END AS cat_level
+									FROM jsonb_array_elements(
+										CASE jsonb_typeof(
+											f.json
+												-> 'flowDataSet'
+												-> 'flowInformation'
+												-> 'dataSetInformation'
+												-> 'classificationInformation'
+												-> 'common:elementaryFlowCategorization'
+												-> 'common:category'
+										)
+											WHEN 'array' THEN (
+												f.json
+													-> 'flowDataSet'
+													-> 'flowInformation'
+													-> 'dataSetInformation'
+													-> 'classificationInformation'
+													-> 'common:elementaryFlowCategorization'
+													-> 'common:category'
+										)
+											WHEN 'object' THEN jsonb_build_array(
+												f.json
+													-> 'flowDataSet'
+													-> 'flowInformation'
+													-> 'dataSetInformation'
+													-> 'classificationInformation'
+													-> 'common:elementaryFlowCategorization'
+													-> 'common:category'
+										)
+											ELSE '[]'::jsonb
+										END
+									) AS cat_item
+								) ordered_cat
+							),
+							''
+						)
+					END AS category_name
+			) cat
+			WHERE f.json @> filter_condition_jsonb
+				AND f.json &@~ query_text
+				AND (
+					(data_source = 'tg' AND state_code = 100)
+					OR (data_source = 'co' AND state_code = 200)
+					OR (data_source = 'my' AND user_id = auth.uid())
+					OR (
+						data_source = 'te'
+						AND EXISTS (
+							SELECT 1
+							FROM roles r
+							WHERE r.user_id = auth.uid()
+								AND r.team_id = f.team_id
+								AND r.role::text IN ('admin', 'member', 'owner')
+						)
+					)
+				)
+				AND (
+					flowType IS NULL
+					OR flowType = ''
+					OR (f.json->'flowDataSet'->'modellingAndValidation'->'LCIMethod'->>'typeOfDataSet') = ANY(flowTypeArray)
+				)
+				AND (
+					asInput IS NULL
+					OR asInput = false
+					OR NOT(
+						f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text": "Emissions", "@level": "0"}]}}}}}}'
+					)
+				)
+		)
+		SELECT
+			ROW_NUMBER() OVER (
+				ORDER BY
+					(CASE WHEN (use_base_name_order OR use_common_category_order) AND use_zh_icu_order AND order_dir = 'asc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" ASC NULLS LAST,
+					(CASE WHEN (use_base_name_order OR use_common_category_order) AND use_zh_icu_order AND order_dir = 'desc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" DESC NULLS LAST,
+					CASE WHEN (use_base_name_order OR use_common_category_order) AND NOT use_zh_icu_order AND order_dir = 'asc' THEN lower(f2.order_value) END ASC NULLS LAST,
+					CASE WHEN (use_base_name_order OR use_common_category_order) AND NOT use_zh_icu_order AND order_dir = 'desc' THEN lower(f2.order_value) END DESC NULLS LAST,
+					f2.score DESC,
+					f2.modified_at DESC,
+					f2.id
+			) AS rank,
+			f2.id,
+			f2.json,
+			f2.version,
+			f2.modified_at,
+			COUNT(*) OVER() AS total_count
+		FROM filtered f2
+		ORDER BY
+			(CASE WHEN (use_base_name_order OR use_common_category_order) AND use_zh_icu_order AND order_dir = 'asc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" ASC NULLS LAST,
+			(CASE WHEN (use_base_name_order OR use_common_category_order) AND use_zh_icu_order AND order_dir = 'desc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" DESC NULLS LAST,
+			CASE WHEN (use_base_name_order OR use_common_category_order) AND NOT use_zh_icu_order AND order_dir = 'asc' THEN lower(f2.order_value) END ASC NULLS LAST,
+			CASE WHEN (use_base_name_order OR use_common_category_order) AND NOT use_zh_icu_order AND order_dir = 'desc' THEN lower(f2.order_value) END DESC NULLS LAST,
+			f2.score DESC,
+			f2.modified_at DESC,
+			f2.id
+		LIMIT page_size
+		OFFSET (page_current - 1) * page_size;
+	END; 
+	
+$_$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_flows_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_lifecyclemodels_text_v1"("query_text" "text", "page_size" integer DEFAULT 10, "page_current" integer DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "extracted_text" "text", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+BEGIN
+  RETURN QUERY
+		SELECT 
+			RANK () OVER (ORDER BY pgroonga_score(f.tableoid, f.ctid) DESC) AS rank, 
+			f.id, 
+			f.extracted_text,
+			f.version,
+			f.modified_at,
+			COUNT(*) OVER() AS total_count
+		FROM public.lifecyclemodels AS f
+		WHERE f.extracted_text &@~ query_text AND ((data_source = 'tg' AND state_code = 100) or (data_source = 'co' AND state_code = 200) or (data_source = 'my' AND user_id = auth.uid())
+																			  or (data_source = 'te' and
+		EXISTS ( 
+						SELECT 1
+						FROM roles r
+						WHERE r.user_id = auth.uid() and r.team_id =  f.team_id
+						AND r.role::text IN ('admin', 'member', 'owner') 
+				)
+			)
+		)
+		ORDER BY pgroonga_score(tableoid, ctid) DESC
+		LIMIT page_size
+		OFFSET (page_current -1) * page_size;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_lifecyclemodels_v1"("query_text" "text", "filter_condition" "text" DEFAULT ''::"text", "order_by" "text" DEFAULT ''::"text", "page_size" bigint DEFAULT 10, "page_current" bigint DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $_$
+DECLARE
+  filter_condition_jsonb JSONB;
+  use_base_name_order boolean := false;
+  use_common_class_order boolean := false;
+  use_zh_icu_order boolean := false;
+  order_by_jsonb jsonb;
+  order_key text;
+  order_lang text;
+  order_dir text;
+  order_lang_norm text;
+BEGIN
+  -- order_by 输入格式（标准 JSON）：{"key":"baseName","lang":"zh","order":"asc"} 或 {"key":"common:class","order":"asc"}
+
+  filter_condition_jsonb := COALESCE(NULLIF(btrim(filter_condition), ''), '{}')::JSONB;
+
+  IF order_by IS NOT NULL AND btrim(order_by) <> '' THEN
+    order_by_jsonb := order_by::jsonb;
+
+    order_key := lower(COALESCE(NULLIF(btrim(order_by_jsonb->>'key'), ''), ''));
+    order_lang := COALESCE(NULLIF(btrim(order_by_jsonb->>'lang'), ''), 'en');
+    order_dir := lower(COALESCE(NULLIF(btrim(order_by_jsonb->>'order'), ''), 'asc'));
+    IF order_dir NOT IN ('asc', 'desc') THEN
+      order_dir := 'asc';
+    END IF;
+
+    use_base_name_order := (order_key = 'basename');
+    use_common_class_order := (order_key = 'common:class');
+  ELSE
+    use_base_name_order := false;
+    use_common_class_order := false;
+    order_lang := 'en';
+    order_dir := 'asc';
+  END IF;
+
+  order_lang_norm := lower(COALESCE(NULLIF(btrim(order_lang), ''), 'en'));
+  use_zh_icu_order := (order_lang_norm LIKE 'zh%');
+
+  RETURN QUERY
+    WITH filtered AS (
+      SELECT
+        f.id,
+        f.json,
+        f.version,
+        f.modified_at,
+        pgroonga_score(f.tableoid, f.ctid) AS score,
+        bn.base_name,
+        cls.class_name,
+        CASE
+          WHEN use_base_name_order THEN bn.base_name
+          WHEN use_common_class_order THEN cls.class_name
+        END AS order_value
+      FROM lifecyclemodels f
+      CROSS JOIN LATERAL (
+        SELECT
+          CASE
+            WHEN use_base_name_order THEN COALESCE(
+              (
+                SELECT bn_item->>'#text'
+                FROM jsonb_array_elements(
+                  CASE jsonb_typeof(
+                    f.json
+                      -> 'lifeCycleModelDataSet'
+                      -> 'lifeCycleModelInformation'
+                      -> 'dataSetInformation'
+                      -> 'name'
+                      -> 'baseName'
+                  )
+                    WHEN 'array' THEN (
+                      f.json
+                        -> 'lifeCycleModelDataSet'
+                        -> 'lifeCycleModelInformation'
+                        -> 'dataSetInformation'
+                        -> 'name'
+                        -> 'baseName'
+                    )
+                    WHEN 'object' THEN jsonb_build_array(
+                      f.json
+                        -> 'lifeCycleModelDataSet'
+                        -> 'lifeCycleModelInformation'
+                        -> 'dataSetInformation'
+                        -> 'name'
+                        -> 'baseName'
+                    )
+                    ELSE '[]'::jsonb
+                  END
+                ) AS bn_item
+                WHERE bn_item->>'@xml:lang' = order_lang
+                LIMIT 1
+              ),
+              (
+                SELECT bn_item->>'#text'
+                FROM jsonb_array_elements(
+                  CASE jsonb_typeof(
+                    f.json
+                      -> 'lifeCycleModelDataSet'
+                      -> 'lifeCycleModelInformation'
+                      -> 'dataSetInformation'
+                      -> 'name'
+                      -> 'baseName'
+                  )
+                    WHEN 'array' THEN (
+                      f.json
+                        -> 'lifeCycleModelDataSet'
+                        -> 'lifeCycleModelInformation'
+                        -> 'dataSetInformation'
+                        -> 'name'
+                        -> 'baseName'
+                    )
+                    WHEN 'object' THEN jsonb_build_array(
+                      f.json
+                        -> 'lifeCycleModelDataSet'
+                        -> 'lifeCycleModelInformation'
+                        -> 'dataSetInformation'
+                        -> 'name'
+                        -> 'baseName'
+                    )
+                    ELSE '[]'::jsonb
+                  END
+                ) AS bn_item
+                WHERE bn_item->>'@xml:lang' = 'en'
+                LIMIT 1
+              ),
+              COALESCE(
+                f.json #>> '{lifeCycleModelDataSet,lifeCycleModelInformation,dataSetInformation,name,baseName,0,#text}',
+                f.json #>> '{lifeCycleModelDataSet,lifeCycleModelInformation,dataSetInformation,name,baseName,#text}'
+              ),
+              ''
+            )
+          END AS base_name
+      ) bn
+      CROSS JOIN LATERAL (
+        SELECT
+          CASE
+            WHEN use_common_class_order THEN COALESCE(
+              (
+                SELECT string_agg(cls_item->>'#text', ' / ' ORDER BY cls_level ASC)
+                FROM (
+                  SELECT
+                    cls_item,
+                    CASE
+                      WHEN (cls_item->>'@level') ~ '^\\d+$' THEN (cls_item->>'@level')::int
+                      ELSE 2147483647
+                    END AS cls_level
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(
+                      f.json
+                        -> 'lifeCycleModelDataSet'
+                        -> 'lifeCycleModelInformation'
+                        -> 'dataSetInformation'
+                        -> 'classificationInformation'
+                        -> 'common:classification'
+                        -> 'common:class'
+                    )
+                      WHEN 'array' THEN (
+                        f.json
+                          -> 'lifeCycleModelDataSet'
+                          -> 'lifeCycleModelInformation'
+                          -> 'dataSetInformation'
+                          -> 'classificationInformation'
+                          -> 'common:classification'
+                          -> 'common:class'
+                    )
+                      WHEN 'object' THEN jsonb_build_array(
+                        f.json
+                          -> 'lifeCycleModelDataSet'
+                          -> 'lifeCycleModelInformation'
+                          -> 'dataSetInformation'
+                          -> 'classificationInformation'
+                          -> 'common:classification'
+                          -> 'common:class'
+                    )
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS cls_item
+                ) ordered_cls
+              ),
+              ''
+            )
+          END AS class_name
+      ) cls
+      WHERE f.json @> filter_condition_jsonb
+        AND f.json &@~ query_text
+        AND (
+          (data_source = 'tg' AND state_code = 100)
+          OR (data_source = 'co' AND state_code = 200)
+          OR (data_source = 'my' AND user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = f.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    )
+    SELECT
+      ROW_NUMBER() OVER (
+        ORDER BY
+          (CASE WHEN (use_base_name_order OR use_common_class_order) AND use_zh_icu_order AND order_dir = 'asc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" ASC NULLS LAST,
+          (CASE WHEN (use_base_name_order OR use_common_class_order) AND use_zh_icu_order AND order_dir = 'desc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" DESC NULLS LAST,
+          CASE WHEN (use_base_name_order OR use_common_class_order) AND NOT use_zh_icu_order AND order_dir = 'asc' THEN lower(f2.order_value) END ASC NULLS LAST,
+          CASE WHEN (use_base_name_order OR use_common_class_order) AND NOT use_zh_icu_order AND order_dir = 'desc' THEN lower(f2.order_value) END DESC NULLS LAST,
+          f2.score DESC,
+          f2.modified_at DESC,
+          f2.id
+      ) AS rank,
+      f2.id,
+      f2.json,
+      f2.version,
+      f2.modified_at,
+      COUNT(*) OVER() AS total_count
+    FROM filtered f2
+    ORDER BY
+      (CASE WHEN (use_base_name_order OR use_common_class_order) AND use_zh_icu_order AND order_dir = 'asc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" ASC NULLS LAST,
+      (CASE WHEN (use_base_name_order OR use_common_class_order) AND use_zh_icu_order AND order_dir = 'desc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" DESC NULLS LAST,
+      CASE WHEN (use_base_name_order OR use_common_class_order) AND NOT use_zh_icu_order AND order_dir = 'asc' THEN lower(f2.order_value) END ASC NULLS LAST,
+      CASE WHEN (use_base_name_order OR use_common_class_order) AND NOT use_zh_icu_order AND order_dir = 'desc' THEN lower(f2.order_value) END DESC NULLS LAST,
+      f2.score DESC,
+      f2.modified_at DESC,
+      f2.id
+    LIMIT page_size
+    OFFSET (page_current - 1) * page_size;
+END;
+$_$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_processes_text_v1"("query_text" "text", "page_size" integer DEFAULT 10, "page_current" integer DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "extracted_text" "text", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+BEGIN
+  RETURN QUERY
+		SELECT 
+			RANK () OVER (ORDER BY pgroonga_score(f.tableoid, f.ctid) DESC) AS rank, 
+			f.id, 
+			f.extracted_text,
+			f.version,
+			f.modified_at,
+			COUNT(*) OVER() AS total_count
+		FROM public.processes AS f
+		WHERE f.extracted_text &@~ query_text AND ((data_source = 'tg' AND state_code = 100) or (data_source = 'co' AND state_code = 200) or (data_source = 'my' AND user_id = auth.uid() )
+																			  or (data_source = 'te' and
+		EXISTS ( 
+						SELECT 1
+						FROM roles r
+						WHERE r.user_id = auth.uid()  and r.team_id =  f.team_id
+						AND r.role::text IN ('admin', 'member', 'owner') 
+				)
+			)
+		)
+		ORDER BY pgroonga_score(tableoid, ctid) DESC
+		LIMIT page_size
+		OFFSET (page_current -1) * page_size;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_processes_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_processes_v1"("query_text" "text", "filter_condition" "text" DEFAULT ''::"text", "order_by" "text" DEFAULT ''::"text", "page_size" bigint DEFAULT 10, "page_current" bigint DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "model_id" "uuid", "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $_$
+DECLARE
+    filter_condition_jsonb JSONB;
+    use_base_name_order boolean := false;
+	use_common_class_order boolean := false;
+	use_zh_icu_order boolean := false;
+    order_by_jsonb jsonb;
+    order_key text;
+    order_lang text;
+    order_dir text;
+	order_lang_norm text;
+BEGIN
+	filter_condition_jsonb := COALESCE(NULLIF(btrim(filter_condition), ''), '{}')::JSONB;
+
+	-- order_by 输入格式（标准 JSON）：{"key":"baseName","lang":"zh","order":"asc"} 或 {"key":"common:class","order":"asc"}
+	IF order_by IS NOT NULL AND btrim(order_by) <> '' THEN
+		order_by_jsonb := order_by::jsonb;
+
+		order_key := lower(COALESCE(NULLIF(btrim(order_by_jsonb->>'key'), ''), ''));
+		order_lang := COALESCE(NULLIF(btrim(order_by_jsonb->>'lang'), ''), 'en');
+		order_dir := lower(COALESCE(NULLIF(btrim(order_by_jsonb->>'order'), ''), 'asc'));
+		IF order_dir NOT IN ('asc', 'desc') THEN
+			order_dir := 'asc';
+		END IF;
+
+		use_base_name_order := (order_key = 'basename');
+		use_common_class_order := (order_key = 'common:class');
+	ELSE
+		use_base_name_order := false;
+		use_common_class_order := false;
+		order_lang := 'en';
+		order_dir := 'asc';
+	END IF;
+
+	order_lang_norm := lower(COALESCE(NULLIF(btrim(order_lang), ''), 'en'));
+	use_zh_icu_order := (order_lang_norm LIKE 'zh%');
+
+  RETURN QUERY
+		WITH filtered AS (
+			SELECT
+				f.id,
+				f.json,
+				f.version,
+				f.modified_at,
+				f.model_id,
+				pgroonga_score(f.tableoid, f.ctid) AS score,
+				bn.base_name,
+				cls.class_name,
+				CASE
+					WHEN use_base_name_order THEN bn.base_name
+					WHEN use_common_class_order THEN cls.class_name
+				END AS order_value
+			FROM processes f
+			CROSS JOIN LATERAL (
+				SELECT
+					CASE
+						WHEN use_base_name_order THEN COALESCE(
+							(
+								SELECT bn_item->>'#text'
+								FROM jsonb_array_elements(
+									CASE jsonb_typeof(
+										f.json
+											-> 'processDataSet'
+											-> 'processInformation'
+											-> 'dataSetInformation'
+											-> 'name'
+											-> 'baseName'
+									)
+										WHEN 'array' THEN (
+											f.json
+												-> 'processDataSet'
+												-> 'processInformation'
+												-> 'dataSetInformation'
+												-> 'name'
+												-> 'baseName'
+										)
+										WHEN 'object' THEN jsonb_build_array(
+											f.json
+												-> 'processDataSet'
+												-> 'processInformation'
+												-> 'dataSetInformation'
+												-> 'name'
+												-> 'baseName'
+										)
+										ELSE '[]'::jsonb
+									END
+								) AS bn_item
+								WHERE bn_item->>'@xml:lang' = order_lang
+								LIMIT 1
+							),
+							(
+								SELECT bn_item->>'#text'
+								FROM jsonb_array_elements(
+									CASE jsonb_typeof(
+										f.json
+											-> 'processDataSet'
+											-> 'processInformation'
+											-> 'dataSetInformation'
+											-> 'name'
+											-> 'baseName'
+									)
+										WHEN 'array' THEN (
+											f.json
+												-> 'processDataSet'
+												-> 'processInformation'
+												-> 'dataSetInformation'
+												-> 'name'
+												-> 'baseName'
+										)
+										WHEN 'object' THEN jsonb_build_array(
+											f.json
+												-> 'processDataSet'
+												-> 'processInformation'
+												-> 'dataSetInformation'
+												-> 'name'
+												-> 'baseName'
+										)
+										ELSE '[]'::jsonb
+									END
+								) AS bn_item
+								WHERE bn_item->>'@xml:lang' = 'en'
+								LIMIT 1
+							),
+							COALESCE(
+								f.json #>> '{processDataSet,processInformation,dataSetInformation,name,baseName,0,#text}',
+								f.json #>> '{processDataSet,processInformation,dataSetInformation,name,baseName,#text}'
+							),
+							''
+						)
+					END AS base_name
+			) bn
+			CROSS JOIN LATERAL (
+				SELECT
+					CASE
+						WHEN use_common_class_order THEN COALESCE(
+							(
+								SELECT string_agg(cls_item->>'#text', ' / ' ORDER BY cls_level ASC)
+								FROM (
+									SELECT
+										cls_item,
+										CASE
+											WHEN (cls_item->>'@level') ~ '^\\d+$' THEN (cls_item->>'@level')::int
+											ELSE 2147483647
+										END AS cls_level
+									FROM jsonb_array_elements(
+										CASE jsonb_typeof(
+											f.json
+												-> 'processDataSet'
+												-> 'processInformation'
+												-> 'dataSetInformation'
+												-> 'classificationInformation'
+												-> 'common:classification'
+												-> 'common:class'
+										)
+											WHEN 'array' THEN (
+												f.json
+													-> 'processDataSet'
+													-> 'processInformation'
+													-> 'dataSetInformation'
+													-> 'classificationInformation'
+													-> 'common:classification'
+													-> 'common:class'
+											)
+											WHEN 'object' THEN jsonb_build_array(
+												f.json
+													-> 'processDataSet'
+													-> 'processInformation'
+													-> 'dataSetInformation'
+													-> 'classificationInformation'
+													-> 'common:classification'
+													-> 'common:class'
+											)
+											ELSE '[]'::jsonb
+										END
+									) AS cls_item
+								) ordered_cls
+							),
+							''
+						)
+					END AS class_name
+			) cls
+			WHERE f.json @> filter_condition_jsonb
+				AND f.json &@~ query_text
+				AND (
+					(data_source = 'tg' AND state_code = 100)
+					OR (data_source = 'co' AND state_code = 200)
+					OR (data_source = 'my' AND user_id = auth.uid())
+					OR (
+						data_source = 'te'
+						AND EXISTS (
+							SELECT 1
+							FROM roles r
+							WHERE r.user_id = auth.uid()
+								AND r.team_id = f.team_id
+								AND r.role::text IN ('admin', 'member', 'owner')
+						)
+					)
+				)
+		)
+		SELECT
+			ROW_NUMBER() OVER (
+				ORDER BY
+					(CASE WHEN (use_base_name_order OR use_common_class_order) AND use_zh_icu_order AND order_dir = 'asc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" ASC NULLS LAST,
+					(CASE WHEN (use_base_name_order OR use_common_class_order) AND use_zh_icu_order AND order_dir = 'desc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" DESC NULLS LAST,
+					CASE WHEN (use_base_name_order OR use_common_class_order) AND NOT use_zh_icu_order AND order_dir = 'asc' THEN lower(f2.order_value) END ASC NULLS LAST,
+					CASE WHEN (use_base_name_order OR use_common_class_order) AND NOT use_zh_icu_order AND order_dir = 'desc' THEN lower(f2.order_value) END DESC NULLS LAST,
+					f2.score DESC,
+					f2.modified_at DESC,
+					f2.id
+			) AS rank,
+			f2.id,
+			f2.json,
+			f2.version,
+			f2.modified_at,
+			f2.model_id,
+			COUNT(*) OVER() AS total_count
+		FROM filtered f2
+		ORDER BY
+			(CASE WHEN (use_base_name_order OR use_common_class_order) AND use_zh_icu_order AND order_dir = 'asc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" ASC NULLS LAST,
+			(CASE WHEN (use_base_name_order OR use_common_class_order) AND use_zh_icu_order AND order_dir = 'desc' THEN f2.order_value END) COLLATE "zh-Hans-CN-x-icu" DESC NULLS LAST,
+			CASE WHEN (use_base_name_order OR use_common_class_order) AND NOT use_zh_icu_order AND order_dir = 'asc' THEN lower(f2.order_value) END ASC NULLS LAST,
+			CASE WHEN (use_base_name_order OR use_common_class_order) AND NOT use_zh_icu_order AND order_dir = 'desc' THEN lower(f2.order_value) END DESC NULLS LAST,
+			f2.score DESC,
+			f2.modified_at DESC,
+			f2.id
+		LIMIT page_size
+		OFFSET (page_current - 1) * page_size;
+END;
+$_$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_processes_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_sources"("query_text" "text", "filter_condition" "text" DEFAULT ''::"text", "page_size" bigint DEFAULT 10, "page_current" bigint DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text", "this_user_id" "text" DEFAULT ''::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+    filter_condition_jsonb JSONB;
+BEGIN
+	filter_condition_jsonb := filter_condition::JSONB;
+  RETURN QUERY
+		SELECT 
+			RANK () OVER (ORDER BY pgroonga_score(f.tableoid, f.ctid) DESC) AS rank, 
+			f.id, 
+			f.json,
+			f.version,
+			f.modified_at,
+			COUNT(*) OVER() AS total_count
+		FROM sources f
+		WHERE f.json @> filter_condition_jsonb AND f.json &@~ query_text AND ((data_source = 'tg' AND state_code = 100) or (data_source = 'my' AND user_id::text = this_user_id))
+		ORDER BY pgroonga_score(tableoid, ctid) DESC
+		LIMIT page_size
+		OFFSET (page_current -1) * page_size;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_sources"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_unitgroups"("query_text" "text", "filter_condition" "text" DEFAULT ''::"text", "page_size" bigint DEFAULT 10, "page_current" bigint DEFAULT 1, "data_source" "text" DEFAULT 'tg'::"text", "this_user_id" "text" DEFAULT ''::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+    filter_condition_jsonb JSONB;
+BEGIN
+ filter_condition_jsonb := filter_condition::JSONB;
+  RETURN QUERY
+  SELECT 
+   RANK () OVER (ORDER BY extensions.pgroonga_score(f.tableoid, f.ctid) DESC) AS rank, 
+   f.id, 
+   f.json,
+   f.version,
+   f.modified_at,
+   COUNT(*) OVER() AS total_count
+  FROM public.unitgroups f
+  WHERE f.json @> filter_condition_jsonb 
+    AND f.json &@~ query_text 
+    AND (
+         (data_source = 'tg' AND f.state_code = 100)
+         OR 
+         (data_source = 'my' AND f.user_id::text = this_user_id)
+        )
+  ORDER BY extensions.pgroonga_score(f.tableoid, f.ctid) DESC
+  LIMIT page_size
+  OFFSET (page_current -1) * page_size;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."pgroonga_search_unitgroups"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."policy_is_current_user_in_roles"("p_team_id" "uuid", "p_roles_to_check" "text"[]) RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+	-- 增加空数组判断：空数组直接返回 false
+    SELECT CASE 
+        WHEN cardinality(p_roles_to_check) = 0 THEN false  -- cardinality() 获取数组长度
+		-- 核心逻辑：用 EXISTS 判断是否存在匹配记录，效率更高（无需聚合，找到即返回）
+        ELSE EXISTS (
+        SELECT 1
+        FROM public.roles r
+        WHERE r.user_id = auth.uid()                  -- 匹配当前登录用户
+          AND r.team_id = p_team_id                   -- 匹配目标团队
+          AND r.role <> 'rejected'::text              -- 排除无效的「拒绝」角色
+          AND r.role = ANY(p_roles_to_check)          -- 关键：判断用户角色是否在输入的角色数组中（任意一个匹配即可）
+     )
+	 END;
+$$;
+
+
+ALTER FUNCTION "public"."policy_is_current_user_in_roles"("p_team_id" "uuid", "p_roles_to_check" "text"[]) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."policy_is_team_id_used"("_team_id" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.teams t
+    WHERE t.id = _team_id);
+$$;
+
+
+ALTER FUNCTION "public"."policy_is_team_id_used"("_team_id" "uuid") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."policy_is_team_public"("_team_id" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.teams t
+    WHERE t.id = _team_id
+      AND t.is_public);
+$$;
+
+
+ALTER FUNCTION "public"."policy_is_team_public"("_team_id" "uuid") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."policy_roles_delete"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+  SELECT (
+	-- 验证当前用户是否为团队管理员或拥有者，被删除用户角色不能为owner角色，自己不能删除自己
+	(
+		_role <> 'owner' AND _user_id <> auth.uid() AND
+		EXISTS (
+			SELECT 1
+			FROM public.roles r
+			WHERE r.user_id = auth.uid() AND r.team_id = _team_id AND (r.role = 'admin' OR r.role = 'owner' OR r.role = 'review-admin'))
+	)
+  );
+$$;
+
+
+ALTER FUNCTION "public"."policy_roles_delete"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."policy_roles_insert"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+  SELECT (
+    ((
+        -- 验证用户是否已经有团队角色，且角色不为rejected
+        EXISTS (
+            SELECT 1
+            FROM public.roles r
+            WHERE r.user_id = _user_id
+            AND r.role <> 'rejected'
+            and r.team_id <> '00000000-0000-0000-0000-000000000000')
+        ) = false
+
+    AND
+    (
+        -- 验证当前用户创建团队时，是否为自己分配owner角色，且团队ID未被使用
+        ((
+            (_user_id = auth.uid() AND _role = 'owner' AND 
+            EXISTS (
+                SELECT 1
+                FROM public.roles r
+                WHERE r.team_id = _team_id) = false)
+        ))
+
+        OR
+        -- 验证当前用户是否为团队管理员或拥有者，邀请的用户角色是否为is_invited角色
+        ((
+            _role = 'is_invited' AND 
+            EXISTS (
+                SELECT 1
+                FROM public.roles r
+                WHERE r.user_id = auth.uid() AND r.team_id = _team_id AND (r.role = 'admin' OR r.role = 'owner'))
+        ))
+    ))
+
+    OR
+    (
+        -- 验证用户是否已经有审核团队角色
+        EXISTS (
+            SELECT 1
+            FROM public.roles r
+            WHERE r.user_id = _user_id
+            AND r.role like 'review-%'
+            AND r.team_id = '00000000-0000-0000-0000-000000000000') = false
+
+        AND
+        -- 验证当前用户是否为审核管理员，邀请的用户角色是否为review-member角色
+        (
+        _role = 'review-member' AND _team_id = '00000000-0000-0000-0000-000000000000'::uuid AND
+        EXISTS (
+            SELECT 1
+            FROM public.roles r
+            WHERE r.user_id = auth.uid() AND r.team_id = _team_id AND r.role = 'review-admin')
+        )
+    )
+
+    OR
+    (
+        -- 验证用户是否已经有系统团队角色
+        EXISTS (
+            SELECT 1
+            FROM public.roles r
+            WHERE r.user_id = _user_id
+            AND (r.role = 'admin' OR r.role = 'member')
+            AND r.team_id = '00000000-0000-0000-0000-000000000000') = false
+
+        AND
+        -- 验证当前用户是否为系统管理员，邀请的用户角色是否为member角色
+        (
+        _role = 'member' AND _team_id = '00000000-0000-0000-0000-000000000000'::uuid AND
+        EXISTS (
+            SELECT 1
+            FROM public.roles r
+            WHERE r.user_id = auth.uid() AND r.team_id = _team_id AND r.role = 'admin')
+        )
+    )
+
+    );
+$$;
+
+
+ALTER FUNCTION "public"."policy_roles_insert"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."policy_roles_select"("_team_id" "uuid", "_role" "text") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+  SELECT (
+  	-- 验证当前用户是否为团队成员（非拒绝状态）
+    EXISTS (
+		select 1 from public.roles r0
+		where r0.user_id = auth.uid() and r0.team_id = _team_id and r0.role <> 'rejected')
+
+    OR
+    -- 验证当前用户是否为审核团队/系统管理团队成员
+    (_team_id = '00000000-0000-0000-0000-000000000000'::uuid and
+    EXISTS (
+		select 1 from public.roles r0
+		where r0.user_id = auth.uid() and r0.team_id = _team_id))
+
+    OR
+    -- 验证当前团队是否为公开团队的拥有者，用于展示加入团队的联系信息
+    _role = 'owner' AND
+    EXISTS (
+        SELECT 1 FROM public.teams t
+        WHERE t.id = _team_id AND t.is_public)
+	);
+$$;
+
+
+ALTER FUNCTION "public"."policy_roles_select"("_team_id" "uuid", "_role" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."policy_roles_update"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+  SELECT (
+  	-- 验证当前用户是否为团队拥有者或管理员
+	(
+  	EXISTS (
+		select 1 from public.roles r0
+		where r0.user_id = auth.uid() and r0.team_id = _team_id and (r0.role ='admin' or r0.role='owner'))
+	and
+	(
+	-- 切换admin和member
+	((_role = 'admin' or _role = 'member') and 
+	  EXISTS (
+		SELECT 1
+		FROM public.roles r1
+		WHERE r1.user_id = _user_id and r1.team_id = _team_id and (r1.role = 'admin' or r1.role = 'member')))
+	or 
+	-- 重新邀请已经拒绝的用户
+	(_role = 'is_invited' and 
+		EXISTS (
+			SELECT 1
+			FROM public.roles r2
+			WHERE r2.user_id = _user_id and r2.team_id = _team_id and r2.role = 'rejected'))
+	))
+	or
+	-- 验证当前用户，接受邀请或拒绝邀请
+	((_role = 'member' or _role = 'rejected') and _user_id = auth.uid() and
+	EXISTS (
+		select 1 from public.roles r3
+		where r3.user_id = _user_id and r3.team_id = _team_id and r3.role ='is_invited'))
+	);
+$$;
+
+
+ALTER FUNCTION "public"."policy_roles_update"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."policy_user_has_team"("_user_id" "uuid") RETURNS boolean
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.roles r
+    WHERE r.user_id = _user_id
+      AND r.role <> 'rejected'
+	  and r.team_id <> '00000000-0000-0000-0000-000000000000');
+$$;
+
+
+ALTER FUNCTION "public"."policy_user_has_team"("_user_id" "uuid") OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."processes" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "state_code" integer DEFAULT 0,
+    "version" character(9) NOT NULL,
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "team_id" "uuid",
+    "extracted_text" "text",
+    "embedding" "extensions"."halfvec"(384),
+    "embedding_at" timestamp with time zone,
+    "review_id" "uuid",
+    "rule_verification" boolean,
+    "reviews" "jsonb",
+    "embedding_flag" smallint,
+    "model_id" "uuid",
+    "embedding_ft_at" timestamp with time zone,
+    "embedding_ft" "extensions"."vector"(1024),
+    "extracted_md" "text"
+);
+
+
+ALTER TABLE "public"."processes" OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."processes_embedding_ft_input"("proc" "public"."processes") RETURNS "text"
+    LANGUAGE "plpgsql" IMMUTABLE
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+begin
+  return proc.extracted_md;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."processes_embedding_ft_input"("proc" "public"."processes") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."processes_embedding_input"("proc" "public"."processes") RETURNS "text"
+    LANGUAGE "plpgsql" IMMUTABLE
+    SET "search_path" TO ''
+    AS $$
+begin
+  return proc.extracted_text;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."processes_embedding_input"("proc" "public"."processes") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."processes_sync_jsonb_version"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb THEN
+        NEW.json := NEW.json_ordered;
+        NEW.version := COALESCE(NEW.json->'processDataSet'->'administrativeInformation'->'publicationAndOwnership'->>'common:dataSetVersion',
+					''
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."processes_sync_jsonb_version"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."save_lifecycle_model_bundle"("p_plan" "jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $_$
+DECLARE
+    v_mode text := coalesce(p_plan->>'mode', '');
+    v_model_id uuid := nullif(p_plan->>'modelId', '')::uuid;
+    v_expected_version text := nullif(btrim(coalesce(p_plan->>'version', '')), '');
+    v_actor_user_id uuid := nullif(p_plan->>'actorUserId', '')::uuid;
+    v_parent jsonb := coalesce(p_plan->'parent', '{}'::jsonb);
+    v_parent_json_ordered json := (v_parent->'jsonOrdered')::json;
+    v_parent_json_tg jsonb := coalesce(v_parent->'jsonTg', '{}'::jsonb);
+    v_parent_rule_verification boolean := coalesce((v_parent->>'ruleVerification')::boolean, true);
+    v_process_mutations jsonb := coalesce(p_plan->'processMutations', '[]'::jsonb);
+    v_mutation jsonb;
+    v_child_id uuid;
+    v_child_version text;
+    v_child_json_ordered json;
+    v_child_rule_verification boolean;
+    v_result_row lifecyclemodels%ROWTYPE;
+    v_rows_affected integer;
+BEGIN
+    IF v_mode NOT IN ('create', 'update') THEN
+        RAISE EXCEPTION 'INVALID_PLAN';
+    END IF;
+
+    IF v_model_id IS NULL OR v_parent_json_ordered IS NULL THEN
+        RAISE EXCEPTION 'INVALID_PLAN';
+    END IF;
+
+    IF v_actor_user_id IS NULL THEN
+        RAISE EXCEPTION 'INVALID_PLAN';
+    END IF;
+
+    IF jsonb_typeof(v_process_mutations) <> 'array' THEN
+        RAISE EXCEPTION 'INVALID_PLAN';
+    END IF;
+
+    IF v_mode = 'update' THEN
+        IF v_expected_version IS NULL THEN
+            RAISE EXCEPTION 'INVALID_PLAN';
+        END IF;
+
+        PERFORM 1
+          FROM lifecyclemodels
+         WHERE id = v_model_id
+           AND version = v_expected_version
+         FOR UPDATE;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'MODEL_NOT_FOUND';
+        END IF;
+    END IF;
+
+    FOR v_mutation IN
+        SELECT value
+          FROM jsonb_array_elements(v_process_mutations)
+    LOOP
+        CASE coalesce(v_mutation->>'op', '')
+            WHEN 'delete' THEN
+                v_child_id := nullif(v_mutation->>'id', '')::uuid;
+                v_child_version := nullif(btrim(coalesce(v_mutation->>'version', '')), '');
+
+                IF v_child_id IS NULL OR v_child_version IS NULL THEN
+                    RAISE EXCEPTION 'INVALID_PLAN';
+                END IF;
+
+                EXECUTE 'del' || 'ete from processes where id = $1 and version = $2 and model_id = $3'
+                   USING v_child_id, v_child_version, v_model_id;
+
+                GET DIAGNOSTICS v_rows_affected = ROW_COUNT;
+                IF v_rows_affected = 0 THEN
+                    RAISE EXCEPTION 'PROCESS_NOT_FOUND';
+                END IF;
+            WHEN 'create' THEN
+                v_child_id := nullif(v_mutation->>'id', '')::uuid;
+                v_child_json_ordered := (v_mutation->'jsonOrdered')::json;
+                v_child_rule_verification := coalesce(
+                    (v_mutation->>'ruleVerification')::boolean,
+                    true
+                );
+
+                IF v_child_id IS NULL OR v_child_json_ordered IS NULL THEN
+                    RAISE EXCEPTION 'INVALID_PLAN';
+                END IF;
+
+                BEGIN
+                    INSERT INTO processes (
+                        id,
+                        json_ordered,
+                        model_id,
+                        user_id,
+                        rule_verification
+                    )
+                    VALUES (
+                        v_child_id,
+                        v_child_json_ordered,
+                        v_model_id,
+                        v_actor_user_id,
+                        v_child_rule_verification
+                    );
+                EXCEPTION
+                    WHEN unique_violation THEN
+                        RAISE EXCEPTION 'VERSION_CONFLICT';
+                END;
+            WHEN 'update' THEN
+                v_child_id := nullif(v_mutation->>'id', '')::uuid;
+                v_child_version := nullif(btrim(coalesce(v_mutation->>'version', '')), '');
+                v_child_json_ordered := (v_mutation->'jsonOrdered')::json;
+                v_child_rule_verification := coalesce(
+                    (v_mutation->>'ruleVerification')::boolean,
+                    true
+                );
+
+                IF v_child_id IS NULL OR v_child_version IS NULL OR v_child_json_ordered IS NULL THEN
+                    RAISE EXCEPTION 'INVALID_PLAN';
+                END IF;
+
+                UPDATE processes
+                   SET json_ordered = v_child_json_ordered,
+                       model_id = v_model_id,
+                       rule_verification = v_child_rule_verification
+                 WHERE id = v_child_id
+                   AND version = v_child_version
+                   AND model_id = v_model_id;
+
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION 'PROCESS_NOT_FOUND';
+                END IF;
+            ELSE
+                RAISE EXCEPTION 'INVALID_PLAN';
+        END CASE;
+    END LOOP;
+
+    IF v_mode = 'create' THEN
+        BEGIN
+            INSERT INTO lifecyclemodels (
+                id,
+                json_ordered,
+                json_tg,
+                user_id,
+                rule_verification
+            )
+            VALUES (
+                v_model_id,
+                v_parent_json_ordered,
+                v_parent_json_tg,
+                v_actor_user_id,
+                v_parent_rule_verification
+            )
+            RETURNING *
+                 INTO v_result_row;
+        EXCEPTION
+            WHEN unique_violation THEN
+                RAISE EXCEPTION 'VERSION_CONFLICT';
+        END;
+    ELSE
+        UPDATE lifecyclemodels
+           SET json_ordered = v_parent_json_ordered,
+               json_tg = v_parent_json_tg,
+               rule_verification = v_parent_rule_verification
+         WHERE id = v_model_id
+           AND version = v_expected_version
+        RETURNING *
+             INTO v_result_row;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION 'MODEL_NOT_FOUND';
+        END IF;
+    END IF;
+
+    RETURN jsonb_build_object(
+        'model_id', v_result_row.id,
+        'version', v_result_row.version,
+        'lifecycle_model', to_jsonb(v_result_row)
+    );
+END;
+$_$;
+
+
+ALTER FUNCTION "public"."save_lifecycle_model_bundle"("p_plan" "jsonb") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."semantic_search"("query_embedding" "text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20) RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb")
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+    query_embedding_vector vector(384);
+BEGIN
+    -- Convert the input TEXT to vector(1536) once
+    query_embedding_vector := query_embedding::vector(384);
+
+    RETURN QUERY
+    SELECT
+        RANK () OVER (ORDER BY f.embedding <=> query_embedding_vector) AS rank,
+        f.id,
+        f.json
+    FROM flows f
+    WHERE f.embedding <=> query_embedding_vector < 1 - match_threshold
+    ORDER BY f.embedding <=> query_embedding_vector
+    LIMIT match_count;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."semantic_search"("query_embedding" "text", "match_threshold" double precision, "match_count" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."semantic_search_flows_v1"("query_embedding" "text", "filter_condition" "text" DEFAULT ''::"text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  query_embedding_vector  vector(1024);
+  filter_condition_jsonb  jsonb;
+  flowType                text;
+  flowTypeArray           text[];
+  asInput                 boolean;
+  candidate_size          int := GREATEST(match_count * 10, 200);
+BEGIN
+  -- 1) 向量转 halfvec(384)
+  query_embedding_vector := query_embedding::vector(1024);
+
+  -- 2) 解析 filter_condition
+  filter_condition_jsonb := filter_condition::jsonb;
+  flowType               := filter_condition_jsonb->>'flowType';
+  flowTypeArray          := string_to_array(flowType, ',');
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  asInput                := (filter_condition_jsonb->'asInput')::boolean;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  -- 3) 两阶段：先 HNSW 候选，再业务过滤
+  RETURN QUERY
+  WITH cand AS (
+    SELECT
+      f.id,
+      f.json,
+      f.version,
+      f.modified_at,
+      f.embedding_ft,
+      f.state_code,
+      f.user_id,
+      f.team_id
+    FROM public.flows f
+    ORDER BY f.embedding_ft <=> query_embedding_vector   
+    LIMIT candidate_size
+  ),
+  final AS (
+    SELECT
+      c.*,
+      (c.embedding_ft <=> query_embedding_vector) AS dist
+    FROM cand c
+    WHERE
+      (c.embedding_ft <=> query_embedding_vector) < 1 - match_threshold
+      AND c.json @> filter_condition_jsonb
+      AND (
+           (data_source = 'tg' AND c.state_code = 100)
+        OR (data_source = 'my' AND c.user_id = auth.uid())
+      )
+      AND (
+        flowType IS NULL
+        OR flowType = ''
+        OR (c.json->'flowDataSet'->'modellingAndValidation'->'LCIMethod'->>'typeOfDataSet') = ANY(flowTypeArray)
+      )
+      AND (
+        asInput IS NULL
+        OR asInput = false
+        OR NOT (
+          c.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+        )
+      )
+  )
+  SELECT
+  RANK() OVER (ORDER BY f2.dist) AS "rank",
+  f2.id,
+  f2.json,
+  f2.version,
+  f2.modified_at,
+  COUNT(*) OVER()               AS total_count
+FROM final AS f2
+ORDER BY f2.dist
+LIMIT match_count;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."semantic_search_flows_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."semantic_search_lifecyclemodels_v1"("query_embedding" "text", "filter_condition" "text" DEFAULT ''::"text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  query_embedding_vector  vector(1024);   
+  filter_condition_jsonb  jsonb;
+  candidate_size          int := GREATEST(match_count * 10, 200);
+BEGIN
+  -- 1) 向量入参 -> vector(384)
+  query_embedding_vector := query_embedding::vector(1024);
+
+  -- 2) 解析 filter_condition
+  filter_condition_jsonb := filter_condition::jsonb;
+
+  -- 3) 两阶段：先用向量索引取候选，再应用阈值/过滤/权限，最后排序分页
+  RETURN QUERY
+  WITH cand AS (
+    SELECT
+      m.id,
+      m.json,
+      m.version,
+      m.modified_at,
+      m.embedding_ft,
+      m.state_code,
+      m.user_id
+    FROM public.lifecyclemodels AS m
+    ORDER BY m.embedding_ft <=> query_embedding_vector      
+    LIMIT candidate_size
+  ),
+  final AS (
+    SELECT
+      c.*,
+      (c.embedding_ft <=> query_embedding_vector) AS dist
+    FROM cand AS c
+    WHERE
+      -- 向量阈值（在候选集上应用）
+      (c.embedding_ft <=> query_embedding_vector) < 1 - match_threshold
+      -- JSON 过滤
+      AND c.json @> filter_condition_jsonb
+      -- data_source 访问控制（与原逻辑一致）
+      AND (
+           (data_source = 'tg' AND c.state_code = 100)
+        OR (data_source = 'my' AND c.user_id = auth.uid())
+      )
+  )
+  SELECT
+    RANK() OVER (ORDER BY f2.dist) AS "rank",
+    f2.id,
+    f2.json,
+    f2.version,
+    f2.modified_at,
+    COUNT(*) OVER()               AS total_count
+  FROM final AS f2
+  ORDER BY f2.dist
+  LIMIT match_count;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."semantic_search_lifecyclemodels_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."semantic_search_processes_v1"("query_embedding" "text", "filter_condition" "text" DEFAULT ''::"text", "match_threshold" double precision DEFAULT 0.5, "match_count" integer DEFAULT 20, "data_source" "text" DEFAULT 'tg'::"text") RETURNS TABLE("rank" bigint, "id" "uuid", "json" "jsonb", "version" character, "modified_at" timestamp with time zone, "total_count" bigint)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  query_embedding_vector  vector(1024);   -- 若列为 halfvec(384)，这里改成 halfvec(384)
+  filter_condition_jsonb  jsonb;
+  candidate_size          int := GREATEST(match_count * 10, 200);
+BEGIN
+  -- 1) 向量入参转 vector(384)（或 halfvec(384)）
+  query_embedding_vector := query_embedding::vector(1024);
+
+  -- 2) 解析 filter_condition
+  filter_condition_jsonb := filter_condition::jsonb;
+
+  -- 3) 两阶段：先按相似度取候选（命中向量索引），再在候选上施加全部业务过滤/阈值
+  RETURN QUERY
+  WITH cand AS (
+    SELECT
+      p.id,
+      p.json,
+      p.version,
+      p.modified_at,
+      p.embedding_ft,
+      p.state_code,
+      p.user_id
+    FROM public.processes AS p
+    ORDER BY p.embedding_ft <=> query_embedding_vector      
+  ),
+  final AS (
+    SELECT
+      c.*,
+      (c.embedding_ft <=> query_embedding_vector) AS dist
+    FROM cand AS c
+    WHERE
+      -- 向量阈值（在候选集上应用）
+      (c.embedding_ft <=> query_embedding_vector) < 1 - match_threshold
+      -- JSON 过滤
+      AND c.json @> filter_condition_jsonb
+      -- data_source 访问控制（保持你原逻辑）
+      AND (
+           (data_source = 'tg' AND c.state_code = 100)
+        OR (data_source = 'my' AND c.user_id = auth.uid())
+      )
+  )
+  SELECT
+    RANK() OVER (ORDER BY f2.dist) AS "rank",
+    f2.id,
+    f2.json,
+    f2.version,
+    f2.modified_at,
+    COUNT(*) OVER()               AS total_count
+  FROM final AS f2
+  ORDER BY f2.dist
+  LIMIT match_count;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."semantic_search_processes_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."sources_sync_jsonb_version"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb THEN
+        NEW.json := NEW.json_ordered;
+        NEW.version := COALESCE(NEW.json->'sourceDataSet'->'administrativeInformation'->'publicationAndOwnership'->>'common:dataSetVersion',
+					''
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."sources_sync_jsonb_version"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."sync_auth_users_to_public_users"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    -- 处理插入操作
+    IF TG_OP = 'INSERT' THEN
+        INSERT INTO public.users (id, raw_user_meta_data)
+        VALUES (NEW.id, NEW.raw_user_meta_data);
+    -- 处理更新操作
+    ELSIF TG_OP = 'UPDATE' THEN
+		IF NEW.raw_user_meta_data != OLD.raw_user_meta_data THEN
+			UPDATE public.users
+			SET raw_user_meta_data = NEW.raw_user_meta_data
+			WHERE id = NEW.id;
+    	END IF;
+    -- 处理删除操作
+    ELSIF TG_OP = 'DELETE' THEN
+        DELETE FROM public.users
+        WHERE id = OLD.id;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."sync_auth_users_to_public_users"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."sync_json_to_jsonb"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb
+    THEN
+        NEW.json := NEW.json_ordered;
+    END IF;
+    RETURN NEW;
+END;$$;
+
+
+ALTER FUNCTION "public"."sync_json_to_jsonb"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."unitgroups_sync_jsonb_version"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $$
+BEGIN
+    IF NEW.json_ordered::jsonb IS DISTINCT FROM OLD.json_ordered::jsonb THEN
+        NEW.json := NEW.json_ordered;
+        NEW.version :=  COALESCE(NEW.json->'unitGroupDataSet'->'administrativeInformation'->'publicationAndOwnership'->>'common:dataSetVersion'
+		,
+					''
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+ALTER FUNCTION "public"."unitgroups_sync_jsonb_version"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "public"."update_modified_at"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    AS $$
+begin
+  new.modified_at = now();
+  return new;
+end;
+$$;
+
+
+ALTER FUNCTION "public"."update_modified_at"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."clear_column"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO ''
+    AS $$
+declare
+    clear_column text := TG_ARGV[0];
+begin
+    NEW := NEW #= public.hstore(clear_column, NULL);
+    return NEW;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."clear_column"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."invoke_edge_function"("name" "text", "body" "jsonb", "timeout_milliseconds" integer DEFAULT ((5 * 60) * 1000)) RETURNS "void"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  service_key text;
+begin
+  service_key := util.project_secret_key();
+
+  perform net.http_post(
+    url => util.project_url() || '/functions/v1/' || name,
+    headers => jsonb_build_object(
+      'Content-Type', 'application/json',
+      'apikey', service_key,
+      'x_region', 'us-east-1'
+    ),
+    body => body,
+    timeout_milliseconds => timeout_milliseconds
+  );
+end;
+$$;
+
+
+ALTER FUNCTION "util"."invoke_edge_function"("name" "text", "body" "jsonb", "timeout_milliseconds" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."invoke_edge_webhook"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  edge_function text := TG_ARGV[0];
+  timeout_milliseconds integer := coalesce(nullif(TG_ARGV[1], '')::integer, 1000);
+  payload jsonb;
+begin
+  if edge_function is null or edge_function = '' then
+    raise exception 'Missing webhook edge function name';
+  end if;
+
+  payload := jsonb_build_object(
+    'type', TG_OP,
+    'schema', TG_TABLE_SCHEMA,
+    'table', TG_TABLE_NAME,
+    'record', case when TG_OP = 'DELETE' then to_jsonb(OLD) else to_jsonb(NEW) end,
+    'old_record', case when TG_OP = 'INSERT' then null else to_jsonb(OLD) end
+  );
+
+  perform util.invoke_edge_function(
+    name => edge_function,
+    body => payload,
+    timeout_milliseconds => timeout_milliseconds
+  );
+
+  if TG_OP = 'DELETE' then
+    return OLD;
+  end if;
+
+  return NEW;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."invoke_edge_webhook"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."process_embeddings"("batch_size" integer DEFAULT 10, "max_requests" integer DEFAULT 10, "timeout_milliseconds" integer DEFAULT ((5 * 60) * 1000)) RETURNS "void"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO ''
+    AS $$
+declare
+  job_batches jsonb[];
+  batch jsonb;
+	edge_fn text;
+begin
+  with
+    -- First get jobs and assign batch numbers
+    numbered_jobs as (
+      select
+        message || jsonb_build_object('jobId', msg_id) as job_info,
+        (row_number() over (order by 1) - 1) / batch_size as batch_num
+      from pgmq.read(
+        queue_name => 'embedding_jobs',
+        vt => timeout_milliseconds / 1000,
+        qty => max_requests * batch_size
+      )
+    ),
+    -- Then group jobs into batches
+    batched_jobs as (
+      select
+        jsonb_agg(job_info) as batch_array,
+        batch_num
+      from numbered_jobs
+      group by batch_num, job_info->>'edgeFunction'
+    )
+  -- Finally aggregate all batches into array
+  select array_agg(batch_array)
+  from batched_jobs
+  into job_batches;
+	
+	if job_batches is null then
+    return;
+  end if;
+
+  -- Invoke the embed edge function for each batch
+  foreach batch in array job_batches loop
+    -- 使用 batch 中第一条 job 的 edgeFunction
+    edge_fn := batch->0->>'edgeFunction';
+
+    perform util.invoke_edge_function(
+      name => edge_fn,
+      body => batch,
+      timeout_milliseconds => timeout_milliseconds
+    );
+  end loop;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."process_embeddings"("batch_size" integer, "max_requests" integer, "timeout_milliseconds" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."process_webhook_jobs"("batch_size" integer DEFAULT 3, "max_batches" integer DEFAULT 10, "timeout_milliseconds" integer DEFAULT ((5 * 60) * 1000)) RETURNS "void"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO ''
+    AS $$
+declare
+  rec record;
+
+  -- 当前批
+  cur_batch jsonb[] := array[]::jsonb[];
+  cur_batch_msg_ids bigint[] := array[]::bigint[];
+  batch_count int := 0;
+
+  -- flush 用
+  payload jsonb;
+  msg_id bigint;
+  i int;
+begin
+  -- 一次性从队列读取（最多 max_batches * batch_size 条）
+  for rec in
+    select *
+    from pgmq.read(
+      queue_name => 'webhook_jobs',
+      vt => timeout_milliseconds / 1000,
+      qty => batch_size * max_batches
+    )
+  loop
+    -- 累加当前批
+    cur_batch := cur_batch || (rec.message)::jsonb;
+    cur_batch_msg_ids := cur_batch_msg_ids || rec.msg_id;
+
+    -- 满一批就 flush
+    if array_length(cur_batch, 1) >= batch_size then
+      payload := to_jsonb(cur_batch);
+
+      begin
+        perform util.invoke_edge_function(
+          name => 'webhook_flow_embedding_ft',
+          body => payload,
+          timeout_milliseconds => timeout_milliseconds
+        );
+      exception when others then
+        -- ===== 重试逻辑（新增）=====
+        for i in 1 .. array_length(cur_batch, 1) loop
+          if (cur_batch[i]->'meta'->>'retry')::int < (cur_batch[i]->'meta'->>'max_retry')::int then
+            perform pgmq.send(
+              queue_name => 'webhook_jobs',
+              msg => jsonb_set(
+                cur_batch[i],
+                '{meta,retry}',
+                to_jsonb((cur_batch[i]->'meta'->>'retry')::int + 1),
+                true
+              )
+            );
+          end if;
+        end loop;
+
+        -- 删除原消息（避免无限重试）
+        foreach msg_id in array cur_batch_msg_ids loop
+          perform pgmq.delete('webhook_jobs', msg_id);
+        end loop;
+
+        -- 清空批缓存
+        cur_batch := array[]::jsonb[];
+        cur_batch_msg_ids := array[]::bigint[];
+        batch_count := batch_count + 1;
+
+        if batch_count >= max_batches then
+          return;
+        end if;
+
+        continue;
+      end;
+
+      -- 调用成功：删除本批消息（原逻辑）
+      foreach msg_id in array cur_batch_msg_ids loop
+        perform pgmq.delete('webhook_jobs', msg_id);
+      end loop;
+
+      cur_batch := array[]::jsonb[];
+      cur_batch_msg_ids := array[]::bigint[];
+      batch_count := batch_count + 1;
+
+      if batch_count >= max_batches then
+        return;
+      end if;
+    end if;
+  end loop;
+
+  -- 处理最后不满一批的
+  if array_length(cur_batch, 1) is not null then
+    payload := to_jsonb(cur_batch);
+
+    begin
+      perform util.invoke_edge_function(
+        name => 'webhook_flow_embedding_ft',
+        body => payload,
+        timeout_milliseconds => timeout_milliseconds
+      );
+    exception when others then
+      -- ===== 重试逻辑（TAIL，新增）=====
+      for i in 1 .. array_length(cur_batch, 1) loop
+        if (cur_batch[i]->'meta'->>'retry')::int < (cur_batch[i]->'meta'->>'max_retry')::int then
+          perform pgmq.send(
+            queue_name => 'webhook_jobs',
+            msg => jsonb_set(
+              cur_batch[i],
+              '{meta,retry}',
+              to_jsonb((cur_batch[i]->'meta'->>'retry')::int + 1),
+              true
+            )
+          );
+        end if;
+      end loop;
+
+      foreach msg_id in array cur_batch_msg_ids loop
+        perform pgmq.delete('webhook_jobs', msg_id);
+      end loop;
+
+      return;
+    end;
+
+    foreach msg_id in array cur_batch_msg_ids loop
+      perform pgmq.delete('webhook_jobs', msg_id);
+    end loop;
+  end if;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."process_webhook_jobs"("batch_size" integer, "max_batches" integer, "timeout_milliseconds" integer) OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."project_x_key"() RETURNS "text"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  secret_value text;
+begin
+  select ds.decrypted_secret
+    into secret_value
+  from vault.decrypted_secrets ds
+  where ds.name = 'project_x_key';
+
+  if secret_value is null or secret_value = '' then
+    raise exception 'Missing vault secret: project_x_key';
+  end if;
+
+  return secret_value;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."project_x_key"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."project_secret_key"() RETURNS "text"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  secret_value text;
+begin
+  select ds.decrypted_secret
+    into secret_value
+  from vault.decrypted_secrets ds
+  where ds.name = 'project_secret_key';
+
+  if secret_value is null or secret_value = '' then
+    raise exception 'Missing vault secret: project_secret_key';
+  end if;
+
+  return secret_value;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."project_secret_key"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."project_url"() RETURNS "text"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  secret_value text;
+begin
+  -- Retrieve the project URL from Vault
+  select ds.decrypted_secret
+    into secret_value
+  from vault.decrypted_secrets ds
+  where ds.name = 'project_url';
+
+  if secret_value is null or secret_value = '' then
+    raise exception 'Missing vault secret: project_url';
+  end if;
+
+  return secret_value;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."project_url"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."queue_embedding_webhook"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+begin
+  perform pgmq.send(
+    queue_name => 'webhook_jobs',
+    msg => jsonb_build_object(
+			'meta', jsonb_build_object(
+        'retry', 0,
+        'max_retry', 3,
+        'first_seen_at', now(),
+        'source', TG_TABLE_NAME
+      ),
+      'type', TG_OP,                -- 'UPDATE'
+      'schema', TG_TABLE_SCHEMA,
+      'table', TG_TABLE_NAME,       -- 'flows'
+      'record', jsonb_build_object( -- 只放必要列，避免超大
+        'id', NEW.id,
+        'version', NEW.version,
+        'json_ordered', NEW.json_ordered    
+      ),
+      'old_record', jsonb_build_object(
+        'id', OLD.id,
+        'version', OLD.version,
+        'json_ordered', OLD.json_ordered
+      )
+    )
+  );
+  return NEW;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."queue_embedding_webhook"() OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "util"."queue_embeddings"() RETURNS "trigger"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  content_function text = TG_ARGV[0];
+  embedding_column text = TG_ARGV[1];
+	edge_function text := coalesce(TG_ARGV[2], 'embedding');
+begin
+  perform pgmq.send(
+    queue_name => 'embedding_jobs',
+    msg => jsonb_build_object(
+      'id', NEW.id,
+			'version', NEW.version,
+      'schema', TG_TABLE_SCHEMA,
+      'table', TG_TABLE_NAME,
+      'contentFunction', content_function,
+      'embeddingColumn', embedding_column,
+			'edgeFunction', edge_function
+    )
+  );
+  return NEW;
+end;
+$$;
+
+
+ALTER FUNCTION "util"."queue_embeddings"() OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."comments" (
+    "review_id" "uuid" NOT NULL,
+    "reviewer_id" "uuid" DEFAULT "auth"."uid"() NOT NULL,
+    "json" json,
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "state_code" integer DEFAULT 0
+);
+
+
+ALTER TABLE "public"."comments" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."contacts" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "embedding" "extensions"."vector"(1536),
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "state_code" integer DEFAULT 0,
+    "version" character(9) NOT NULL,
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "team_id" "uuid",
+    "review_id" "uuid",
+    "rule_verification" boolean,
+    "reviews" "jsonb"
+);
+
+
+ALTER TABLE "public"."contacts" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."flowproperties" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "embedding" "extensions"."vector"(1536),
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "state_code" integer DEFAULT 0,
+    "version" character(9) NOT NULL,
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "team_id" "uuid",
+    "review_id" "uuid",
+    "rule_verification" boolean,
+    "reviews" "jsonb"
+);
+
+
+ALTER TABLE "public"."flowproperties" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."ilcd" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "file_name" character varying(255),
+    "json" "jsonb",
+    "created_at" timestamp(6) with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "modified_at" timestamp with time zone DEFAULT "now"()
+);
+
+
+ALTER TABLE "public"."ilcd" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_active_snapshots" (
+    "scope" "text" NOT NULL,
+    "snapshot_id" "uuid" NOT NULL,
+    "source_hash" "text" NOT NULL,
+    "activated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "activated_by" "uuid",
+    "note" "text"
+);
+
+
+ALTER TABLE "public"."lca_active_snapshots" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_factorization_registry" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "scope" "text" DEFAULT 'prod'::"text" NOT NULL,
+    "snapshot_id" "uuid" NOT NULL,
+    "backend" "text" DEFAULT 'umfpack'::"text" NOT NULL,
+    "numeric_options_hash" "text" NOT NULL,
+    "status" "text" DEFAULT 'pending'::"text" NOT NULL,
+    "owner_worker_id" "text",
+    "lease_until" timestamp with time zone,
+    "prepared_job_id" "uuid",
+    "diagnostics" "jsonb" DEFAULT '{}'::"jsonb" NOT NULL,
+    "prepared_at" timestamp with time zone,
+    "last_used_at" timestamp with time zone,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_factorization_registry_backend_chk" CHECK (("backend" = ANY (ARRAY['umfpack'::"text", 'cholmod'::"text", 'spqr'::"text"]))),
+    CONSTRAINT "lca_factorization_registry_status_chk" CHECK (("status" = ANY (ARRAY['pending'::"text", 'building'::"text", 'ready'::"text", 'failed'::"text", 'stale'::"text"])))
+);
+
+
+ALTER TABLE "public"."lca_factorization_registry" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_jobs" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "job_type" "text" NOT NULL,
+    "snapshot_id" "uuid" NOT NULL,
+    "status" "text" DEFAULT 'queued'::"text" NOT NULL,
+    "payload" "jsonb",
+    "diagnostics" "jsonb",
+    "attempt" integer DEFAULT 0 NOT NULL,
+    "max_attempt" integer DEFAULT 3 NOT NULL,
+    "requested_by" "uuid",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "started_at" timestamp with time zone,
+    "finished_at" timestamp with time zone,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "request_key" "text",
+    "idempotency_key" "text",
+    CONSTRAINT "lca_jobs_attempt_chk" CHECK ((("attempt" >= 0) AND ("max_attempt" >= 0) AND ("attempt" <= "max_attempt"))),
+    CONSTRAINT "lca_jobs_status_chk" CHECK (("status" = ANY (ARRAY['queued'::"text", 'running'::"text", 'ready'::"text", 'completed'::"text", 'failed'::"text", 'stale'::"text"]))),
+    CONSTRAINT "lca_jobs_type_chk" CHECK (("job_type" = ANY (ARRAY['prepare_factorization'::"text", 'solve_one'::"text", 'solve_batch'::"text", 'solve_all_unit'::"text", 'invalidate_factorization'::"text", 'rebuild_factorization'::"text", 'build_snapshot'::"text", 'analyze_contribution_path'::"text"])))
+);
+
+
+ALTER TABLE "public"."lca_jobs" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_latest_all_unit_results" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "snapshot_id" "uuid" NOT NULL,
+    "job_id" "uuid" NOT NULL,
+    "result_id" "uuid" NOT NULL,
+    "query_artifact_url" "text" NOT NULL,
+    "query_artifact_sha256" "text" NOT NULL,
+    "query_artifact_byte_size" bigint NOT NULL,
+    "query_artifact_format" "text" NOT NULL,
+    "status" "text" DEFAULT 'ready'::"text" NOT NULL,
+    "computed_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_latest_all_unit_results_size_chk" CHECK (("query_artifact_byte_size" >= 0)),
+    CONSTRAINT "lca_latest_all_unit_results_status_chk" CHECK (("status" = ANY (ARRAY['ready'::"text", 'stale'::"text", 'failed'::"text"])))
+);
+
+
+ALTER TABLE "public"."lca_latest_all_unit_results" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_network_snapshots" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "scope" "text" DEFAULT 'full_library'::"text" NOT NULL,
+    "process_filter" "jsonb",
+    "lcia_method_id" "uuid",
+    "lcia_method_version" character(9),
+    "provider_matching_rule" "text" DEFAULT 'split_by_evidence_hybrid'::"text" NOT NULL,
+    "source_hash" "text",
+    "status" "text" DEFAULT 'draft'::"text" NOT NULL,
+    "created_by" "uuid",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_network_snapshots_provider_rule_chk" CHECK (("provider_matching_rule" = ANY (ARRAY['strict_unique_provider'::"text", 'best_provider_strict'::"text", 'split_by_evidence'::"text", 'split_by_evidence_hybrid'::"text", 'split_equal'::"text", 'equal_split_multi_provider'::"text", 'custom_weighted_provider'::"text"]))),
+    CONSTRAINT "lca_network_snapshots_scope_chk" CHECK (("scope" = 'full_library'::"text")),
+    CONSTRAINT "lca_network_snapshots_status_chk" CHECK (("status" = ANY (ARRAY['draft'::"text", 'ready'::"text", 'stale'::"text", 'failed'::"text"])))
+);
+
+
+ALTER TABLE "public"."lca_network_snapshots" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_package_artifacts" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "job_id" "uuid" NOT NULL,
+    "artifact_kind" "text" NOT NULL,
+    "status" "text" DEFAULT 'pending'::"text" NOT NULL,
+    "artifact_url" "text" NOT NULL,
+    "artifact_sha256" "text",
+    "artifact_byte_size" bigint,
+    "artifact_format" "text" NOT NULL,
+    "content_type" "text" NOT NULL,
+    "metadata" "jsonb" DEFAULT '{}'::"jsonb" NOT NULL,
+    "expires_at" timestamp with time zone,
+    "is_pinned" boolean DEFAULT false NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_package_artifacts_format_chk" CHECK (("artifact_format" = ANY (ARRAY['tidas-package-zip:v1'::"text", 'tidas-package-export-report:v1'::"text", 'tidas-package-import-report:v1'::"text"]))),
+    CONSTRAINT "lca_package_artifacts_kind_chk" CHECK (("artifact_kind" = ANY (ARRAY['import_source'::"text", 'export_zip'::"text", 'export_report'::"text", 'import_report'::"text"]))),
+    CONSTRAINT "lca_package_artifacts_size_chk" CHECK ((("artifact_byte_size" IS NULL) OR ("artifact_byte_size" >= 0))),
+    CONSTRAINT "lca_package_artifacts_status_chk" CHECK (("status" = ANY (ARRAY['pending'::"text", 'ready'::"text", 'failed'::"text", 'deleted'::"text"]))),
+    CONSTRAINT "lca_package_artifacts_url_chk" CHECK (("length"("btrim"("artifact_url")) > 0))
+);
+
+
+ALTER TABLE "public"."lca_package_artifacts" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_package_export_items" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "job_id" "uuid" NOT NULL,
+    "table_name" "text" NOT NULL,
+    "dataset_id" "uuid" NOT NULL,
+    "version" "text" NOT NULL,
+    "is_seed" boolean DEFAULT false NOT NULL,
+    "refs_done" boolean DEFAULT false NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_package_export_items_table_chk" CHECK (("table_name" = ANY (ARRAY['contacts'::"text", 'sources'::"text", 'unitgroups'::"text", 'flowproperties'::"text", 'flows'::"text", 'processes'::"text", 'lifecyclemodels'::"text"]))),
+    CONSTRAINT "lca_package_export_items_version_chk" CHECK (("length"("btrim"("version")) > 0))
+);
+
+
+ALTER TABLE "public"."lca_package_export_items" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_package_jobs" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "job_type" "text" NOT NULL,
+    "status" "text" DEFAULT 'queued'::"text" NOT NULL,
+    "payload" "jsonb" DEFAULT '{}'::"jsonb" NOT NULL,
+    "diagnostics" "jsonb" DEFAULT '{}'::"jsonb" NOT NULL,
+    "attempt" integer DEFAULT 0 NOT NULL,
+    "max_attempt" integer DEFAULT 3 NOT NULL,
+    "requested_by" "uuid" NOT NULL,
+    "scope" "text",
+    "root_count" integer DEFAULT 0 NOT NULL,
+    "request_key" "text",
+    "idempotency_key" "text",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "started_at" timestamp with time zone,
+    "finished_at" timestamp with time zone,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_package_jobs_attempt_chk" CHECK ((("attempt" >= 0) AND ("max_attempt" >= 0) AND ("attempt" <= "max_attempt"))),
+    CONSTRAINT "lca_package_jobs_idempotency_key_chk" CHECK ((("idempotency_key" IS NULL) OR ("length"("btrim"("idempotency_key")) > 0))),
+    CONSTRAINT "lca_package_jobs_request_key_chk" CHECK ((("request_key" IS NULL) OR ("length"("btrim"("request_key")) > 0))),
+    CONSTRAINT "lca_package_jobs_root_count_chk" CHECK (("root_count" >= 0)),
+    CONSTRAINT "lca_package_jobs_status_chk" CHECK (("status" = ANY (ARRAY['queued'::"text", 'running'::"text", 'ready'::"text", 'completed'::"text", 'failed'::"text", 'stale'::"text"]))),
+    CONSTRAINT "lca_package_jobs_type_chk" CHECK (("job_type" = ANY (ARRAY['export_package'::"text", 'import_package'::"text"])))
+);
+
+
+ALTER TABLE "public"."lca_package_jobs" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_package_request_cache" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "requested_by" "uuid" NOT NULL,
+    "operation" "text" NOT NULL,
+    "request_key" "text" NOT NULL,
+    "request_payload" "jsonb" NOT NULL,
+    "status" "text" DEFAULT 'pending'::"text" NOT NULL,
+    "job_id" "uuid",
+    "export_artifact_id" "uuid",
+    "report_artifact_id" "uuid",
+    "error_code" "text",
+    "error_message" "text",
+    "hit_count" bigint DEFAULT 0 NOT NULL,
+    "last_accessed_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_package_request_cache_hit_count_chk" CHECK (("hit_count" >= 0)),
+    CONSTRAINT "lca_package_request_cache_operation_chk" CHECK (("operation" = ANY (ARRAY['export_package'::"text", 'import_package'::"text"]))),
+    CONSTRAINT "lca_package_request_cache_request_key_chk" CHECK (("length"("btrim"("request_key")) > 0)),
+    CONSTRAINT "lca_package_request_cache_status_chk" CHECK (("status" = ANY (ARRAY['pending'::"text", 'running'::"text", 'ready'::"text", 'failed'::"text", 'stale'::"text"])))
+);
+
+
+ALTER TABLE "public"."lca_package_request_cache" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_result_cache" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "scope" "text" DEFAULT 'prod'::"text" NOT NULL,
+    "snapshot_id" "uuid" NOT NULL,
+    "request_key" "text" NOT NULL,
+    "request_payload" "jsonb" NOT NULL,
+    "status" "text" DEFAULT 'pending'::"text" NOT NULL,
+    "job_id" "uuid",
+    "result_id" "uuid",
+    "error_code" "text",
+    "error_message" "text",
+    "hit_count" bigint DEFAULT 0 NOT NULL,
+    "last_accessed_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_result_cache_hit_count_chk" CHECK (("hit_count" >= 0)),
+    CONSTRAINT "lca_result_cache_request_key_chk" CHECK (("length"("request_key") > 0)),
+    CONSTRAINT "lca_result_cache_status_chk" CHECK (("status" = ANY (ARRAY['pending'::"text", 'running'::"text", 'ready'::"text", 'failed'::"text", 'stale'::"text"])))
+);
+
+
+ALTER TABLE "public"."lca_result_cache" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_results" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "job_id" "uuid" NOT NULL,
+    "snapshot_id" "uuid" NOT NULL,
+    "payload" "jsonb",
+    "diagnostics" "jsonb",
+    "artifact_url" "text",
+    "artifact_sha256" "text",
+    "artifact_byte_size" bigint,
+    "artifact_format" "text",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_results_artifact_size_chk" CHECK ((("artifact_byte_size" IS NULL) OR ("artifact_byte_size" >= 0)))
+);
+
+
+ALTER TABLE "public"."lca_results" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lca_snapshot_artifacts" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "snapshot_id" "uuid" NOT NULL,
+    "artifact_url" "text" NOT NULL,
+    "artifact_sha256" "text" NOT NULL,
+    "artifact_byte_size" bigint NOT NULL,
+    "artifact_format" "text" NOT NULL,
+    "process_count" integer NOT NULL,
+    "flow_count" integer NOT NULL,
+    "impact_count" integer NOT NULL,
+    "a_nnz" bigint NOT NULL,
+    "b_nnz" bigint NOT NULL,
+    "c_nnz" bigint NOT NULL,
+    "coverage" "jsonb",
+    "status" "text" DEFAULT 'ready'::"text" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lca_snapshot_artifacts_counts_chk" CHECK ((("process_count" >= 0) AND ("flow_count" >= 0) AND ("impact_count" >= 0) AND ("a_nnz" >= 0) AND ("b_nnz" >= 0) AND ("c_nnz" >= 0))),
+    CONSTRAINT "lca_snapshot_artifacts_size_chk" CHECK (("artifact_byte_size" >= 0)),
+    CONSTRAINT "lca_snapshot_artifacts_status_chk" CHECK (("status" = ANY (ARRAY['ready'::"text", 'stale'::"text", 'failed'::"text"])))
+);
+
+
+ALTER TABLE "public"."lca_snapshot_artifacts" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."lciamethods" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp(6) with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "state_code" integer DEFAULT 0,
+    "version" character(9) NOT NULL,
+    "modified_at" timestamp with time zone DEFAULT "now"()
+);
+
+
+ALTER TABLE "public"."lciamethods" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."notifications" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "recipient_user_id" "uuid" NOT NULL,
+    "sender_user_id" "uuid" NOT NULL,
+    "type" "text" NOT NULL,
+    "dataset_type" "text" NOT NULL,
+    "dataset_id" "uuid" NOT NULL,
+    "dataset_version" "text" NOT NULL,
+    "json" "jsonb" DEFAULT '{}'::"jsonb" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "modified_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."notifications" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."reviews" (
+    "id" "uuid" NOT NULL,
+    "data_id" "uuid",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "state_code" integer DEFAULT 0,
+    "data_version" character(9),
+    "reviewer_id" "jsonb",
+    "json" "jsonb",
+    "deadline" timestamp with time zone
+);
+
+
+ALTER TABLE "public"."reviews" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."roles" (
+    "user_id" "uuid" NOT NULL,
+    "team_id" "uuid" NOT NULL,
+    "role" character varying(255) NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "modified_at" timestamp with time zone
+);
+
+
+ALTER TABLE "public"."roles" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."sources" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "embedding" "extensions"."vector"(1536),
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "state_code" integer DEFAULT 0,
+    "version" character(9) NOT NULL,
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "team_id" "uuid",
+    "review_id" "uuid",
+    "rule_verification" boolean,
+    "reviews" "jsonb"
+);
+
+
+ALTER TABLE "public"."sources" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."teams" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "modified_at" timestamp with time zone,
+    "rank" integer DEFAULT '-1'::integer,
+    "is_public" boolean DEFAULT false
+);
+
+
+ALTER TABLE "public"."teams" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."unitgroups" (
+    "id" "uuid" NOT NULL,
+    "json" "jsonb",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "json_ordered" json,
+    "embedding" "extensions"."vector"(1536),
+    "user_id" "uuid" DEFAULT "auth"."uid"(),
+    "state_code" integer DEFAULT 0,
+    "version" character(9) NOT NULL,
+    "modified_at" timestamp with time zone DEFAULT "now"(),
+    "team_id" "uuid",
+    "review_id" "uuid",
+    "rule_verification" boolean,
+    "reviews" "jsonb"
+);
+
+
+ALTER TABLE "public"."unitgroups" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "public"."users" (
+    "id" "uuid" NOT NULL,
+    "raw_user_meta_data" "jsonb",
+    "contact" "jsonb"
+);
+
+
+ALTER TABLE "public"."users" OWNER TO "postgres";
+
+
+ALTER TABLE ONLY "public"."comments"
+    ADD CONSTRAINT "comments_pkey" PRIMARY KEY ("review_id", "reviewer_id");
+
+
+
+ALTER TABLE ONLY "public"."contacts"
+    ADD CONSTRAINT "contacts_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "public"."flowproperties"
+    ADD CONSTRAINT "flowproperties_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "public"."flows"
+    ADD CONSTRAINT "flows_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "public"."ilcd"
+    ADD CONSTRAINT "ilcd_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_active_snapshots"
+    ADD CONSTRAINT "lca_active_snapshots_pkey" PRIMARY KEY ("scope");
+
+
+
+ALTER TABLE ONLY "public"."lca_factorization_registry"
+    ADD CONSTRAINT "lca_factorization_registry_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_factorization_registry"
+    ADD CONSTRAINT "lca_factorization_registry_scope_snapshot_backend_opts_uk" UNIQUE ("scope", "snapshot_id", "backend", "numeric_options_hash");
+
+
+
+ALTER TABLE ONLY "public"."lca_jobs"
+    ADD CONSTRAINT "lca_jobs_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_latest_all_unit_results"
+    ADD CONSTRAINT "lca_latest_all_unit_results_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_latest_all_unit_results"
+    ADD CONSTRAINT "lca_latest_all_unit_results_snapshot_uk" UNIQUE ("snapshot_id");
+
+
+
+ALTER TABLE ONLY "public"."lca_network_snapshots"
+    ADD CONSTRAINT "lca_network_snapshots_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_package_artifacts"
+    ADD CONSTRAINT "lca_package_artifacts_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_package_export_items"
+    ADD CONSTRAINT "lca_package_export_items_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_package_jobs"
+    ADD CONSTRAINT "lca_package_jobs_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_package_request_cache"
+    ADD CONSTRAINT "lca_package_request_cache_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_package_request_cache"
+    ADD CONSTRAINT "lca_package_request_cache_user_op_request_uk" UNIQUE ("requested_by", "operation", "request_key");
+
+
+
+ALTER TABLE ONLY "public"."lca_result_cache"
+    ADD CONSTRAINT "lca_result_cache_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_result_cache"
+    ADD CONSTRAINT "lca_result_cache_scope_snapshot_request_key_uk" UNIQUE ("scope", "snapshot_id", "request_key");
+
+
+
+ALTER TABLE ONLY "public"."lca_results"
+    ADD CONSTRAINT "lca_results_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_snapshot_artifacts"
+    ADD CONSTRAINT "lca_snapshot_artifacts_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."lciamethods"
+    ADD CONSTRAINT "lciamethods_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "public"."lifecyclemodels"
+    ADD CONSTRAINT "lifecyclemodels_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "public"."notifications"
+    ADD CONSTRAINT "notifications_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."processes"
+    ADD CONSTRAINT "processes_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "public"."reviews"
+    ADD CONSTRAINT "reviews_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."roles"
+    ADD CONSTRAINT "roles_pkey" PRIMARY KEY ("user_id", "team_id");
+
+
+
+ALTER TABLE ONLY "public"."sources"
+    ADD CONSTRAINT "sources_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "public"."teams"
+    ADD CONSTRAINT "teams_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."unitgroups"
+    ADD CONSTRAINT "unitgroups_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "public"."users"
+    ADD CONSTRAINT "users_pkey" PRIMARY KEY ("id");
+
+
+
+CREATE INDEX "contacts_created_at_idx" ON "public"."contacts" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "contacts_json_dataversion" ON "public"."contacts" USING "btree" (((((("json" -> 'contactDataSet'::"text") -> 'administrativeInformation'::"text") -> 'publicationAndOwnership'::"text") ->> 'common:dataSetVersion'::"text")));
+
+
+
+CREATE INDEX "contacts_json_email" ON "public"."contacts" USING "btree" (((((("json" -> 'contactDataSet'::"text") -> 'contactInformation'::"text") -> 'dataSetInformation'::"text") ->> 'email'::"text")));
+
+
+
+CREATE INDEX "contacts_json_idx" ON "public"."contacts" USING "gin" ("json");
+
+
+
+CREATE INDEX "contacts_json_ordered_vector" ON "public"."contacts" USING "hnsw" ("embedding" "extensions"."vector_cosine_ops");
+
+
+
+CREATE INDEX "contacts_json_pgroonga" ON "public"."contacts" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2");
+
+
+
+CREATE INDEX "contacts_user_id_created_at_idx" ON "public"."contacts" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE UNIQUE INDEX "file_name_index" ON "public"."ilcd" USING "btree" ("file_name");
+
+
+
+CREATE INDEX "flowproperties_created_at_idx" ON "public"."flowproperties" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "flowproperties_json_dataversion" ON "public"."flowproperties" USING "btree" (((((("json" -> 'flowPropertyDataSet'::"text") -> 'administrativeInformation'::"text") -> 'publicationAndOwnership'::"text") ->> 'common:dataSetVersion'::"text")));
+
+
+
+CREATE INDEX "flowproperties_json_idx" ON "public"."flowproperties" USING "gin" ("json");
+
+
+
+CREATE INDEX "flowproperties_json_ordered_vector" ON "public"."flowproperties" USING "hnsw" ("embedding" "extensions"."vector_cosine_ops");
+
+
+
+CREATE INDEX "flowproperties_json_pgroonga" ON "public"."flowproperties" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2");
+
+
+
+CREATE INDEX "flowproperties_json_refobjectid" ON "public"."flowproperties" USING "btree" ((((((("json" -> 'flowPropertyDataSet'::"text") -> 'flowPropertiesInformation'::"text") -> 'quantitativeReference'::"text") -> 'referenceToReferenceUnitGroup'::"text") ->> '@refObjectId'::"text")));
+
+
+
+CREATE INDEX "flowproperties_modified_at_idx" ON "public"."flowproperties" USING "btree" ("modified_at");
+
+
+
+CREATE INDEX "flowproperties_user_id_created_at_idx" ON "public"."flowproperties" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE INDEX "flows_composite_idx" ON "public"."flows" USING "btree" (((((("json" -> 'flowDataSet'::"text") -> 'modellingAndValidation'::"text") -> 'LCIMethod'::"text") ->> 'typeOfDataSet'::"text")), "state_code", "modified_at" DESC);
+
+
+
+CREATE INDEX "flows_created_at_idx" ON "public"."flows" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "flows_embedding_ft_hnsw_idx" ON "public"."flows" USING "hnsw" ("embedding_ft" "extensions"."vector_cosine_ops");
+
+
+
+CREATE INDEX "flows_embedding_hnsw_idx" ON "public"."flows" USING "hnsw" ("embedding" "extensions"."halfvec_cosine_ops");
+
+
+
+CREATE INDEX "flows_json_casnumber" ON "public"."flows" USING "btree" (((((("json" -> 'flowDataSet'::"text") -> 'flowInformation'::"text") -> 'dataSetInformation'::"text") ->> 'CASNumber'::"text")));
+
+
+
+CREATE INDEX "flows_json_dataversion" ON "public"."flows" USING "btree" (((((("json" -> 'flowDataSet'::"text") -> 'administrativeInformation'::"text") -> 'publicationAndOwnership'::"text") ->> 'common:dataSetVersion'::"text")));
+
+
+
+CREATE INDEX "flows_json_locationofsupply" ON "public"."flows" USING "btree" (((((("json" -> 'flowDataSet'::"text") -> 'flowInformation'::"text") -> 'geography'::"text") ->> 'locationOfSupply'::"text")));
+
+
+
+CREATE INDEX "flows_json_pgroonga" ON "public"."flows" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2");
+
+
+
+CREATE INDEX "flows_json_typeofdataset" ON "public"."flows" USING "btree" (((((("json" -> 'flowDataSet'::"text") -> 'modellingAndValidation'::"text") -> 'LCIMethod'::"text") ->> 'typeOfDataSet'::"text")));
+
+
+
+CREATE INDEX "flows_modified_at_idx" ON "public"."flows" USING "btree" ("modified_at");
+
+
+
+CREATE INDEX "flows_not_emissions_idx" ON "public"."flows" USING "btree" ("state_code", "modified_at" DESC) WHERE (NOT ("json" @> '{"flowDataSet": {"flowInformation": {"dataSetInformation": {"classificationInformation": {"common:elementaryFlowCategorization": {"common:category": [{"#text": "Emissions", "@level": "0"}]}}}}}}'::"jsonb"));
+
+
+
+CREATE INDEX "flows_review_id_idx" ON "public"."flows" USING "btree" ("review_id");
+
+
+
+CREATE INDEX "flows_state_code_idx" ON "public"."flows" USING "btree" ("state_code");
+
+
+
+CREATE INDEX "flows_team_id_idx" ON "public"."flows" USING "btree" ("team_id");
+
+
+
+CREATE INDEX "flows_text_pgroonga" ON "public"."flows" USING "pgroonga" ("extracted_text");
+
+
+
+CREATE INDEX "flows_user_id_created_at_idx" ON "public"."flows" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE INDEX "ilcd_created_at_idx" ON "public"."ilcd" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "ilcd_json_idx" ON "public"."ilcd" USING "gin" ("json");
+
+
+
+CREATE INDEX "ilcd_modified_at_idx" ON "public"."ilcd" USING "btree" ("modified_at");
+
+
+
+CREATE INDEX "ilcd_user_id_created_at_idx" ON "public"."ilcd" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE INDEX "lca_active_snapshots_snapshot_idx" ON "public"."lca_active_snapshots" USING "btree" ("snapshot_id");
+
+
+
+CREATE INDEX "lca_factorization_registry_snapshot_status_idx" ON "public"."lca_factorization_registry" USING "btree" ("snapshot_id", "status", "updated_at" DESC);
+
+
+
+CREATE INDEX "lca_factorization_registry_status_lease_idx" ON "public"."lca_factorization_registry" USING "btree" ("status", "lease_until");
+
+
+
+CREATE UNIQUE INDEX "lca_jobs_idempotency_key_uidx" ON "public"."lca_jobs" USING "btree" ("idempotency_key") WHERE ("idempotency_key" IS NOT NULL);
+
+
+
+CREATE INDEX "lca_jobs_snapshot_created_idx" ON "public"."lca_jobs" USING "btree" ("snapshot_id", "created_at" DESC);
+
+
+
+CREATE INDEX "lca_jobs_snapshot_type_status_created_idx" ON "public"."lca_jobs" USING "btree" ("snapshot_id", "job_type", "status", "created_at" DESC);
+
+
+
+CREATE INDEX "lca_jobs_status_created_idx" ON "public"."lca_jobs" USING "btree" ("status", "created_at");
+
+
+
+CREATE INDEX "lca_latest_all_unit_results_computed_idx" ON "public"."lca_latest_all_unit_results" USING "btree" ("computed_at" DESC);
+
+
+
+CREATE INDEX "lca_latest_all_unit_results_result_idx" ON "public"."lca_latest_all_unit_results" USING "btree" ("result_id");
+
+
+
+CREATE INDEX "lca_network_snapshots_status_created_idx" ON "public"."lca_network_snapshots" USING "btree" ("status", "created_at" DESC);
+
+
+
+CREATE INDEX "lca_network_snapshots_updated_idx" ON "public"."lca_network_snapshots" USING "btree" ("updated_at" DESC);
+
+
+
+CREATE INDEX "lca_package_artifacts_job_created_idx" ON "public"."lca_package_artifacts" USING "btree" ("job_id", "created_at" DESC);
+
+
+
+CREATE UNIQUE INDEX "lca_package_artifacts_job_kind_uidx" ON "public"."lca_package_artifacts" USING "btree" ("job_id", "artifact_kind");
+
+
+
+CREATE INDEX "lca_package_artifacts_status_created_idx" ON "public"."lca_package_artifacts" USING "btree" ("status", "created_at" DESC);
+
+
+
+CREATE UNIQUE INDEX "lca_package_export_items_job_dataset_uidx" ON "public"."lca_package_export_items" USING "btree" ("job_id", "table_name", "dataset_id", "version");
+
+
+
+CREATE INDEX "lca_package_export_items_job_refs_idx" ON "public"."lca_package_export_items" USING "btree" ("job_id", "refs_done", "created_at", "table_name");
+
+
+
+CREATE INDEX "lca_package_export_items_job_seed_idx" ON "public"."lca_package_export_items" USING "btree" ("job_id", "is_seed", "created_at");
+
+
+
+CREATE UNIQUE INDEX "lca_package_jobs_idempotency_key_uidx" ON "public"."lca_package_jobs" USING "btree" ("idempotency_key") WHERE ("idempotency_key" IS NOT NULL);
+
+
+
+CREATE INDEX "lca_package_jobs_requested_by_created_idx" ON "public"."lca_package_jobs" USING "btree" ("requested_by", "created_at" DESC);
+
+
+
+CREATE INDEX "lca_package_jobs_status_created_idx" ON "public"."lca_package_jobs" USING "btree" ("status", "created_at");
+
+
+
+CREATE INDEX "lca_package_jobs_type_status_created_idx" ON "public"."lca_package_jobs" USING "btree" ("job_type", "status", "created_at" DESC);
+
+
+
+CREATE UNIQUE INDEX "lca_package_request_cache_job_uidx" ON "public"."lca_package_request_cache" USING "btree" ("job_id") WHERE ("job_id" IS NOT NULL);
+
+
+
+CREATE INDEX "lca_package_request_cache_last_accessed_idx" ON "public"."lca_package_request_cache" USING "btree" ("last_accessed_at" DESC);
+
+
+
+CREATE INDEX "lca_package_request_cache_lookup_idx" ON "public"."lca_package_request_cache" USING "btree" ("requested_by", "operation", "status", "updated_at" DESC);
+
+
+
+CREATE UNIQUE INDEX "lca_result_cache_job_uidx" ON "public"."lca_result_cache" USING "btree" ("job_id") WHERE ("job_id" IS NOT NULL);
+
+
+
+CREATE INDEX "lca_result_cache_last_accessed_idx" ON "public"."lca_result_cache" USING "btree" ("last_accessed_at" DESC);
+
+
+
+CREATE INDEX "lca_result_cache_lookup_idx" ON "public"."lca_result_cache" USING "btree" ("scope", "snapshot_id", "status", "updated_at" DESC);
+
+
+
+CREATE UNIQUE INDEX "lca_result_cache_result_uidx" ON "public"."lca_result_cache" USING "btree" ("result_id") WHERE ("result_id" IS NOT NULL);
+
+
+
+CREATE INDEX "lca_results_job_idx" ON "public"."lca_results" USING "btree" ("job_id");
+
+
+
+CREATE INDEX "lca_results_snapshot_created_idx" ON "public"."lca_results" USING "btree" ("snapshot_id", "created_at" DESC);
+
+
+
+CREATE INDEX "lca_snapshot_artifacts_created_idx" ON "public"."lca_snapshot_artifacts" USING "btree" ("created_at" DESC);
+
+
+
+CREATE UNIQUE INDEX "lca_snapshot_artifacts_snapshot_format_key" ON "public"."lca_snapshot_artifacts" USING "btree" ("snapshot_id", "artifact_format");
+
+
+
+CREATE INDEX "lca_snapshot_artifacts_snapshot_status_idx" ON "public"."lca_snapshot_artifacts" USING "btree" ("snapshot_id", "status", "created_at" DESC);
+
+
+
+CREATE INDEX "lciamethods_created_at_idx" ON "public"."lciamethods" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "lciamethods_json_dataversion" ON "public"."lciamethods" USING "btree" (((((("json" -> 'LCIAMethodDataSetDataSet'::"text") -> 'administrativeInformation'::"text") -> 'publicationAndOwnership'::"text") ->> 'common:dataSetVersion'::"text")));
+
+
+
+CREATE INDEX "lciamethods_json_idx" ON "public"."lciamethods" USING "gin" ("json");
+
+
+
+CREATE INDEX "lciamethods_json_pgroonga" ON "public"."lciamethods" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2");
+
+
+
+CREATE INDEX "lciamethods_modified_at_idx" ON "public"."lciamethods" USING "btree" ("modified_at");
+
+
+
+CREATE INDEX "lciamethods_user_id_created_at_idx" ON "public"."lciamethods" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE INDEX "lifecyclemodels_created_at_idx" ON "public"."lifecyclemodels" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "lifecyclemodels_embedding_ft_hnsw_idx" ON "public"."lifecyclemodels" USING "hnsw" ("embedding_ft" "extensions"."vector_cosine_ops");
+
+
+
+CREATE INDEX "lifecyclemodels_embedding_hnsw_idx" ON "public"."lifecyclemodels" USING "hnsw" ("embedding" "extensions"."halfvec_cosine_ops");
+
+
+
+CREATE INDEX "lifecyclemodels_json_dataversion" ON "public"."lifecyclemodels" USING "btree" (((((("json" -> 'lifeCycleModelDataSet'::"text") -> 'administrativeInformation'::"text") -> 'publicationAndOwnership'::"text") ->> 'common:dataSetVersion'::"text")));
+
+
+
+CREATE INDEX "lifecyclemodels_json_idx" ON "public"."lifecyclemodels" USING "gin" ("json");
+
+
+
+CREATE INDEX "lifecyclemodels_json_pgroonga" ON "public"."lifecyclemodels" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2");
+
+
+
+CREATE INDEX "lifecyclemodels_json_tg_idx" ON "public"."lifecyclemodels" USING "gin" ("json_tg");
+
+
+
+CREATE INDEX "lifecyclemodels_modified_at_idx" ON "public"."lifecyclemodels" USING "btree" ("modified_at");
+
+
+
+CREATE INDEX "lifecyclemodels_text_pgroonga" ON "public"."lifecyclemodels" USING "pgroonga" ("extracted_text");
+
+
+
+CREATE INDEX "lifecyclemodels_user_id_created_at_idx" ON "public"."lifecyclemodels" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE UNIQUE INDEX "notifications_recipient_sender_type_dataset_uq" ON "public"."notifications" USING "btree" ("recipient_user_id", "sender_user_id", "type", "dataset_type", "dataset_id", "dataset_version");
+
+
+
+CREATE INDEX "notifications_recipient_type_modified_idx" ON "public"."notifications" USING "btree" ("recipient_user_id", "type", "modified_at" DESC);
+
+
+
+CREATE INDEX "processes_created_at_idx" ON "public"."processes" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "processes_embedding_ft_hnsw_idx" ON "public"."processes" USING "hnsw" ("embedding_ft" "extensions"."vector_cosine_ops");
+
+
+
+CREATE INDEX "processes_embedding_hnsw_idx" ON "public"."processes" USING "hnsw" ("embedding" "extensions"."halfvec_cosine_ops");
+
+
+
+CREATE INDEX "processes_json_dataversion" ON "public"."processes" USING "btree" (((((("json" -> 'processDataSet'::"text") -> 'administrativeInformation'::"text") -> 'publicationAndOwnership'::"text") ->> 'common:dataSetVersion'::"text")));
+
+
+
+CREATE INDEX "processes_json_exchange_gin_idx" ON "public"."processes" USING "gin" ((((("json" -> 'processDataSet'::"text") -> 'exchanges'::"text") -> 'exchange'::"text")));
+
+
+
+CREATE INDEX "processes_json_location" ON "public"."processes" USING "btree" ((((((("json" -> 'processDataSet'::"text") -> 'processInformation'::"text") -> 'geography'::"text") -> 'locationOfOperationSupplyOrProduction'::"text") ->> '@location'::"text")));
+
+
+
+CREATE INDEX "processes_json_pgroonga" ON "public"."processes" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2");
+
+
+
+CREATE INDEX "processes_json_referenceyear" ON "public"."processes" USING "btree" (((((("json" -> 'processDataSet'::"text") -> 'processInformation'::"text") -> 'time'::"text") ->> 'common:referenceYear'::"text")));
+
+
+
+CREATE INDEX "processes_modified_at_idx" ON "public"."processes" USING "btree" ("modified_at");
+
+
+
+CREATE INDEX "processes_review_id_idx" ON "public"."processes" USING "btree" ("review_id");
+
+
+
+CREATE INDEX "processes_rule_verification_idx" ON "public"."processes" USING "btree" ("rule_verification");
+
+
+
+CREATE INDEX "processes_state_code_idx" ON "public"."processes" USING "btree" ("state_code");
+
+
+
+CREATE INDEX "processes_team_id_idx" ON "public"."processes" USING "btree" ("team_id");
+
+
+
+CREATE INDEX "processes_text_pgroonga" ON "public"."processes" USING "pgroonga" ("extracted_text");
+
+
+
+CREATE INDEX "processes_user_id_created_at_idx" ON "public"."processes" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE INDEX "reviews_data_id_data_version_idx" ON "public"."reviews" USING "btree" ("data_id", "data_version");
+
+
+
+CREATE INDEX "roles_role_idx" ON "public"."roles" USING "btree" ("role");
+
+
+
+CREATE INDEX "roles_team_id_user_id_role_idx" ON "public"."roles" USING "btree" ("team_id", "user_id", "role");
+
+
+
+CREATE INDEX "sources_created_at_idx" ON "public"."sources" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "sources_json_dataversion" ON "public"."sources" USING "btree" (((((("json" -> 'sourceDataSet'::"text") -> 'administrativeInformation'::"text") -> 'publicationAndOwnership'::"text") ->> 'common:dataSetVersion'::"text")));
+
+
+
+CREATE INDEX "sources_json_idx" ON "public"."sources" USING "gin" ("json");
+
+
+
+CREATE INDEX "sources_json_ordered_vector" ON "public"."sources" USING "hnsw" ("embedding" "extensions"."vector_cosine_ops");
+
+
+
+CREATE INDEX "sources_json_pgroonga" ON "public"."sources" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2");
+
+
+
+CREATE INDEX "sources_json_publicationtype" ON "public"."sources" USING "btree" (((((("json" -> 'sourceDataSet'::"text") -> 'sourceInformation'::"text") -> 'dataSetInformation'::"text") ->> 'publicationType'::"text")));
+
+
+
+CREATE INDEX "sources_json_sourcecitation" ON "public"."sources" USING "btree" (((((("json" -> 'sourceDataSet'::"text") -> 'sourceInformation'::"text") -> 'dataSetInformation'::"text") ->> 'sourceCitation'::"text")));
+
+
+
+CREATE INDEX "sources_modified_at_idx" ON "public"."sources" USING "btree" ("modified_at");
+
+
+
+CREATE INDEX "sources_user_id_created_at_idx" ON "public"."sources" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE INDEX "unitgroups_created_at_idx" ON "public"."unitgroups" USING "btree" ("created_at" DESC);
+
+
+
+CREATE INDEX "unitgroups_json_dataversion" ON "public"."unitgroups" USING "btree" (((((("json" -> 'unitGroupDataSet'::"text") -> 'administrativeInformation'::"text") -> 'publicationAndOwnership'::"text") ->> 'common:dataSetVersion'::"text")));
+
+
+
+CREATE INDEX "unitgroups_json_idx" ON "public"."unitgroups" USING "gin" ("json");
+
+
+
+CREATE INDEX "unitgroups_json_ordered_vector" ON "public"."unitgroups" USING "hnsw" ("embedding" "extensions"."vector_cosine_ops");
+
+
+
+CREATE INDEX "unitgroups_json_pgroonga" ON "public"."unitgroups" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2");
+
+
+
+CREATE INDEX "unitgroups_json_referencetoreferenceunit" ON "public"."unitgroups" USING "btree" (((((("json" -> 'unitGroupDataSet'::"text") -> 'unitGroupInformation'::"text") -> 'quantitativeReference'::"text") ->> 'referenceToReferenceUnit'::"text")));
+
+
+
+CREATE INDEX "unitgroups_modified_at_idx" ON "public"."unitgroups" USING "btree" ("modified_at");
+
+
+
+CREATE INDEX "unitgroups_user_id_created_at_idx" ON "public"."unitgroups" USING "btree" ("user_id", "created_at" DESC);
+
+
+
+CREATE OR REPLACE TRIGGER "contacts_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."contacts" FOR EACH ROW EXECUTE FUNCTION "public"."contacts_sync_jsonb_version"();
+
+
+
+CREATE OR REPLACE TRIGGER "contacts_set_modified_at_trigger" BEFORE UPDATE ON "public"."contacts" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "flow_embedding_ft_on_extract_md_update" AFTER UPDATE OF "extracted_md" ON "public"."flows" FOR EACH ROW WHEN (("old"."extracted_md" IS DISTINCT FROM "new"."extracted_md")) EXECUTE FUNCTION "util"."queue_embeddings"('flows_embedding_ft_input', 'embedding_ft', 'embedding_ft');
+
+
+
+CREATE OR REPLACE TRIGGER "flow_extract_md_trigger_insert" AFTER INSERT ON "public"."flows" FOR EACH ROW EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_flow_embedding_ft', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "flow_extract_md_trigger_update" AFTER UPDATE OF "json" ON "public"."flows" FOR EACH ROW WHEN (("new"."json" IS DISTINCT FROM "old"."json")) EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_flow_embedding_ft', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "flow_extract_md_trigger_update_flag" AFTER UPDATE OF "embedding_flag" ON "public"."flows" FOR EACH ROW WHEN (("new"."embedding_flag" IS DISTINCT FROM "old"."embedding_flag")) EXECUTE FUNCTION "util"."queue_embedding_webhook"();
+
+
+
+CREATE OR REPLACE TRIGGER "flow_extract_text_trigger_insert" AFTER INSERT ON "public"."flows" FOR EACH ROW EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_flow_embedding', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "flow_extract_text_trigger_update" AFTER UPDATE OF "json" ON "public"."flows" FOR EACH ROW WHEN (("new"."json" IS DISTINCT FROM "old"."json")) EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_flow_embedding', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "flowproperties_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."flowproperties" FOR EACH ROW EXECUTE FUNCTION "public"."flowproperties_sync_jsonb_version"();
+
+
+
+CREATE OR REPLACE TRIGGER "flowproperties_set_modified_at_trigger" BEFORE UPDATE ON "public"."flowproperties" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "flows_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."flows" FOR EACH ROW EXECUTE FUNCTION "public"."flows_sync_jsonb_version"();
+
+
+
+CREATE OR REPLACE TRIGGER "flows_set_modified_at_trigger" BEFORE UPDATE ON "public"."flows" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "ilcd_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."ilcd" FOR EACH ROW EXECUTE FUNCTION "public"."sync_json_to_jsonb"();
+
+
+
+CREATE OR REPLACE TRIGGER "ilcd_set_modified_at_trigger" BEFORE UPDATE ON "public"."ilcd" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "lciamethods_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."lciamethods" FOR EACH ROW EXECUTE FUNCTION "public"."lciamethods_sync_jsonb_version"();
+
+
+
+CREATE OR REPLACE TRIGGER "lciamethods_set_modified_at_trigger" BEFORE UPDATE ON "public"."lciamethods" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "lifecyclemodel_embedding_ft_on_extract_md_update" AFTER UPDATE OF "extracted_md" ON "public"."lifecyclemodels" FOR EACH ROW WHEN (("old"."extracted_md" IS DISTINCT FROM "new"."extracted_md")) EXECUTE FUNCTION "util"."queue_embeddings"('lifecyclemodels_embedding_ft_input', 'embedding_ft', 'embedding_ft');
+
+
+
+CREATE OR REPLACE TRIGGER "lifecyclemodel_extract_md_trigger_insert" AFTER INSERT ON "public"."lifecyclemodels" FOR EACH ROW EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_model_embedding_ft', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "lifecyclemodel_extract_md_trigger_update" AFTER UPDATE OF "json" ON "public"."lifecyclemodels" FOR EACH ROW WHEN (("new"."json" IS DISTINCT FROM "old"."json")) EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_model_embedding_ft', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "lifecyclemodel_extract_md_trigger_update_flag" AFTER UPDATE OF "embedding_flag" ON "public"."lifecyclemodels" FOR EACH ROW WHEN (("new"."embedding_flag" IS DISTINCT FROM "old"."embedding_flag")) EXECUTE FUNCTION "util"."queue_embedding_webhook"();
+
+
+
+CREATE OR REPLACE TRIGGER "lifecyclemodels_extract_text_trigger_insert" AFTER INSERT ON "public"."lifecyclemodels" FOR EACH ROW EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_model_embedding', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "lifecyclemodels_extract_text_trigger_update" AFTER UPDATE OF "json" ON "public"."lifecyclemodels" FOR EACH ROW WHEN (("new"."json" IS DISTINCT FROM "old"."json")) EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_model_embedding', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "lifecyclemodels_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."lifecyclemodels" FOR EACH ROW EXECUTE FUNCTION "public"."lifecyclemodels_sync_jsonb_version"();
+
+
+
+CREATE OR REPLACE TRIGGER "lifecyclemodels_set_modified_at_trigger" BEFORE UPDATE ON "public"."lifecyclemodels" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "notifications_set_modified_at_trigger" BEFORE UPDATE ON "public"."notifications" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "process_embedding_ft_on_extract_md_update" AFTER UPDATE OF "extracted_md" ON "public"."processes" FOR EACH ROW WHEN (("old"."extracted_md" IS DISTINCT FROM "new"."extracted_md")) EXECUTE FUNCTION "util"."queue_embeddings"('processes_embedding_ft_input', 'embedding_ft', 'embedding_ft');
+
+
+
+CREATE OR REPLACE TRIGGER "process_extract_md_trigger_insert" AFTER INSERT ON "public"."processes" FOR EACH ROW EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_process_embedding_ft', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "process_extract_md_trigger_update" AFTER UPDATE OF "json" ON "public"."processes" FOR EACH ROW WHEN (("new"."json" IS DISTINCT FROM "old"."json")) EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_process_embedding_ft', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "process_extract_md_trigger_update_flag" AFTER UPDATE OF "embedding_flag" ON "public"."processes" FOR EACH ROW WHEN (("new"."embedding_flag" IS DISTINCT FROM "old"."embedding_flag")) EXECUTE FUNCTION "util"."queue_embedding_webhook"();
+
+
+
+CREATE OR REPLACE TRIGGER "process_extract_text_trigger_insert" AFTER INSERT ON "public"."processes" FOR EACH ROW EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_process_embedding', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "process_extract_text_trigger_update" AFTER UPDATE OF "json" ON "public"."processes" FOR EACH ROW WHEN (("new"."json" IS DISTINCT FROM "old"."json")) EXECUTE FUNCTION "util"."invoke_edge_webhook"('webhook_process_embedding', '1000');
+
+
+
+CREATE OR REPLACE TRIGGER "processes_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."processes" FOR EACH ROW EXECUTE FUNCTION "public"."processes_sync_jsonb_version"();
+
+
+
+CREATE OR REPLACE TRIGGER "processes_set_modified_at_trigger" BEFORE UPDATE ON "public"."processes" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "roles_set_modified_at_trigger" BEFORE UPDATE ON "public"."roles" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "sources_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."sources" FOR EACH ROW EXECUTE FUNCTION "public"."sources_sync_jsonb_version"();
+
+
+
+CREATE OR REPLACE TRIGGER "sources_set_modified_at_trigger" BEFORE UPDATE ON "public"."sources" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "teams_set_modified_at_trigger" BEFORE UPDATE ON "public"."teams" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+CREATE OR REPLACE TRIGGER "unitgroups_json_sync_trigger" BEFORE INSERT OR UPDATE ON "public"."unitgroups" FOR EACH ROW EXECUTE FUNCTION "public"."unitgroups_sync_jsonb_version"();
+
+
+
+CREATE OR REPLACE TRIGGER "unitgroups_set_modified_at_trigger" BEFORE UPDATE ON "public"."unitgroups" FOR EACH ROW EXECUTE FUNCTION "public"."update_modified_at"();
+
+
+
+ALTER TABLE ONLY "public"."comments"
+    ADD CONSTRAINT "comments_review_id_fkey" FOREIGN KEY ("review_id") REFERENCES "public"."reviews"("id");
+
+
+
+ALTER TABLE ONLY "public"."lca_active_snapshots"
+    ADD CONSTRAINT "lca_active_snapshots_snapshot_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."lca_network_snapshots"("id") ON DELETE RESTRICT;
+
+
+
+ALTER TABLE ONLY "public"."lca_factorization_registry"
+    ADD CONSTRAINT "lca_factorization_registry_prepared_job_fk" FOREIGN KEY ("prepared_job_id") REFERENCES "public"."lca_jobs"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."lca_factorization_registry"
+    ADD CONSTRAINT "lca_factorization_registry_snapshot_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."lca_network_snapshots"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_jobs"
+    ADD CONSTRAINT "lca_jobs_snapshot_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."lca_network_snapshots"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_latest_all_unit_results"
+    ADD CONSTRAINT "lca_latest_all_unit_results_job_fk" FOREIGN KEY ("job_id") REFERENCES "public"."lca_jobs"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_latest_all_unit_results"
+    ADD CONSTRAINT "lca_latest_all_unit_results_result_fk" FOREIGN KEY ("result_id") REFERENCES "public"."lca_results"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_latest_all_unit_results"
+    ADD CONSTRAINT "lca_latest_all_unit_results_snapshot_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."lca_network_snapshots"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_network_snapshots"
+    ADD CONSTRAINT "lca_network_snapshots_lcia_fk" FOREIGN KEY ("lcia_method_id", "lcia_method_version") REFERENCES "public"."lciamethods"("id", "version") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."lca_package_artifacts"
+    ADD CONSTRAINT "lca_package_artifacts_job_fk" FOREIGN KEY ("job_id") REFERENCES "public"."lca_package_jobs"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_package_export_items"
+    ADD CONSTRAINT "lca_package_export_items_job_fk" FOREIGN KEY ("job_id") REFERENCES "public"."lca_package_jobs"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_package_request_cache"
+    ADD CONSTRAINT "lca_package_request_cache_export_artifact_fk" FOREIGN KEY ("export_artifact_id") REFERENCES "public"."lca_package_artifacts"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."lca_package_request_cache"
+    ADD CONSTRAINT "lca_package_request_cache_job_fk" FOREIGN KEY ("job_id") REFERENCES "public"."lca_package_jobs"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."lca_package_request_cache"
+    ADD CONSTRAINT "lca_package_request_cache_report_artifact_fk" FOREIGN KEY ("report_artifact_id") REFERENCES "public"."lca_package_artifacts"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."lca_result_cache"
+    ADD CONSTRAINT "lca_result_cache_job_fk" FOREIGN KEY ("job_id") REFERENCES "public"."lca_jobs"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."lca_result_cache"
+    ADD CONSTRAINT "lca_result_cache_result_fk" FOREIGN KEY ("result_id") REFERENCES "public"."lca_results"("id") ON DELETE SET NULL;
+
+
+
+ALTER TABLE ONLY "public"."lca_result_cache"
+    ADD CONSTRAINT "lca_result_cache_snapshot_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."lca_network_snapshots"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_results"
+    ADD CONSTRAINT "lca_results_job_fk" FOREIGN KEY ("job_id") REFERENCES "public"."lca_jobs"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_results"
+    ADD CONSTRAINT "lca_results_snapshot_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."lca_network_snapshots"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."lca_snapshot_artifacts"
+    ADD CONSTRAINT "lca_snapshot_artifacts_snapshot_fk" FOREIGN KEY ("snapshot_id") REFERENCES "public"."lca_network_snapshots"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."notifications"
+    ADD CONSTRAINT "notifications_recipient_user_id_fkey" FOREIGN KEY ("recipient_user_id") REFERENCES "auth"."users"("id");
+
+
+
+ALTER TABLE ONLY "public"."notifications"
+    ADD CONSTRAINT "notifications_sender_user_id_fkey" FOREIGN KEY ("sender_user_id") REFERENCES "auth"."users"("id");
+
+
+
+ALTER TABLE ONLY "public"."roles"
+    ADD CONSTRAINT "roles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id");
+
+
+
+CREATE POLICY "Enable delete for users based on user_id" ON "public"."contacts" FOR DELETE TO "authenticated" USING ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable delete for users based on user_id" ON "public"."flowproperties" FOR DELETE TO "authenticated" USING ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable delete for users based on user_id" ON "public"."flows" FOR DELETE TO "authenticated" USING ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable delete for users based on user_id" ON "public"."lifecyclemodels" FOR DELETE TO "authenticated" USING ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable delete for users based on user_id" ON "public"."processes" FOR DELETE TO "authenticated" USING ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable delete for users based on user_id" ON "public"."sources" FOR DELETE TO "authenticated" USING ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable delete for users based on user_id" ON "public"."unitgroups" FOR DELETE TO "authenticated" USING ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable insert data access for self" ON "public"."reviews" FOR INSERT TO "authenticated" WITH CHECK ((("auth"."uid"() IS NOT NULL) AND (((("json" -> 'user'::"text") ->> 'id'::"text"))::"uuid" = ( SELECT "auth"."uid"() AS "uid"))));
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."contacts" FOR INSERT TO "authenticated" WITH CHECK ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."flowproperties" FOR INSERT TO "authenticated" WITH CHECK ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."flows" FOR INSERT TO "authenticated" WITH CHECK ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."lifecyclemodels" FOR INSERT TO "authenticated" WITH CHECK ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."processes" FOR INSERT TO "authenticated" WITH CHECK ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."sources" FOR INSERT TO "authenticated" WITH CHECK ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable insert for authenticated users only" ON "public"."unitgroups" FOR INSERT TO "authenticated" WITH CHECK ((("state_code" = 0) AND (( SELECT "auth"."uid"() AS "uid") = "user_id")));
+
+
+
+CREATE POLICY "Enable insert for review-admin" ON "public"."comments" FOR INSERT TO "authenticated" WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid")) AND (("roles"."role")::"text" = 'review-admin'::"text")))));
+
+
+
+CREATE POLICY "Enable read access for all users" ON "public"."ilcd" FOR SELECT TO "authenticated" USING (true);
+
+
+
+CREATE POLICY "Enable read access for all users" ON "public"."lciamethods" FOR SELECT TO "authenticated" USING (true);
+
+
+
+CREATE POLICY "Enable read access for authenticated users" ON "public"."contacts" FOR SELECT USING ((("state_code" >= 100) OR (( SELECT "auth"."uid"() AS "uid") = "user_id") OR (EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = "contacts"."team_id") AND (("roles"."role")::"text" = ANY (ARRAY[('admin'::character varying)::"text", ('member'::character varying)::"text", ('owner'::character varying)::"text"])) AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (("state_code" = 20) AND ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = '00000000-0000-0000-0000-000000000000'::"uuid") AND (("roles"."role")::"text" = 'review-admin'::"text") AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."state_code" > 0) AND (((("r"."json" -> 'data'::"text") ->> 'id'::"text"))::"uuid" = "contacts"."id") AND ((("r"."json" -> 'data'::"text") ->> 'version'::"text") = ("contacts"."version")::"text") AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."id" IN ( SELECT (("review_item"."value" ->> 'id'::"text"))::"uuid" AS "uuid"
+           FROM "jsonb_array_elements"("contacts"."reviews") "review_item"("value"))) AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text")))))))));
+
+
+
+CREATE POLICY "Enable read access for authenticated users" ON "public"."flowproperties" FOR SELECT TO "authenticated" USING ((("state_code" >= 100) OR (( SELECT "auth"."uid"() AS "uid") = "user_id") OR (EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = "flowproperties"."team_id") AND (("roles"."role")::"text" = ANY (ARRAY[('admin'::character varying)::"text", ('member'::character varying)::"text", ('owner'::character varying)::"text"])) AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (("state_code" = 20) AND ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = '00000000-0000-0000-0000-000000000000'::"uuid") AND (("roles"."role")::"text" = 'review-admin'::"text") AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."state_code" > 0) AND (((("r"."json" -> 'data'::"text") ->> 'id'::"text"))::"uuid" = "flowproperties"."id") AND ((("r"."json" -> 'data'::"text") ->> 'version'::"text") = ("flowproperties"."version")::"text") AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."id" IN ( SELECT (("review_item"."value" ->> 'id'::"text"))::"uuid" AS "uuid"
+           FROM "jsonb_array_elements"("flowproperties"."reviews") "review_item"("value"))) AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text")))))))));
+
+
+
+CREATE POLICY "Enable read access for authenticated users" ON "public"."flows" FOR SELECT TO "authenticated" USING ((("state_code" >= 100) OR (( SELECT "auth"."uid"() AS "uid") = "user_id") OR (EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = "flows"."team_id") AND (("roles"."role")::"text" = ANY (ARRAY[('admin'::character varying)::"text", ('member'::character varying)::"text", ('owner'::character varying)::"text"])) AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (("state_code" = 20) AND ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = '00000000-0000-0000-0000-000000000000'::"uuid") AND (("roles"."role")::"text" = 'review-admin'::"text") AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."state_code" > 0) AND (((("r"."json" -> 'data'::"text") ->> 'id'::"text"))::"uuid" = "flows"."id") AND ((("r"."json" -> 'data'::"text") ->> 'version'::"text") = ("flows"."version")::"text") AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."id" IN ( SELECT (("review_item"."value" ->> 'id'::"text"))::"uuid" AS "uuid"
+           FROM "jsonb_array_elements"("flows"."reviews") "review_item"("value"))) AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text")))))))));
+
+
+
+CREATE POLICY "Enable read access for authenticated users" ON "public"."lifecyclemodels" FOR SELECT TO "authenticated" USING ((("state_code" >= 100) OR (( SELECT "auth"."uid"() AS "uid") = "user_id") OR (EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = "lifecyclemodels"."team_id") AND (("roles"."role")::"text" = ANY (ARRAY[('admin'::character varying)::"text", ('member'::character varying)::"text", ('owner'::character varying)::"text"])) AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (("state_code" = 20) AND ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = '00000000-0000-0000-0000-000000000000'::"uuid") AND (("roles"."role")::"text" = 'review-admin'::"text") AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."state_code" > 0) AND (((("r"."json" -> 'data'::"text") ->> 'id'::"text"))::"uuid" = "lifecyclemodels"."id") AND ((("r"."json" -> 'data'::"text") ->> 'version'::"text") = ("lifecyclemodels"."version")::"text") AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."id" IN ( SELECT (("review_item"."value" ->> 'id'::"text"))::"uuid" AS "uuid"
+           FROM "jsonb_array_elements"("lifecyclemodels"."reviews") "review_item"("value"))) AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text")))))))));
+
+
+
+CREATE POLICY "Enable read access for authenticated users" ON "public"."processes" FOR SELECT TO "authenticated" USING ((("state_code" >= 100) OR (( SELECT "auth"."uid"() AS "uid") = "user_id") OR (EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = "processes"."team_id") AND (("roles"."role")::"text" = ANY (ARRAY[('admin'::character varying)::"text", ('member'::character varying)::"text", ('owner'::character varying)::"text"])) AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = '00000000-0000-0000-0000-000000000000'::"uuid") AND (("roles"."role")::"text" = 'review-admin'::"text") AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."state_code" > 0) AND (((("r"."json" -> 'data'::"text") ->> 'id'::"text"))::"uuid" = "processes"."id") AND ((("r"."json" -> 'data'::"text") ->> 'version'::"text") = ("processes"."version")::"text") AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."id" IN ( SELECT (("review_item"."value" ->> 'id'::"text"))::"uuid" AS "uuid"
+           FROM "jsonb_array_elements"("processes"."reviews") "review_item"("value"))) AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text"))))))));
+
+
+
+CREATE POLICY "Enable read access for authenticated users" ON "public"."sources" FOR SELECT TO "authenticated" USING ((("state_code" >= 100) OR (( SELECT "auth"."uid"() AS "uid") = "user_id") OR (EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = "sources"."team_id") AND (("roles"."role")::"text" = ANY (ARRAY[('admin'::character varying)::"text", ('member'::character varying)::"text", ('owner'::character varying)::"text"])) AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (("state_code" = 20) AND ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = '00000000-0000-0000-0000-000000000000'::"uuid") AND (("roles"."role")::"text" = 'review-admin'::"text") AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."state_code" > 0) AND (((("r"."json" -> 'data'::"text") ->> 'id'::"text"))::"uuid" = "sources"."id") AND ((("r"."json" -> 'data'::"text") ->> 'version'::"text") = ("sources"."version")::"text") AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."id" IN ( SELECT (("review_item"."value" ->> 'id'::"text"))::"uuid" AS "uuid"
+           FROM "jsonb_array_elements"("sources"."reviews") "review_item"("value"))) AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text")))))))));
+
+
+
+CREATE POLICY "Enable read access for authenticated users" ON "public"."unitgroups" FOR SELECT TO "authenticated" USING ((("state_code" >= 100) OR (( SELECT "auth"."uid"() AS "uid") = "user_id") OR (EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = "unitgroups"."team_id") AND (("roles"."role")::"text" = ANY (ARRAY[('admin'::character varying)::"text", ('member'::character varying)::"text", ('owner'::character varying)::"text"])) AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (("state_code" = 20) AND ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."team_id" = '00000000-0000-0000-0000-000000000000'::"uuid") AND (("roles"."role")::"text" = 'review-admin'::"text") AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."state_code" > 0) AND (((("r"."json" -> 'data'::"text") ->> 'id'::"text"))::"uuid" = "unitgroups"."id") AND ((("r"."json" -> 'data'::"text") ->> 'version'::"text") = ("unitgroups"."version")::"text") AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text"))))) OR (EXISTS ( SELECT 1
+   FROM "public"."reviews" "r"
+  WHERE (("r"."id" IN ( SELECT (("review_item"."value" ->> 'id'::"text"))::"uuid" AS "uuid"
+           FROM "jsonb_array_elements"("unitgroups"."reviews") "review_item"("value"))) AND ("r"."reviewer_id" @> "jsonb_build_array"((( SELECT "auth"."uid"() AS "uid"))::"text")))))))));
+
+
+
+CREATE POLICY "Enable read open data access for reviews" ON "public"."comments" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid")) AND ((("roles"."role")::"text" = 'review-admin'::"text") OR (("roles"."role")::"text" = 'review-member'::"text"))))));
+
+
+
+CREATE POLICY "Enable read open data access for reviews" ON "public"."reviews" FOR SELECT TO "authenticated" USING (((EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE (("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid")) AND ((("roles"."role")::"text" = 'review-admin'::"text") OR ((("roles"."role")::"text" = 'review-member'::"text") AND ("reviews"."reviewer_id" ? (( SELECT "auth"."uid"() AS "uid"))::"text")))))) OR ((( SELECT "auth"."uid"() AS "uid") IS NOT NULL) AND (((("json" -> 'user'::"text") ->> 'id'::"text"))::"uuid" = ( SELECT "auth"."uid"() AS "uid"))) OR ("state_code" = ANY (ARRAY[2, '-1'::integer]))));
+
+
+
+ALTER TABLE "public"."comments" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."contacts" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "delete by owner and admin" ON "public"."roles" FOR DELETE TO "authenticated" USING ("public"."policy_roles_delete"("user_id", "team_id", ("role")::"text"));
+
+
+
+ALTER TABLE "public"."flowproperties" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."flows" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."ilcd" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "insert by authenticated" ON "public"."roles" FOR INSERT TO "authenticated" WITH CHECK ("public"."policy_roles_insert"("user_id", "team_id", ("role")::"text"));
+
+
+
+CREATE POLICY "insert by authenticated" ON "public"."teams" FOR INSERT TO "authenticated" WITH CHECK ((( SELECT "count"(1) AS "count"
+   FROM "public"."roles"
+  WHERE (("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid")) AND (("roles"."role")::"text" <> 'rejected'::"text") AND ("roles"."team_id" <> '00000000-0000-0000-0000-000000000000'::"uuid"))) = 0));
+
+
+
+ALTER TABLE "public"."lca_active_snapshots" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_active_snapshots_service_role_all" ON "public"."lca_active_snapshots" TO "service_role" USING (true) WITH CHECK (true);
+
+
+
+ALTER TABLE "public"."lca_factorization_registry" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_factorization_registry_service_role_all" ON "public"."lca_factorization_registry" TO "service_role" USING (true) WITH CHECK (true);
+
+
+
+ALTER TABLE "public"."lca_jobs" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_jobs_select_own" ON "public"."lca_jobs" FOR SELECT TO "authenticated" USING (("requested_by" = ( SELECT "auth"."uid"() AS "uid")));
+
+
+
+ALTER TABLE "public"."lca_latest_all_unit_results" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_latest_all_unit_results_service_role_all" ON "public"."lca_latest_all_unit_results" TO "service_role" USING (true) WITH CHECK (true);
+
+
+
+ALTER TABLE "public"."lca_network_snapshots" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_network_snapshots_service_role_all" ON "public"."lca_network_snapshots" TO "service_role" USING (true) WITH CHECK (true);
+
+
+
+ALTER TABLE "public"."lca_package_artifacts" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_package_artifacts_select_own" ON "public"."lca_package_artifacts" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."lca_package_jobs" "j"
+  WHERE (("j"."id" = "lca_package_artifacts"."job_id") AND ("j"."requested_by" = "auth"."uid"())))));
+
+
+
+ALTER TABLE "public"."lca_package_export_items" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."lca_package_jobs" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_package_jobs_select_own" ON "public"."lca_package_jobs" FOR SELECT TO "authenticated" USING (("requested_by" = "auth"."uid"()));
+
+
+
+ALTER TABLE "public"."lca_package_request_cache" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_package_request_cache_select_own" ON "public"."lca_package_request_cache" FOR SELECT TO "authenticated" USING (("requested_by" = "auth"."uid"()));
+
+
+
+ALTER TABLE "public"."lca_result_cache" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_result_cache_service_role_all" ON "public"."lca_result_cache" TO "service_role" USING (true) WITH CHECK (true);
+
+
+
+ALTER TABLE "public"."lca_results" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_results_select_own" ON "public"."lca_results" FOR SELECT TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."lca_jobs" "j"
+  WHERE (("j"."id" = "lca_results"."job_id") AND ("j"."requested_by" = ( SELECT "auth"."uid"() AS "uid"))))));
+
+
+
+ALTER TABLE "public"."lca_snapshot_artifacts" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "lca_snapshot_artifacts_service_role_all" ON "public"."lca_snapshot_artifacts" TO "service_role" USING (true) WITH CHECK (true);
+
+
+
+ALTER TABLE "public"."lciamethods" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."lifecyclemodels" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."notifications" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "notifications_insert_sender" ON "public"."notifications" FOR INSERT TO "authenticated" WITH CHECK (("auth"."uid"() = "sender_user_id"));
+
+
+
+CREATE POLICY "notifications_select_sender_or_recipient" ON "public"."notifications" FOR SELECT TO "authenticated" USING ((("auth"."uid"() = "sender_user_id") OR ("auth"."uid"() = "recipient_user_id")));
+
+
+
+CREATE POLICY "notifications_update_sender" ON "public"."notifications" FOR UPDATE TO "authenticated" USING (("auth"."uid"() = "sender_user_id")) WITH CHECK (("auth"."uid"() = "sender_user_id"));
+
+
+
+ALTER TABLE "public"."processes" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."reviews" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."roles" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "select by owner or public teams" ON "public"."teams" FOR SELECT TO "authenticated" USING (("is_public" OR ("rank" > 0) OR (EXISTS ( SELECT 1
+   FROM "public"."roles"
+  WHERE ((("roles"."team_id" = "teams"."id") OR ("roles"."team_id" = '00000000-0000-0000-0000-000000000000'::"uuid")) AND ("roles"."user_id" = ( SELECT "auth"."uid"() AS "uid")) AND (("roles"."role")::"text" <> 'rejected'::"text"))))));
+
+
+
+CREATE POLICY "select by self and team" ON "public"."roles" FOR SELECT TO "authenticated" USING ("public"."policy_roles_select"("team_id", ("role")::"text"));
+
+
+
+CREATE POLICY "select by self and team and admin" ON "public"."users" FOR SELECT TO "authenticated" USING ((("id" = ( SELECT "auth"."uid"() AS "uid")) OR ("id" IN ( SELECT "r"."user_id"
+   FROM "public"."roles" "r"
+  WHERE ((("r"."role")::"text" = 'owner'::"text") AND ("public"."policy_is_team_public"("r"."team_id") = true)))) OR ("id" IN ( SELECT "r0"."user_id"
+   FROM "public"."roles" "r0"
+  WHERE ("r0"."team_id" IN ( SELECT "r"."team_id"
+           FROM "public"."roles" "r"
+          WHERE (("r"."user_id" = ( SELECT "auth"."uid"() AS "uid")) AND (("r"."role")::"text" <> 'rejected'::"text")))))) OR "public"."policy_is_current_user_in_roles"('00000000-0000-0000-0000-000000000000'::"uuid", ARRAY['admin'::"text", 'review-admin'::"text", 'review-member'::"text"])));
+
+
+
+ALTER TABLE "public"."sources" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."teams" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "public"."unitgroups" ENABLE ROW LEVEL SECURITY;
+
+
+CREATE POLICY "update by admin or owner or self" ON "public"."roles" FOR UPDATE TO "authenticated" USING ("public"."policy_roles_update"("user_id", "team_id", ("role")::"text"));
+
+
+
+CREATE POLICY "update by owner and admin" ON "public"."teams" FOR UPDATE TO "authenticated" USING ((( SELECT "auth"."uid"() AS "uid") IN ( SELECT "roles"."user_id"
+   FROM "public"."roles"
+  WHERE ((("roles"."role")::"text" = 'admin'::"text") OR (("roles"."role")::"text" = 'owner'::"text")))));
+
+
+
+CREATE POLICY "update by review-admin or data owener" ON "public"."comments" FOR UPDATE TO "authenticated" USING ((("reviewer_id" = ( SELECT "auth"."uid"() AS "uid")) OR (EXISTS ( SELECT 1
+   FROM "public"."roles" "r"
+  WHERE (("r"."user_id" = ( SELECT "auth"."uid"() AS "uid")) AND (("r"."role")::"text" = 'review-admin'::"text"))))));
+
+
+
+ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;
+
+
+
+
+ALTER PUBLICATION "supabase_realtime" OWNER TO "postgres";
+
+
+
+
+
+GRANT USAGE ON SCHEMA "public" TO "anon";
+GRANT USAGE ON SCHEMA "public" TO "authenticated";
+GRANT USAGE ON SCHEMA "public" TO "service_role";
+GRANT USAGE ON SCHEMA "public" TO "postgres";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+GRANT ALL ON FUNCTION "public"."_navicat_temp_stored_proc"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" numeric, "extracted_text_weight" numeric, "semantic_weight" numeric, "rrf_k" integer, "data_source" "text", "this_user_id" "text", "page_size" integer, "page_current" integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."_navicat_temp_stored_proc"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" numeric, "extracted_text_weight" numeric, "semantic_weight" numeric, "rrf_k" integer, "data_source" "text", "this_user_id" "text", "page_size" integer, "page_current" integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."_navicat_temp_stored_proc"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" numeric, "extracted_text_weight" numeric, "semantic_weight" numeric, "rrf_k" integer, "data_source" "text", "this_user_id" "text", "page_size" integer, "page_current" integer) TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."contacts_sync_jsonb_version"() TO "anon";
+GRANT ALL ON FUNCTION "public"."contacts_sync_jsonb_version"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."contacts_sync_jsonb_version"() TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "public"."delete_lifecycle_model_bundle"("p_model_id" "uuid", "p_version" "text") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."delete_lifecycle_model_bundle"("p_model_id" "uuid", "p_version" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."flowproperties_sync_jsonb_version"() TO "anon";
+GRANT ALL ON FUNCTION "public"."flowproperties_sync_jsonb_version"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."flowproperties_sync_jsonb_version"() TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."flows" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."flows" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."flows" TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."flows_embedding_ft_input"("proc" "public"."flows") TO "anon";
+GRANT ALL ON FUNCTION "public"."flows_embedding_ft_input"("proc" "public"."flows") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."flows_embedding_ft_input"("proc" "public"."flows") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."flows_embedding_input"("flow" "public"."flows") TO "anon";
+GRANT ALL ON FUNCTION "public"."flows_embedding_input"("flow" "public"."flows") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."flows_embedding_input"("flow" "public"."flows") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."flows_sync_jsonb_version"() TO "anon";
+GRANT ALL ON FUNCTION "public"."flows_sync_jsonb_version"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."flows_sync_jsonb_version"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."generate_flow_embedding"() TO "anon";
+GRANT ALL ON FUNCTION "public"."generate_flow_embedding"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."generate_flow_embedding"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"("query_text" "text", "query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "full_text_weight" double precision, "extracted_text_weight" double precision, "semantic_weight" double precision, "rrf_k" integer, "data_source" "text", "page_size" integer, "page_current" integer) TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."ilcd_classification_get"("this_file_name" "text", "category_type" "text", "get_values" "text"[]) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."ilcd_classification_get"("this_file_name" "text", "category_type" "text", "get_values" "text"[]) TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."ilcd_flow_categorization_get"("this_file_name" "text", "get_values" "text"[]) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."ilcd_flow_categorization_get"("this_file_name" "text", "get_values" "text"[]) TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."ilcd_location_get"("this_file_name" "text", "get_values" "text"[]) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."ilcd_location_get"("this_file_name" "text", "get_values" "text"[]) TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "public"."lca_enqueue_job"("p_queue_name" "text", "p_message" "jsonb") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."lca_enqueue_job"("p_queue_name" "text", "p_message" "jsonb") TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "public"."lca_package_enqueue_job"("p_message" "jsonb") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."lca_package_enqueue_job"("p_message" "jsonb") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."lciamethods_sync_jsonb_version"() TO "anon";
+GRANT ALL ON FUNCTION "public"."lciamethods_sync_jsonb_version"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."lciamethods_sync_jsonb_version"() TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."lifecyclemodels" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."lifecyclemodels" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."lifecyclemodels" TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_embedding_ft_input"("proc" "public"."lifecyclemodels") TO "anon";
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_embedding_ft_input"("proc" "public"."lifecyclemodels") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_embedding_ft_input"("proc" "public"."lifecyclemodels") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_embedding_input"("models" "public"."lifecyclemodels") TO "anon";
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_embedding_input"("models" "public"."lifecyclemodels") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_embedding_input"("models" "public"."lifecyclemodels") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_sync_jsonb_version"() TO "anon";
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_sync_jsonb_version"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."lifecyclemodels_sync_jsonb_version"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search"("query_text" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search"("query_text" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search"("query_text" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_text_v1"("query_text" "text", "page_size" integer, "page_current" integer, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_v1"("query_text" "text", "filter_condition" "text", "order_by" "text", "page_size" bigint, "page_current" bigint, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups"("query_text" "text", "filter_condition" "text", "page_size" bigint, "page_current" bigint, "data_source" "text", "this_user_id" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."policy_is_current_user_in_roles"("p_team_id" "uuid", "p_roles_to_check" "text"[]) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."policy_is_current_user_in_roles"("p_team_id" "uuid", "p_roles_to_check" "text"[]) TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."policy_is_team_id_used"("_team_id" "uuid") TO "anon";
+GRANT ALL ON FUNCTION "public"."policy_is_team_id_used"("_team_id" "uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."policy_is_team_id_used"("_team_id" "uuid") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."policy_is_team_public"("_team_id" "uuid") TO "anon";
+GRANT ALL ON FUNCTION "public"."policy_is_team_public"("_team_id" "uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."policy_is_team_public"("_team_id" "uuid") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."policy_roles_delete"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."policy_roles_delete"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."policy_roles_delete"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."policy_roles_insert"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."policy_roles_insert"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."policy_roles_insert"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."policy_roles_select"("_team_id" "uuid", "_role" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."policy_roles_select"("_team_id" "uuid", "_role" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."policy_roles_select"("_team_id" "uuid", "_role" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."policy_roles_update"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."policy_roles_update"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."policy_roles_update"("_user_id" "uuid", "_team_id" "uuid", "_role" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."policy_user_has_team"("_user_id" "uuid") TO "anon";
+GRANT ALL ON FUNCTION "public"."policy_user_has_team"("_user_id" "uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."policy_user_has_team"("_user_id" "uuid") TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."processes" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."processes" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."processes" TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."processes_embedding_ft_input"("proc" "public"."processes") TO "anon";
+GRANT ALL ON FUNCTION "public"."processes_embedding_ft_input"("proc" "public"."processes") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."processes_embedding_ft_input"("proc" "public"."processes") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."processes_embedding_input"("proc" "public"."processes") TO "anon";
+GRANT ALL ON FUNCTION "public"."processes_embedding_input"("proc" "public"."processes") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."processes_embedding_input"("proc" "public"."processes") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."processes_sync_jsonb_version"() TO "anon";
+GRANT ALL ON FUNCTION "public"."processes_sync_jsonb_version"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."processes_sync_jsonb_version"() TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "public"."save_lifecycle_model_bundle"("p_plan" "jsonb") FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."save_lifecycle_model_bundle"("p_plan" "jsonb") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."semantic_search"("query_embedding" "text", "match_threshold" double precision, "match_count" integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."semantic_search"("query_embedding" "text", "match_threshold" double precision, "match_count" integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."semantic_search"("query_embedding" "text", "match_threshold" double precision, "match_count" integer) TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."semantic_search_flows_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."semantic_search_flows_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."semantic_search_flows_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."semantic_search_lifecyclemodels_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."semantic_search_lifecyclemodels_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."semantic_search_lifecyclemodels_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."semantic_search_processes_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "anon";
+GRANT ALL ON FUNCTION "public"."semantic_search_processes_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "public"."semantic_search_processes_v1"("query_embedding" "text", "filter_condition" "text", "match_threshold" double precision, "match_count" integer, "data_source" "text") TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."sources_sync_jsonb_version"() TO "anon";
+GRANT ALL ON FUNCTION "public"."sources_sync_jsonb_version"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."sources_sync_jsonb_version"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."sync_auth_users_to_public_users"() TO "anon";
+GRANT ALL ON FUNCTION "public"."sync_auth_users_to_public_users"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."sync_auth_users_to_public_users"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."sync_json_to_jsonb"() TO "anon";
+GRANT ALL ON FUNCTION "public"."sync_json_to_jsonb"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."sync_json_to_jsonb"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."unitgroups_sync_jsonb_version"() TO "anon";
+GRANT ALL ON FUNCTION "public"."unitgroups_sync_jsonb_version"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."unitgroups_sync_jsonb_version"() TO "service_role";
+
+
+
+GRANT ALL ON FUNCTION "public"."update_modified_at"() TO "anon";
+GRANT ALL ON FUNCTION "public"."update_modified_at"() TO "authenticated";
+GRANT ALL ON FUNCTION "public"."update_modified_at"() TO "service_role";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."comments" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."comments" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."comments" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."contacts" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."contacts" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."contacts" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."flowproperties" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."flowproperties" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."flowproperties" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."ilcd" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."ilcd" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."ilcd" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."lca_active_snapshots" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."lca_factorization_registry" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."lca_jobs" TO "service_role";
+GRANT SELECT ON TABLE "public"."lca_jobs" TO "authenticated";
+
+
+
+GRANT ALL ON TABLE "public"."lca_latest_all_unit_results" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."lca_network_snapshots" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."lca_package_artifacts" TO "service_role";
+GRANT SELECT ON TABLE "public"."lca_package_artifacts" TO "authenticated";
+
+
+
+GRANT ALL ON TABLE "public"."lca_package_export_items" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."lca_package_jobs" TO "service_role";
+GRANT SELECT ON TABLE "public"."lca_package_jobs" TO "authenticated";
+
+
+
+GRANT ALL ON TABLE "public"."lca_package_request_cache" TO "service_role";
+GRANT SELECT ON TABLE "public"."lca_package_request_cache" TO "authenticated";
+
+
+
+GRANT ALL ON TABLE "public"."lca_result_cache" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."lca_results" TO "service_role";
+GRANT SELECT ON TABLE "public"."lca_results" TO "authenticated";
+
+
+
+GRANT ALL ON TABLE "public"."lca_snapshot_artifacts" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."lciamethods" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."lciamethods" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."lciamethods" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."notifications" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."notifications" TO "authenticated";
+GRANT ALL ON TABLE "public"."notifications" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."reviews" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."reviews" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."reviews" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."roles" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."roles" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."roles" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."sources" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."sources" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."sources" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."teams" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."teams" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."teams" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."unitgroups" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."unitgroups" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."unitgroups" TO "service_role";
+
+
+
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."users" TO "anon";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."users" TO "authenticated";
+GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLE "public"."users" TO "service_role";
+
+
+
+
+
+
+
+
+
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON SEQUENCES TO "postgres";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON SEQUENCES TO "anon";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON SEQUENCES TO "authenticated";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON SEQUENCES TO "service_role";
+
+
+
+
+
+
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUNCTIONS TO "postgres";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUNCTIONS TO "anon";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUNCTIONS TO "authenticated";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUNCTIONS TO "service_role";
+
+
+
+
+
+
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "postgres";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "anon";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "authenticated";
+ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT SELECT,INSERT,REFERENCES,DELETE,TRIGGER,TRUNCATE,UPDATE ON TABLES TO "service_role";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/supabase/migrations/20260404123556_access_control_fix_update_policies.sql
+++ b/supabase/migrations/20260404123556_access_control_fix_update_policies.sql
@@ -1,0 +1,129 @@
+drop policy if exists "update by owner and admin" on public.teams;
+
+create policy "update by owner and admin"
+on public.teams
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.roles r
+    where r.user_id = auth.uid()
+      and r.team_id = teams.id
+      and r.role in ('owner', 'admin')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.roles r
+    where r.user_id = auth.uid()
+      and r.team_id = teams.id
+      and r.role in ('owner', 'admin')
+  )
+);
+
+drop policy if exists "update by review-admin or data owener" on public.comments;
+drop policy if exists "comments update by reviewer self" on public.comments;
+drop policy if exists "comments update by review-admin" on public.comments;
+
+create policy "comments update by reviewer self"
+on public.comments
+for update
+to authenticated
+using (reviewer_id = auth.uid())
+with check (reviewer_id = auth.uid());
+
+create policy "comments update by review-admin"
+on public.comments
+for update
+to authenticated
+using (
+  public.policy_is_current_user_in_roles(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    array['review-admin']::text[]
+  )
+)
+with check (
+  public.policy_is_current_user_in_roles(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    array['review-admin']::text[]
+  )
+);
+
+drop policy if exists "transitional_update_owner_draft_only" on public.contacts;
+create policy "transitional_update_owner_draft_only"
+on public.contacts
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.sources;
+create policy "transitional_update_owner_draft_only"
+on public.sources
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.unitgroups;
+create policy "transitional_update_owner_draft_only"
+on public.unitgroups
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.flowproperties;
+create policy "transitional_update_owner_draft_only"
+on public.flowproperties
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.flows;
+create policy "transitional_update_owner_draft_only"
+on public.flows
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.processes;
+create policy "transitional_update_owner_draft_only"
+on public.processes
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_update_owner_draft_only" on public.lifecyclemodels;
+create policy "transitional_update_owner_draft_only"
+on public.lifecyclemodels
+for update
+to authenticated
+using (state_code = 0 and user_id = auth.uid())
+with check (state_code = 0 and user_id = auth.uid());
+
+drop policy if exists "transitional_reviews_update_submitter_only" on public.reviews;
+create policy "transitional_reviews_update_submitter_only"
+on public.reviews
+for update
+to authenticated
+using (
+  auth.uid() is not null
+  and ((json -> 'user' ->> 'id')::uuid) = auth.uid()
+)
+with check (
+  auth.uid() is not null
+  and ((json -> 'user' ->> 'id')::uuid) = auth.uid()
+);
+
+drop policy if exists "notifications_delete_recipient_only" on public.notifications;
+create policy "notifications_delete_recipient_only"
+on public.notifications
+for delete
+to authenticated
+using (auth.uid() = recipient_user_id);

--- a/supabase/migrations/20260404123557_access_control_add_state_role_constraints_and_audit.sql
+++ b/supabase/migrations/20260404123557_access_control_add_state_role_constraints_and_audit.sql
@@ -1,0 +1,96 @@
+alter table public.roles
+  drop constraint if exists roles_role_check;
+
+alter table public.roles
+  add constraint roles_role_check
+  check (
+    role in (
+      'owner',
+      'admin',
+      'member',
+      'is_invited',
+      'rejected',
+      'review-admin',
+      'review-member'
+    )
+  );
+
+alter table public.reviews
+  drop constraint if exists reviews_state_code_check;
+
+alter table public.reviews
+  add constraint reviews_state_code_check
+  check (state_code in (-1, 0, 1, 2));
+
+alter table public.comments
+  drop constraint if exists comments_state_code_check;
+
+alter table public.comments
+  add constraint comments_state_code_check
+  check (state_code in (-3, -2, -1, 0, 1, 2));
+
+alter table public.contacts
+  drop constraint if exists contacts_state_code_check;
+
+alter table public.contacts
+  add constraint contacts_state_code_check
+  check (state_code in (0, 3, 20, 100));
+
+alter table public.sources
+  drop constraint if exists sources_state_code_check;
+
+alter table public.sources
+  add constraint sources_state_code_check
+  check (state_code in (0, 20, 100));
+
+alter table public.unitgroups
+  drop constraint if exists unitgroups_state_code_check;
+
+alter table public.unitgroups
+  add constraint unitgroups_state_code_check
+  check (state_code in (0, 100, 200));
+
+alter table public.flowproperties
+  drop constraint if exists flowproperties_state_code_check;
+
+alter table public.flowproperties
+  add constraint flowproperties_state_code_check
+  check (state_code in (0, 20, 100, 200));
+
+alter table public.flows
+  drop constraint if exists flows_state_code_check;
+
+alter table public.flows
+  add constraint flows_state_code_check
+  check (state_code in (0, 20, 100, 200));
+
+alter table public.processes
+  drop constraint if exists processes_state_code_check;
+
+alter table public.processes
+  add constraint processes_state_code_check
+  check (state_code in (0, 20, 100, 200));
+
+alter table public.lifecyclemodels
+  drop constraint if exists lifecyclemodels_state_code_check;
+
+alter table public.lifecyclemodels
+  add constraint lifecyclemodels_state_code_check
+  check (state_code in (0, 20, 100));
+
+create table if not exists public.command_audit_log (
+  id bigint generated always as identity primary key,
+  command text not null,
+  actor_user_id uuid not null,
+  target_table text,
+  target_id uuid,
+  target_version text,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+revoke all on public.command_audit_log from anon, authenticated;
+grant all on public.command_audit_log to service_role;
+
+revoke all on sequence public.command_audit_log_id_seq from anon, authenticated;
+grant all on sequence public.command_audit_log_id_seq to service_role;

--- a/supabase/migrations/20260404153000_access_control_add_dataset_command_rpcs.sql
+++ b/supabase/migrations/20260404153000_access_control_add_dataset_command_rpcs.sql
@@ -1,0 +1,474 @@
+create or replace function public.cmd_dataset_save_draft(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_json_ordered jsonb,
+  p_model_id uuid default null,
+  p_rule_verification boolean default null,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_current_row jsonb;
+  v_owner_id uuid;
+  v_state_code integer;
+  v_updated_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table'
+    );
+  end if;
+
+  if p_json_ordered is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'JSON_ORDERED_REQUIRED',
+      'status', 400,
+      'message', 'jsonOrdered is required'
+    );
+  end if;
+
+  if p_table = 'processes' and p_model_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'MODEL_ID_REQUIRED',
+      'status', 400,
+      'message', 'modelId is required for process dataset drafts'
+    );
+  end if;
+
+  if p_table <> 'processes' and p_model_id is not null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'MODEL_ID_NOT_ALLOWED',
+      'status', 400,
+      'message', 'modelId is only allowed for process dataset drafts'
+    );
+  end if;
+
+  execute format(
+    'select to_jsonb(t) from public.%I as t where t.id = $1 and t.version = $2 for update of t',
+    p_table
+  )
+    into v_current_row
+    using p_id, p_version;
+
+  if v_current_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  v_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+  v_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+  if v_owner_id is distinct from v_actor then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_OWNER_REQUIRED',
+      'status', 403,
+      'message', 'Only the dataset owner can save draft changes'
+    );
+  end if;
+
+  if v_state_code >= 100 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_ALREADY_PUBLISHED',
+      'status', 403,
+      'message', 'Published data cannot be edited through draft save',
+      'details', jsonb_build_object(
+        'state_code', v_state_code
+      )
+    );
+  end if;
+
+  if v_state_code >= 20 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_UNDER_REVIEW',
+      'status', 403,
+      'message', 'Data is under review and cannot be modified',
+      'details', jsonb_build_object(
+        'state_code', 20,
+        'review_state_code', v_state_code
+      )
+    );
+  end if;
+
+  if p_table = 'processes' then
+    execute format(
+      'update public.%I as t
+          set json_ordered = $1::json,
+              model_id = $2,
+              rule_verification = $3,
+              modified_at = now()
+        where t.id = $4
+          and t.version = $5
+      returning to_jsonb(t)',
+      p_table
+    )
+      into v_updated_row
+      using p_json_ordered, p_model_id, p_rule_verification, p_id, p_version;
+  else
+    execute format(
+      'update public.%I as t
+          set json_ordered = $1::json,
+              rule_verification = $2,
+              modified_at = now()
+        where t.id = $3
+          and t.version = $4
+      returning to_jsonb(t)',
+      p_table
+    )
+      into v_updated_row
+      using p_json_ordered, p_rule_verification, p_id, p_version;
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_save_draft',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_updated_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_dataset_assign_team(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_team_id uuid,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_current_row jsonb;
+  v_owner_id uuid;
+  v_state_code integer;
+  v_updated_row jsonb;
+  v_actor_has_team_role boolean;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table'
+    );
+  end if;
+
+  execute format(
+    'select to_jsonb(t) from public.%I as t where t.id = $1 and t.version = $2 for update of t',
+    p_table
+  )
+    into v_current_row
+    using p_id, p_version;
+
+  if v_current_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  v_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+  v_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+  if v_owner_id is distinct from v_actor then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_OWNER_REQUIRED',
+      'status', 403,
+      'message', 'Only the dataset owner can change dataset team ownership'
+    );
+  end if;
+
+  if v_state_code >= 100 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_ALREADY_PUBLISHED',
+      'status', 403,
+      'message', 'Published data cannot be reassigned to another team',
+      'details', jsonb_build_object(
+        'state_code', v_state_code
+      )
+    );
+  end if;
+
+  if v_state_code >= 20 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_UNDER_REVIEW',
+      'status', 403,
+      'message', 'Data is under review and cannot be reassigned',
+      'details', jsonb_build_object(
+        'state_code', 20,
+        'review_state_code', v_state_code
+      )
+    );
+  end if;
+
+  select exists (
+    select 1
+    from public.roles r
+    where r.user_id = v_actor
+      and r.team_id = p_team_id
+      and r.role not in ('is_invited', 'rejected')
+  )
+    into v_actor_has_team_role;
+
+  if not v_actor_has_team_role then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_MEMBERSHIP_REQUIRED',
+      'status', 403,
+      'message', 'You must belong to the target team before assigning dataset ownership'
+    );
+  end if;
+
+  execute format(
+    'update public.%I as t
+        set team_id = $1,
+            modified_at = now()
+      where t.id = $2
+        and t.version = $3
+    returning to_jsonb(t)',
+    p_table
+  )
+    into v_updated_row
+    using p_team_id, p_id, p_version;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_assign_team',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_updated_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_dataset_publish(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_current_row jsonb;
+  v_owner_id uuid;
+  v_state_code integer;
+  v_updated_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table'
+    );
+  end if;
+
+  execute format(
+    'select to_jsonb(t) from public.%I as t where t.id = $1 and t.version = $2 for update of t',
+    p_table
+  )
+    into v_current_row
+    using p_id, p_version;
+
+  if v_current_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  v_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+  v_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+  if v_owner_id is distinct from v_actor then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_OWNER_REQUIRED',
+      'status', 403,
+      'message', 'Only the dataset owner can publish the dataset'
+    );
+  end if;
+
+  if v_state_code >= 100 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_ALREADY_PUBLISHED',
+      'status', 403,
+      'message', 'Dataset is already published',
+      'details', jsonb_build_object(
+        'state_code', v_state_code
+      )
+    );
+  end if;
+
+  if v_state_code >= 20 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_UNDER_REVIEW',
+      'status', 403,
+      'message', 'Data is under review and cannot be published directly',
+      'details', jsonb_build_object(
+        'state_code', 20,
+        'review_state_code', v_state_code
+      )
+    );
+  end if;
+
+  execute format(
+    'update public.%I as t
+        set state_code = 100,
+            modified_at = now()
+      where t.id = $1
+        and t.version = $2
+    returning to_jsonb(t)',
+    p_table
+  )
+    into v_updated_row
+    using p_id, p_version;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_publish',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_updated_row
+  );
+end;
+$$;
+
+revoke all on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) from public;
+revoke all on function public.cmd_dataset_assign_team(text, uuid, text, uuid, jsonb) from public;
+revoke all on function public.cmd_dataset_publish(text, uuid, text, jsonb) from public;
+
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to authenticated;
+grant execute on function public.cmd_dataset_assign_team(text, uuid, text, uuid, jsonb) to authenticated;
+grant execute on function public.cmd_dataset_publish(text, uuid, text, jsonb) to authenticated;
+
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to service_role;
+grant execute on function public.cmd_dataset_assign_team(text, uuid, text, uuid, jsonb) to service_role;
+grant execute on function public.cmd_dataset_publish(text, uuid, text, jsonb) to service_role;

--- a/supabase/migrations/20260404170000_access_control_add_review_submit_rpc.sql
+++ b/supabase/migrations/20260404170000_access_control_add_review_submit_rpc.sql
@@ -1,0 +1,761 @@
+create or replace function public.cmd_review_ref_type_to_table(p_ref_type text)
+returns text
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  select case lower(trim(coalesce(p_ref_type, '')))
+    when 'contact data set' then 'contacts'
+    when 'source data set' then 'sources'
+    when 'unit group data set' then 'unitgroups'
+    when 'flow property data set' then 'flowproperties'
+    when 'flow data set' then 'flows'
+    when 'process data set' then 'processes'
+    when 'lifecyclemodel data set' then 'lifecyclemodels'
+    when 'lifecycle model data set' then 'lifecyclemodels'
+    when 'lifecyclemodel dataset' then 'lifecyclemodels'
+    else null
+  end
+$$;
+
+create or replace function public.cmd_review_extract_refs(p_json jsonb)
+returns table (
+  ref_type text,
+  ref_object_id uuid,
+  ref_version text
+)
+language sql
+stable
+set search_path = public, pg_temp
+as $$
+  with recursive walk(value) as (
+    select coalesce(p_json, '{}'::jsonb)
+    union all
+    select child.value
+    from walk
+    cross join lateral (
+      select object_values.value
+      from jsonb_each(
+        case
+          when jsonb_typeof(walk.value) = 'object' then walk.value
+          else '{}'::jsonb
+        end
+      ) as object_values(key, value)
+      union all
+      select array_values.value
+      from jsonb_array_elements(
+        case
+          when jsonb_typeof(walk.value) = 'array' then walk.value
+          else '[]'::jsonb
+        end
+      ) as array_values(value)
+    ) as child
+  )
+  select distinct
+    lower(trim(value->>'@type')) as ref_type,
+    (value->>'@refObjectId')::uuid as ref_object_id,
+    value->>'@version' as ref_version
+  from walk
+  where jsonb_typeof(value) = 'object'
+    and value ? '@refObjectId'
+    and value ? '@version'
+    and value ? '@type'
+    and (value->>'@refObjectId') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    and nullif(value->>'@version', '') is not null
+    and public.cmd_review_ref_type_to_table(value->>'@type') is not null
+$$;
+
+create or replace function public.cmd_review_get_dataset_row(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_lock boolean default false
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_row jsonb;
+begin
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return null;
+  end if;
+
+  execute format(
+    'select to_jsonb(t) from public.%I as t where t.id = $1 and t.version = $2 %s',
+    p_table,
+    case when p_lock then 'for update of t' else '' end
+  )
+    into v_row
+    using p_id, p_version;
+
+  return v_row;
+end;
+$$;
+
+create or replace function public.cmd_review_get_dataset_name(
+  p_table text,
+  p_row jsonb
+) returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  select case p_table
+    when 'contacts' then coalesce(
+      p_row#>'{json,contactDataSet,contactInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,contactDataSet,contactInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    when 'sources' then coalesce(
+      p_row#>'{json,sourceDataSet,sourceInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,sourceDataSet,sourceInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    when 'unitgroups' then coalesce(
+      p_row#>'{json,unitGroupDataSet,unitGroupInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,unitGroupDataSet,unitGroupInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    when 'flowproperties' then coalesce(
+      p_row#>'{json,flowPropertyDataSet,flowPropertiesInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,flowPropertyDataSet,flowPropertiesInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    when 'flows' then coalesce(
+      p_row#>'{json,flowDataSet,flowInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,flowDataSet,flowInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    when 'processes' then coalesce(
+      p_row#>'{json,processDataSet,processInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,processDataSet,processInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    when 'lifecyclemodels' then coalesce(
+      p_row#>'{json,lifeCycleModelDataSet,lifeCycleModelInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,lifeCycleModelDataSet,lifeCycleModelInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    else '{}'::jsonb
+  end
+$$;
+
+create or replace function public.cmd_review_append_review_ref(
+  p_existing_reviews jsonb,
+  p_review_id uuid
+) returns jsonb
+language plpgsql
+immutable
+set search_path = public, pg_temp
+as $$
+declare
+  v_reviews jsonb := case
+    when jsonb_typeof(p_existing_reviews) = 'array' then p_existing_reviews
+    else '[]'::jsonb
+  end;
+begin
+  if exists (
+    select 1
+    from jsonb_array_elements(v_reviews) as review_item(value)
+    where review_item.value->>'id' = p_review_id::text
+  ) then
+    return v_reviews;
+  end if;
+
+  return v_reviews || jsonb_build_array(
+    jsonb_build_object(
+      'key', jsonb_array_length(v_reviews),
+      'id', p_review_id
+    )
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_submit(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_current record;
+  v_current_row jsonb;
+  v_current_state_code integer;
+  v_conflicting_version text;
+  v_conflicting_state integer;
+  v_root_row jsonb;
+  v_root_owner_id uuid;
+  v_review_id uuid := gen_random_uuid();
+  v_review_record public.reviews%rowtype;
+  v_review_json jsonb;
+  v_review_row jsonb;
+  v_team_name jsonb;
+  v_user_meta jsonb;
+  v_ref record;
+  v_ref_table text;
+  v_submodel jsonb;
+  v_paired_process_exists boolean;
+  v_paired_model_exists boolean;
+  v_affected_datasets jsonb := '[]'::jsonb;
+  v_updated_reviews jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table not in (
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table for review submission'
+    );
+  end if;
+
+  create temporary table if not exists cmd_review_submit_queue (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  create temporary table if not exists cmd_review_submit_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  truncate table cmd_review_submit_queue;
+  truncate table cmd_review_submit_targets;
+
+  insert into cmd_review_submit_queue (
+    table_name,
+    dataset_id,
+    dataset_version,
+    is_root
+  )
+  values (
+    p_table,
+    p_id,
+    p_version,
+    true
+  )
+  on conflict do nothing;
+
+  while exists (select 1 from cmd_review_submit_queue) loop
+    select
+      table_name,
+      dataset_id,
+      dataset_version,
+      is_root
+    into v_current
+    from cmd_review_submit_queue
+    order by is_root desc, table_name, dataset_id, dataset_version
+    limit 1;
+
+    delete from cmd_review_submit_queue
+    where table_name = v_current.table_name
+      and dataset_id = v_current.dataset_id
+      and dataset_version = v_current.dataset_version;
+
+    if exists (
+      select 1
+      from cmd_review_submit_targets
+      where table_name = v_current.table_name
+        and dataset_id = v_current.dataset_id
+        and dataset_version = v_current.dataset_version
+    ) then
+      continue;
+    end if;
+
+    v_current_row := public.cmd_review_get_dataset_row(
+      v_current.table_name,
+      v_current.dataset_id,
+      v_current.dataset_version,
+      true
+    );
+
+    if v_current_row is null then
+      if v_current.is_root then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'DATASET_NOT_FOUND',
+          'status', 404,
+          'message', 'Dataset not found'
+        );
+      end if;
+
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'REFERENCED_DATASET_NOT_FOUND',
+        'status', 409,
+        'message', 'Referenced dataset not found',
+        'details', jsonb_build_object(
+          'table', v_current.table_name,
+          'id', v_current.dataset_id,
+          'version', v_current.dataset_version
+        )
+      );
+    end if;
+
+    v_current_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+    if v_current.is_root then
+      v_root_row := v_current_row;
+      v_root_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+
+      if v_root_owner_id is distinct from v_actor then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'DATASET_OWNER_REQUIRED',
+          'status', 403,
+          'message', 'Only the dataset owner can submit review'
+        );
+      end if;
+
+      if v_current_state_code >= 100 then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'DATA_ALREADY_PUBLISHED',
+          'status', 403,
+          'message', 'Published data cannot be submitted for review',
+          'details', jsonb_build_object(
+            'state_code', v_current_state_code
+          )
+        );
+      end if;
+
+      if v_current_state_code >= 20 then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'DATA_UNDER_REVIEW',
+          'status', 403,
+          'message', 'Data is already under review',
+          'details', jsonb_build_object(
+            'state_code', 20,
+            'review_state_code', v_current_state_code
+          )
+        );
+      end if;
+    else
+      if v_current_state_code >= 20 and v_current_state_code < 100 then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'REFERENCED_DATA_UNDER_REVIEW',
+          'status', 409,
+          'message', 'Referenced data is already under review',
+          'details', jsonb_build_object(
+            'table', v_current.table_name,
+            'id', v_current.dataset_id,
+            'version', v_current.dataset_version,
+            'state_code', 20,
+            'review_state_code', v_current_state_code
+          )
+        );
+      end if;
+
+      if v_current_state_code >= 100 then
+        if v_current.table_name = 'processes' then
+          v_paired_model_exists := public.cmd_review_get_dataset_row(
+            'lifecyclemodels',
+            v_current.dataset_id,
+            v_current.dataset_version,
+            false
+          ) is not null;
+
+          if v_paired_model_exists then
+            insert into cmd_review_submit_queue (
+              table_name,
+              dataset_id,
+              dataset_version,
+              is_root
+            )
+            values (
+              'lifecyclemodels',
+              v_current.dataset_id,
+              v_current.dataset_version,
+              false
+            )
+            on conflict do nothing;
+          end if;
+        end if;
+
+        continue;
+      end if;
+    end if;
+
+    execute format(
+      'select version, state_code
+         from public.%I
+        where id = $1
+          and version <> $2
+          and state_code >= 20
+          and state_code < 100
+        order by version desc
+        limit 1',
+      v_current.table_name
+    )
+      into v_conflicting_version, v_conflicting_state
+      using v_current.dataset_id, v_current.dataset_version;
+
+    if v_conflicting_version is not null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', case
+          when v_current.is_root then 'DATASET_VERSION_UNDER_REVIEW'
+          else 'REFERENCED_VERSION_UNDER_REVIEW'
+        end,
+        'status', case
+          when v_current.is_root then 403
+          else 409
+        end,
+        'message', case
+          when v_current.is_root then 'Another version of this dataset is already under review'
+          else 'Another version of a referenced dataset is already under review'
+        end,
+        'details', jsonb_build_object(
+          'table', v_current.table_name,
+          'id', v_current.dataset_id,
+          'version', v_current.dataset_version,
+          'under_review_version', v_conflicting_version,
+          'state_code', 20,
+          'review_state_code', v_conflicting_state
+        )
+      );
+    end if;
+
+    execute format(
+      'select version
+         from public.%I
+        where id = $1
+          and version > $2
+          and state_code = 100
+        order by version desc
+        limit 1',
+      v_current.table_name
+    )
+      into v_conflicting_version
+      using v_current.dataset_id, v_current.dataset_version;
+
+    if v_conflicting_version is not null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', case
+          when v_current.is_root then 'DATASET_VERSION_ALREADY_PUBLISHED'
+          else 'REFERENCED_VERSION_ALREADY_PUBLISHED'
+        end,
+        'status', case
+          when v_current.is_root then 403
+          else 409
+        end,
+        'message', case
+          when v_current.is_root then 'A newer published version of this dataset already exists'
+          else 'A newer published version of a referenced dataset already exists'
+        end,
+        'details', jsonb_build_object(
+          'table', v_current.table_name,
+          'id', v_current.dataset_id,
+          'version', v_current.dataset_version,
+          'published_version', v_conflicting_version,
+          'state_code', 100
+        )
+      );
+    end if;
+
+    insert into cmd_review_submit_targets (
+      table_name,
+      dataset_id,
+      dataset_version,
+      state_code,
+      reviews
+    )
+    values (
+      v_current.table_name,
+      v_current.dataset_id,
+      v_current.dataset_version,
+      v_current_state_code,
+      v_current_row->'reviews'
+    )
+    on conflict do nothing;
+
+    for v_ref in (
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json_ordered', '{}'::jsonb))
+      union
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json', '{}'::jsonb))
+      union
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json_tg', '{}'::jsonb))
+    ) loop
+      v_ref_table := public.cmd_review_ref_type_to_table(v_ref.ref_type);
+
+      if v_ref_table is null then
+        continue;
+      end if;
+
+      if v_ref_table = v_current.table_name
+        and v_ref.ref_object_id = v_current.dataset_id
+        and v_ref.ref_version = v_current.dataset_version then
+        continue;
+      end if;
+
+      insert into cmd_review_submit_queue (
+        table_name,
+        dataset_id,
+        dataset_version,
+        is_root
+      )
+      values (
+        v_ref_table,
+        v_ref.ref_object_id,
+        v_ref.ref_version,
+        false
+      )
+      on conflict do nothing;
+    end loop;
+
+    if v_current.table_name = 'processes' and not v_current.is_root then
+      v_paired_model_exists := public.cmd_review_get_dataset_row(
+        'lifecyclemodels',
+        v_current.dataset_id,
+        v_current.dataset_version,
+        false
+      ) is not null;
+
+      if v_paired_model_exists then
+        insert into cmd_review_submit_queue (
+          table_name,
+          dataset_id,
+          dataset_version,
+          is_root
+        )
+        values (
+          'lifecyclemodels',
+          v_current.dataset_id,
+          v_current.dataset_version,
+          false
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+
+    if v_current.table_name = 'lifecyclemodels' then
+      if v_current.is_root then
+        v_paired_process_exists := public.cmd_review_get_dataset_row(
+          'processes',
+          v_current.dataset_id,
+          v_current.dataset_version,
+          false
+        ) is not null;
+
+        if v_paired_process_exists then
+          insert into cmd_review_submit_queue (
+            table_name,
+            dataset_id,
+            dataset_version,
+            is_root
+          )
+          values (
+            'processes',
+            v_current.dataset_id,
+            v_current.dataset_version,
+            false
+          )
+          on conflict do nothing;
+        end if;
+      end if;
+
+      for v_submodel in
+        select value
+        from jsonb_array_elements(coalesce(v_current_row->'json_tg'->'submodels', '[]'::jsonb))
+      loop
+        if coalesce(v_submodel->>'type', '') <> 'secondary' then
+          continue;
+        end if;
+
+        if not ((v_submodel->>'id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') then
+          continue;
+        end if;
+
+        insert into cmd_review_submit_queue (
+          table_name,
+          dataset_id,
+          dataset_version,
+          is_root
+        )
+        values (
+          'processes',
+          (v_submodel->>'id')::uuid,
+          coalesce(nullif(v_submodel->>'version', ''), v_current.dataset_version),
+          false
+        )
+        on conflict do nothing;
+      end loop;
+    end if;
+  end loop;
+
+  select coalesce(t.json->'title', t.json->'name')
+    into v_team_name
+  from public.teams as t
+  where t.id = nullif(v_root_row->>'team_id', '')::uuid;
+
+  select u.raw_user_meta_data
+    into v_user_meta
+  from public.users as u
+  where u.id = v_actor;
+
+  v_review_json := jsonb_build_object(
+    'data', jsonb_build_object(
+      'id', p_id,
+      'version', p_version,
+      'name', public.cmd_review_get_dataset_name(p_table, v_root_row)
+    ),
+    'team', jsonb_build_object(
+      'id', nullif(v_root_row->>'team_id', ''),
+      'name', v_team_name
+    ),
+    'user', jsonb_build_object(
+      'id', v_actor,
+      'name', coalesce(nullif(v_user_meta->>'display_name', ''), nullif(v_user_meta->>'email', '')),
+      'email', nullif(v_user_meta->>'email', '')
+    ),
+    'comment', jsonb_build_object(
+      'message', ''
+    ),
+    'logs', jsonb_build_array(
+      jsonb_build_object(
+        'action', 'submit_review',
+        'time', to_jsonb(now()),
+        'user', jsonb_build_object(
+          'id', v_actor,
+          'display_name', coalesce(nullif(v_user_meta->>'display_name', ''), nullif(v_user_meta->>'email', ''))
+        )
+      )
+    )
+  );
+
+  insert into public.reviews (
+    id,
+    data_id,
+    data_version,
+    state_code,
+    reviewer_id,
+    json
+  )
+  values (
+    v_review_id,
+    p_id,
+    p_version,
+    0,
+    '[]'::jsonb,
+    v_review_json
+  )
+  returning *
+    into v_review_record;
+
+  for v_current in
+    select
+      table_name,
+      dataset_id,
+      dataset_version,
+      reviews
+    from cmd_review_submit_targets
+    order by table_name, dataset_id, dataset_version
+  loop
+    v_updated_reviews := public.cmd_review_append_review_ref(v_current.reviews, v_review_id);
+
+    execute format(
+      'update public.%I
+          set state_code = 20,
+              reviews = $1
+        where id = $2
+          and version = $3',
+      v_current.table_name
+    )
+      using v_updated_reviews, v_current.dataset_id, v_current.dataset_version;
+  end loop;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'table', table_name,
+        'id', dataset_id,
+        'version', dataset_version,
+        'state_code', 20
+      )
+      order by table_name, dataset_id, dataset_version
+    ),
+    '[]'::jsonb
+  )
+    into v_affected_datasets
+  from cmd_review_submit_targets;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_review_submit',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'review_id', v_review_id,
+      'affected_datasets', v_affected_datasets
+    )
+  );
+
+  v_review_row := to_jsonb(v_review_record);
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', v_review_row,
+      'affected_datasets', v_affected_datasets
+    )
+  );
+end;
+$$;
+
+revoke all on function public.cmd_review_ref_type_to_table(text) from public;
+revoke all on function public.cmd_review_extract_refs(jsonb) from public;
+revoke all on function public.cmd_review_get_dataset_row(text, uuid, text, boolean) from public;
+revoke all on function public.cmd_review_get_dataset_name(text, jsonb) from public;
+revoke all on function public.cmd_review_append_review_ref(jsonb, uuid) from public;
+revoke all on function public.cmd_review_submit(text, uuid, text, jsonb) from public;
+
+grant execute on function public.cmd_review_submit(text, uuid, text, jsonb) to authenticated;
+grant execute on function public.cmd_review_submit(text, uuid, text, jsonb) to service_role;

--- a/supabase/migrations/20260405103000_access_control_add_review_workflow_rpcs.sql
+++ b/supabase/migrations/20260405103000_access_control_add_review_workflow_rpcs.sql
@@ -1,0 +1,2238 @@
+create or replace function public.cmd_review_json_array(p_value jsonb)
+returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  select case jsonb_typeof(p_value)
+    when 'array' then coalesce(p_value, '[]'::jsonb)
+    when 'object' then jsonb_build_array(p_value)
+    when 'string' then jsonb_build_array(p_value)
+    when 'number' then jsonb_build_array(p_value)
+    when 'boolean' then jsonb_build_array(p_value)
+    else '[]'::jsonb
+  end
+$$;
+
+create or replace function public.cmd_review_merge_json_collection(
+  p_existing jsonb,
+  p_additions jsonb
+)
+returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  select public.cmd_review_json_array(p_existing) || public.cmd_review_json_array(p_additions)
+$$;
+
+create or replace function public.cmd_review_apply_model_validation_to_process_json(
+  p_process_json jsonb,
+  p_model_json jsonb,
+  p_comment_review jsonb default '[]'::jsonb,
+  p_comment_compliance jsonb default '[]'::jsonb
+)
+returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  with base as (
+    select
+      coalesce(p_process_json, '{}'::jsonb) as process_json,
+      coalesce(p_model_json, '{}'::jsonb) as model_json
+  )
+  select jsonb_set(
+    jsonb_set(
+      base.process_json,
+      '{processDataSet,modellingAndValidation,validation,review}',
+      public.cmd_review_merge_json_collection(
+        base.model_json #> '{lifeCycleModelDataSet,modellingAndValidation,validation,review}',
+        p_comment_review
+      ),
+      true
+    ),
+    '{processDataSet,modellingAndValidation,complianceDeclarations,compliance}',
+    public.cmd_review_merge_json_collection(
+      base.model_json #> '{lifeCycleModelDataSet,modellingAndValidation,complianceDeclarations,compliance}',
+      p_comment_compliance
+    ),
+    true
+  )
+  from base
+$$;
+
+create or replace function public.cmd_review_normalize_reviewer_ids(p_reviewer_ids jsonb)
+returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  with normalized as (
+    select
+      value,
+      min(ordinality) as ordinality
+    from jsonb_array_elements_text(
+      case
+        when jsonb_typeof(p_reviewer_ids) = 'array' then p_reviewer_ids
+        else '[]'::jsonb
+      end
+    ) with ordinality as reviewer_ids(value, ordinality)
+    where value ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    group by value
+  )
+  select coalesce(
+    jsonb_agg(to_jsonb(value) order by ordinality),
+    '[]'::jsonb
+  )
+  from normalized
+$$;
+
+create or replace function public.cmd_review_is_review_admin(p_actor uuid default auth.uid())
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.roles
+    where user_id = coalesce(p_actor, auth.uid())
+      and role = 'review-admin'
+  )
+$$;
+
+create or replace function public.cmd_review_get_actor_meta(p_actor uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_meta jsonb;
+  v_display_name text;
+  v_email text;
+begin
+  select u.raw_user_meta_data
+    into v_meta
+  from public.users as u
+  where u.id = p_actor;
+
+  v_display_name := coalesce(nullif(v_meta->>'display_name', ''), nullif(v_meta->>'email', ''));
+  v_email := nullif(v_meta->>'email', '');
+
+  return jsonb_strip_nulls(
+    jsonb_build_object(
+      'id', p_actor,
+      'display_name', v_display_name,
+      'email', v_email
+    )
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_append_log(
+  p_review_json jsonb,
+  p_action text,
+  p_actor uuid,
+  p_extra jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_review_json jsonb := coalesce(p_review_json, '{}'::jsonb);
+  v_logs jsonb := public.cmd_review_json_array(v_review_json->'logs');
+  v_actor_meta jsonb := public.cmd_review_get_actor_meta(p_actor);
+  v_log_entry jsonb;
+begin
+  v_log_entry := jsonb_build_object(
+    'action', p_action,
+    'time', to_jsonb(now()),
+    'user', v_actor_meta
+  ) || coalesce(p_extra, '{}'::jsonb);
+
+  return jsonb_set(
+    v_review_json,
+    '{logs}',
+    v_logs || jsonb_build_array(v_log_entry),
+    true
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_get_root_table(
+  p_review_json jsonb,
+  p_data_id uuid,
+  p_data_version text
+)
+returns text
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_explicit text := lower(nullif(p_review_json#>>'{data,table}', ''));
+  v_process_row jsonb;
+  v_model_row jsonb;
+  v_expected_name jsonb := coalesce(p_review_json#>'{data,name}', '{}'::jsonb);
+begin
+  if v_explicit in ('processes', 'lifecyclemodels') then
+    return v_explicit;
+  end if;
+
+  v_process_row := public.cmd_review_get_dataset_row('processes', p_data_id, p_data_version, false);
+  v_model_row := public.cmd_review_get_dataset_row(
+    'lifecyclemodels',
+    p_data_id,
+    p_data_version,
+    false
+  );
+
+  if v_model_row is not null
+     and public.cmd_review_get_dataset_name('lifecyclemodels', v_model_row) = v_expected_name then
+    return 'lifecyclemodels';
+  end if;
+
+  if v_process_row is not null
+     and public.cmd_review_get_dataset_name('processes', v_process_row) = v_expected_name then
+    return 'processes';
+  end if;
+
+  if v_model_row is not null and v_process_row is null then
+    return 'lifecyclemodels';
+  end if;
+
+  if v_process_row is not null then
+    return 'processes';
+  end if;
+
+  return null;
+end;
+$$;
+
+create or replace function public.cmd_review_collect_dataset_targets(
+  p_roots jsonb,
+  p_lock boolean default false
+)
+returns table (
+  table_name text,
+  dataset_id uuid,
+  dataset_version text,
+  state_code integer,
+  reviews jsonb,
+  dataset_row jsonb,
+  is_root boolean
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_root jsonb;
+  v_current record;
+  v_current_row jsonb;
+  v_current_state_code integer;
+  v_ref record;
+  v_ref_table text;
+  v_submodel jsonb;
+  v_paired_model_exists boolean;
+  v_paired_process_exists boolean;
+begin
+  create temporary table if not exists cmd_review_collect_queue (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  create temporary table if not exists cmd_review_collect_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    dataset_row jsonb not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  truncate table cmd_review_collect_queue;
+  truncate table cmd_review_collect_targets;
+
+  if jsonb_typeof(p_roots) <> 'array' then
+    return;
+  end if;
+
+  for v_root in
+    select value
+    from jsonb_array_elements(p_roots)
+  loop
+    if lower(coalesce(v_root->>'table', '')) not in (
+      'contacts',
+      'sources',
+      'unitgroups',
+      'flowproperties',
+      'flows',
+      'processes',
+      'lifecyclemodels'
+    ) then
+      continue;
+    end if;
+
+    if not (coalesce(v_root->>'id', '') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') then
+      continue;
+    end if;
+
+    if nullif(v_root->>'version', '') is null then
+      continue;
+    end if;
+
+    insert into cmd_review_collect_queue (
+      table_name,
+      dataset_id,
+      dataset_version,
+      is_root
+    )
+    values (
+      lower(v_root->>'table'),
+      (v_root->>'id')::uuid,
+      v_root->>'version',
+      coalesce((v_root->>'is_root')::boolean, false)
+    )
+    on conflict do nothing;
+  end loop;
+
+  while exists (select 1 from cmd_review_collect_queue) loop
+    select
+      q.table_name,
+      q.dataset_id,
+      q.dataset_version,
+      q.is_root
+    into v_current
+    from cmd_review_collect_queue as q
+    order by q.is_root desc, q.table_name, q.dataset_id, q.dataset_version
+    limit 1;
+
+    delete from cmd_review_collect_queue as q
+    where q.table_name = v_current.table_name
+      and q.dataset_id = v_current.dataset_id
+      and q.dataset_version = v_current.dataset_version;
+
+    if exists (
+      select 1
+      from cmd_review_collect_targets as t
+      where t.table_name = v_current.table_name
+        and t.dataset_id = v_current.dataset_id
+        and t.dataset_version = v_current.dataset_version
+    ) then
+      continue;
+    end if;
+
+    v_current_row := public.cmd_review_get_dataset_row(
+      v_current.table_name,
+      v_current.dataset_id,
+      v_current.dataset_version,
+      p_lock
+    );
+
+    if v_current_row is null then
+      continue;
+    end if;
+
+    v_current_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+    insert into cmd_review_collect_targets (
+      table_name,
+      dataset_id,
+      dataset_version,
+      state_code,
+      reviews,
+      dataset_row,
+      is_root
+    )
+    values (
+      v_current.table_name,
+      v_current.dataset_id,
+      v_current.dataset_version,
+      v_current_state_code,
+      v_current_row->'reviews',
+      v_current_row,
+      v_current.is_root
+    )
+    on conflict do nothing;
+
+    if v_current_state_code >= 100 and not v_current.is_root then
+      if v_current.table_name = 'processes' then
+        v_paired_model_exists := public.cmd_review_get_dataset_row(
+          'lifecyclemodels',
+          v_current.dataset_id,
+          v_current.dataset_version,
+          false
+        ) is not null;
+
+        if v_paired_model_exists then
+          insert into cmd_review_collect_queue (
+            table_name,
+            dataset_id,
+            dataset_version,
+            is_root
+          )
+          values (
+            'lifecyclemodels',
+            v_current.dataset_id,
+            v_current.dataset_version,
+            false
+          )
+          on conflict do nothing;
+        end if;
+      end if;
+
+      continue;
+    end if;
+
+    for v_ref in (
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json_ordered', '{}'::jsonb))
+      union
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json', '{}'::jsonb))
+      union
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json_tg', '{}'::jsonb))
+    ) loop
+      v_ref_table := public.cmd_review_ref_type_to_table(v_ref.ref_type);
+
+      if v_ref_table is null then
+        continue;
+      end if;
+
+      if v_ref_table = v_current.table_name
+         and v_ref.ref_object_id = v_current.dataset_id
+         and v_ref.ref_version = v_current.dataset_version then
+        continue;
+      end if;
+
+      insert into cmd_review_collect_queue (
+        table_name,
+        dataset_id,
+        dataset_version,
+        is_root
+      )
+      values (
+        v_ref_table,
+        v_ref.ref_object_id,
+        v_ref.ref_version,
+        false
+      )
+      on conflict do nothing;
+    end loop;
+
+    if v_current.table_name = 'processes' and not v_current.is_root then
+      v_paired_model_exists := public.cmd_review_get_dataset_row(
+        'lifecyclemodels',
+        v_current.dataset_id,
+        v_current.dataset_version,
+        false
+      ) is not null;
+
+      if v_paired_model_exists then
+        insert into cmd_review_collect_queue (
+          table_name,
+          dataset_id,
+          dataset_version,
+          is_root
+        )
+        values (
+          'lifecyclemodels',
+          v_current.dataset_id,
+          v_current.dataset_version,
+          false
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+
+    if v_current.table_name = 'lifecyclemodels' then
+      if v_current.is_root then
+        v_paired_process_exists := public.cmd_review_get_dataset_row(
+          'processes',
+          v_current.dataset_id,
+          v_current.dataset_version,
+          false
+        ) is not null;
+
+        if v_paired_process_exists then
+          insert into cmd_review_collect_queue (
+            table_name,
+            dataset_id,
+            dataset_version,
+            is_root
+          )
+          values (
+            'processes',
+            v_current.dataset_id,
+            v_current.dataset_version,
+            false
+          )
+          on conflict do nothing;
+        end if;
+      end if;
+
+      for v_submodel in
+        select value
+        from jsonb_array_elements(coalesce(v_current_row->'json_tg'->'submodels', '[]'::jsonb))
+      loop
+        if lower(coalesce(v_submodel->>'type', '')) <> 'secondary' then
+          continue;
+        end if;
+
+        if not ((v_submodel->>'id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') then
+          continue;
+        end if;
+
+        insert into cmd_review_collect_queue (
+          table_name,
+          dataset_id,
+          dataset_version,
+          is_root
+        )
+        values (
+          'processes',
+          (v_submodel->>'id')::uuid,
+          coalesce(nullif(v_submodel->>'version', ''), v_current.dataset_version),
+          false
+        )
+        on conflict do nothing;
+      end loop;
+    end if;
+  end loop;
+
+  return query
+  select
+    t.table_name,
+    t.dataset_id,
+    t.dataset_version,
+    t.state_code,
+    t.reviews,
+    t.dataset_row,
+    t.is_root
+  from cmd_review_collect_targets as t
+  order by t.is_root desc, t.table_name, t.dataset_id, t.dataset_version;
+end;
+$$;
+
+create or replace function public.cmd_review_apply_mv_payload(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_review_items jsonb default '[]'::jsonb,
+  p_compliance_items jsonb default '[]'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_row jsonb;
+  v_doc jsonb;
+  v_review_path text[];
+  v_compliance_path text[];
+  v_review_items jsonb := coalesce(p_review_items, '[]'::jsonb);
+  v_compliance_items jsonb := coalesce(p_compliance_items, '[]'::jsonb);
+begin
+  if p_table not in ('processes', 'lifecyclemodels') then
+    return public.cmd_review_get_dataset_row(p_table, p_id, p_version, false);
+  end if;
+
+  v_row := public.cmd_review_get_dataset_row(p_table, p_id, p_version, true);
+
+  if v_row is null then
+    return null;
+  end if;
+
+  if p_table = 'processes' then
+    v_review_path := array['processDataSet', 'modellingAndValidation', 'validation', 'review'];
+    v_compliance_path := array[
+      'processDataSet',
+      'modellingAndValidation',
+      'complianceDeclarations',
+      'compliance'
+    ];
+  else
+    v_review_path := array[
+      'lifeCycleModelDataSet',
+      'modellingAndValidation',
+      'validation',
+      'review'
+    ];
+    v_compliance_path := array[
+      'lifeCycleModelDataSet',
+      'modellingAndValidation',
+      'complianceDeclarations',
+      'compliance'
+    ];
+  end if;
+
+  v_doc := coalesce(v_row->'json_ordered', v_row->'json', '{}'::jsonb);
+
+  if jsonb_array_length(v_review_items) > 0 then
+    v_doc := jsonb_set(
+      v_doc,
+      v_review_path,
+      public.cmd_review_json_array(v_doc #> v_review_path) || v_review_items,
+      true
+    );
+  end if;
+
+  if jsonb_array_length(v_compliance_items) > 0 then
+    v_doc := jsonb_set(
+      v_doc,
+      v_compliance_path,
+      public.cmd_review_json_array(v_doc #> v_compliance_path) || v_compliance_items,
+      true
+    );
+  end if;
+
+  execute format(
+    'update public.%I
+        set json_ordered = $1::json,
+            json = $1::jsonb,
+            modified_at = now()
+      where id = $2
+        and version = $3',
+    p_table
+  )
+    using v_doc, p_id, p_version;
+
+  return public.cmd_review_get_dataset_row(p_table, p_id, p_version, false);
+end;
+$$;
+
+create or replace function public.cmd_review_save_assignment_draft(
+  p_review_id uuid,
+  p_reviewer_ids jsonb,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_reviewer_ids jsonb;
+  v_review_json jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ADMIN_REQUIRED',
+      'status', 403,
+      'message', 'Only review admins can manage reviewer assignments'
+    );
+  end if;
+
+  if coalesce(jsonb_typeof(p_reviewer_ids), 'null') not in ('null', 'array') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEWER_IDS',
+      'status', 400,
+      'message', 'reviewerIds must be an array of UUID strings'
+    );
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_array_elements_text(coalesce(p_reviewer_ids, '[]'::jsonb)) as reviewer_ids(value)
+    where reviewer_ids.value !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEWER_IDS',
+      'status', 400,
+      'message', 'reviewerIds must contain valid UUID strings only'
+    );
+  end if;
+
+  v_reviewer_ids := public.cmd_review_normalize_reviewer_ids(coalesce(p_reviewer_ids, '[]'::jsonb));
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code not in (-1, 0, 1) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Reviewer assignments can only be changed for unassigned or active reviews',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  v_review_json := public.cmd_review_append_log(
+    coalesce(v_review.json, '{}'::jsonb),
+    'assign_reviewers_temporary',
+    v_actor,
+    jsonb_build_object(
+      'reviewer_ids', v_reviewer_ids
+    )
+  );
+
+  update public.reviews
+    set reviewer_id = v_reviewer_ids,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_save_assignment_draft',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'reviewer_ids', v_reviewer_ids
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review)
+    )
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_assign_reviewers(
+  p_review_id uuid,
+  p_reviewer_ids jsonb,
+  p_deadline timestamptz default null,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_reviewer_ids jsonb;
+  v_review_json jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ADMIN_REQUIRED',
+      'status', 403,
+      'message', 'Only review admins can assign reviewers'
+    );
+  end if;
+
+  if coalesce(jsonb_typeof(p_reviewer_ids), 'null') <> 'array' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEWER_IDS',
+      'status', 400,
+      'message', 'reviewerIds must be an array of UUID strings'
+    );
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_array_elements_text(p_reviewer_ids) as reviewer_ids(value)
+    where reviewer_ids.value !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEWER_IDS',
+      'status', 400,
+      'message', 'reviewerIds must contain valid UUID strings only'
+    );
+  end if;
+
+  v_reviewer_ids := public.cmd_review_normalize_reviewer_ids(p_reviewer_ids);
+
+  if jsonb_array_length(v_reviewer_ids) = 0 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_REQUIRED',
+      'status', 400,
+      'message', 'At least one reviewer is required'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code not in (-1, 0, 1) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Reviewers can only be assigned for pending or rejected reviews',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  create temporary table if not exists cmd_review_assignment_active_reviewers (
+    reviewer_id uuid primary key
+  ) on commit drop;
+
+  truncate table cmd_review_assignment_active_reviewers;
+
+  insert into cmd_review_assignment_active_reviewers (reviewer_id)
+  select value::uuid
+  from jsonb_array_elements_text(v_reviewer_ids) as reviewer_ids(value);
+
+  update public.comments
+    set state_code = -2,
+        modified_at = now()
+  where review_id = p_review_id
+    and reviewer_id not in (
+      select reviewer_id
+      from cmd_review_assignment_active_reviewers
+    )
+    and state_code = 0;
+
+  insert into public.comments (
+    review_id,
+    reviewer_id,
+    state_code
+  )
+  select
+    p_review_id,
+    reviewer_id,
+    0
+  from cmd_review_assignment_active_reviewers
+  on conflict (review_id, reviewer_id) do update
+    set state_code = case
+      when public.comments.state_code in (-2, -1) then 0
+      else public.comments.state_code
+    end,
+        modified_at = now();
+
+  v_review_json := public.cmd_review_append_log(
+    coalesce(v_review.json, '{}'::jsonb),
+    'assign_reviewers',
+    v_actor,
+    jsonb_strip_nulls(
+      jsonb_build_object(
+        'reviewer_ids', v_reviewer_ids,
+        'deadline', case
+          when p_deadline is null then null
+          else to_jsonb(p_deadline)
+        end
+      )
+    )
+  );
+
+  update public.reviews
+    set reviewer_id = v_reviewer_ids,
+        state_code = 1,
+        deadline = p_deadline,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_assign_reviewers',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_strip_nulls(
+      jsonb_build_object(
+        'reviewer_ids', v_reviewer_ids,
+        'deadline', case
+          when p_deadline is null then null
+          else to_jsonb(p_deadline)
+        end
+      )
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review)
+    )
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_revoke_reviewer(
+  p_review_id uuid,
+  p_reviewer_id uuid,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_comment public.comments%rowtype;
+  v_remaining_reviewer_ids jsonb;
+  v_review_json jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ADMIN_REQUIRED',
+      'status', 403,
+      'message', 'Only review admins can revoke reviewers'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code <> 1 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Reviewers can only be revoked from assigned reviews',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  if not public.cmd_review_json_array(v_review.reviewer_id) @> jsonb_build_array(to_jsonb(p_reviewer_id::text)) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_NOT_ASSIGNED',
+      'status', 409,
+      'message', 'Reviewer is not currently assigned to this review'
+    );
+  end if;
+
+  select *
+    into v_comment
+  from public.comments
+  where review_id = p_review_id
+    and reviewer_id = p_reviewer_id
+  for update;
+
+  if found and v_comment.state_code <> 0 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_ALREADY_RESPONDED',
+      'status', 409,
+      'message', 'Only pending reviewers can be revoked',
+      'details', jsonb_build_object(
+        'comment_state_code', v_comment.state_code
+      )
+    );
+  end if;
+
+  select coalesce(
+    jsonb_agg(to_jsonb(value) order by ordinality),
+    '[]'::jsonb
+  )
+    into v_remaining_reviewer_ids
+  from jsonb_array_elements_text(public.cmd_review_json_array(v_review.reviewer_id))
+       with ordinality as reviewer_ids(value, ordinality)
+  where reviewer_ids.value <> p_reviewer_id::text;
+
+  v_review_json := public.cmd_review_append_log(
+    coalesce(v_review.json, '{}'::jsonb),
+    'revoke_reviewer',
+    v_actor,
+    jsonb_build_object(
+      'reviewer_id', p_reviewer_id
+    )
+  );
+
+  update public.reviews
+    set reviewer_id = v_remaining_reviewer_ids,
+        state_code = case
+          when jsonb_array_length(v_remaining_reviewer_ids) = 0 then 0
+          else 1
+        end,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  update public.comments
+    set state_code = -2,
+        modified_at = now()
+  where review_id = p_review_id
+    and reviewer_id = p_reviewer_id;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_revoke_reviewer',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'reviewer_id', p_reviewer_id,
+      'remaining_reviewer_ids', v_remaining_reviewer_ids
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review)
+    )
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_save_comment_draft(
+  p_review_id uuid,
+  p_json jsonb,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_comment public.comments%rowtype;
+  v_comment_json jsonb := coalesce(p_json, '{}'::jsonb);
+  v_review_json jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if coalesce(jsonb_typeof(v_comment_json), 'null') <> 'object' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_COMMENT_JSON',
+      'status', 400,
+      'message', 'comment json must be an object'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code not in (-1, 1) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Review comments can only be edited for assigned or rejected reviews',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  if not public.cmd_review_json_array(v_review.reviewer_id) @> jsonb_build_array(to_jsonb(v_actor::text)) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_REQUIRED',
+      'status', 403,
+      'message', 'Only assigned reviewers can edit review comments'
+    );
+  end if;
+
+  select *
+    into v_comment
+  from public.comments
+  where review_id = p_review_id
+    and reviewer_id = v_actor
+  for update;
+
+  if found and v_comment.state_code in (-2, 2) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_COMMENT_STATE',
+      'status', 409,
+      'message', 'This reviewer comment can no longer be edited',
+      'details', jsonb_build_object(
+        'state_code', v_comment.state_code
+      )
+    );
+  end if;
+
+  if not found then
+    insert into public.comments (
+      review_id,
+      reviewer_id,
+      json,
+      state_code
+    )
+    values (
+      p_review_id,
+      v_actor,
+      v_comment_json::json,
+      case
+        when v_review.state_code = -1 then -1
+        else 0
+      end
+    )
+    returning *
+      into v_comment;
+  else
+    update public.comments
+      set json = v_comment_json::json,
+          modified_at = now()
+    where review_id = p_review_id
+      and reviewer_id = v_actor
+    returning *
+      into v_comment;
+  end if;
+
+  v_review_json := public.cmd_review_append_log(
+    coalesce(v_review.json, '{}'::jsonb),
+    'submit_comments_temporary',
+    v_actor,
+    jsonb_build_object(
+      'reviewer_id', v_actor
+    )
+  );
+
+  update public.reviews
+    set json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_save_comment_draft',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'reviewer_id', v_actor,
+      'comment_state_code', v_comment.state_code
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'comment', to_jsonb(v_comment)
+    )
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_submit_comment(
+  p_review_id uuid,
+  p_json jsonb,
+  p_comment_state integer default 1,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_comment public.comments%rowtype;
+  v_comment_json jsonb := coalesce(p_json, '{}'::jsonb);
+  v_review_json jsonb;
+  v_ref record;
+  v_ref_table text;
+  v_ref_roots jsonb := '[]'::jsonb;
+  v_target record;
+  v_affected_datasets jsonb := '[]'::jsonb;
+  v_action text;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_comment_state not in (-3, 1) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_COMMENT_STATE',
+      'status', 400,
+      'message', 'commentState must be 1 or -3'
+    );
+  end if;
+
+  if coalesce(jsonb_typeof(v_comment_json), 'null') <> 'object' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_COMMENT_JSON',
+      'status', 400,
+      'message', 'comment json must be an object'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code not in (-1, 1) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Review comments can only be submitted for assigned or rejected reviews',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  if not public.cmd_review_json_array(v_review.reviewer_id) @> jsonb_build_array(to_jsonb(v_actor::text)) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_REQUIRED',
+      'status', 403,
+      'message', 'Only assigned reviewers can submit review comments'
+    );
+  end if;
+
+  select *
+    into v_comment
+  from public.comments
+  where review_id = p_review_id
+    and reviewer_id = v_actor
+  for update;
+
+  if found and v_comment.state_code in (-2, 2) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_COMMENT_STATE',
+      'status', 409,
+      'message', 'This reviewer comment can no longer be submitted',
+      'details', jsonb_build_object(
+        'state_code', v_comment.state_code
+      )
+    );
+  end if;
+
+  if not found then
+    insert into public.comments (
+      review_id,
+      reviewer_id,
+      state_code
+    )
+    values (
+      p_review_id,
+      v_actor,
+      case
+        when v_review.state_code = -1 then -1
+        else 0
+      end
+    )
+    returning *
+      into v_comment;
+  end if;
+
+  if p_comment_state = 1 then
+    for v_ref in
+      select *
+      from public.cmd_review_extract_refs(v_comment_json)
+    loop
+      v_ref_table := public.cmd_review_ref_type_to_table(v_ref.ref_type);
+
+      if v_ref_table is null then
+        continue;
+      end if;
+
+      v_ref_roots := v_ref_roots || jsonb_build_array(
+        jsonb_build_object(
+          'table', v_ref_table,
+          'id', v_ref.ref_object_id,
+          'version', v_ref.ref_version,
+          'is_root', false
+        )
+      );
+    end loop;
+
+    create temporary table if not exists cmd_review_submit_comment_targets (
+      table_name text not null,
+      dataset_id uuid not null,
+      dataset_version text not null,
+      state_code integer not null,
+      reviews jsonb,
+      dataset_row jsonb not null,
+      is_root boolean not null default false,
+      primary key (table_name, dataset_id, dataset_version)
+    ) on commit drop;
+
+    truncate table cmd_review_submit_comment_targets;
+
+    insert into cmd_review_submit_comment_targets (
+      table_name,
+      dataset_id,
+      dataset_version,
+      state_code,
+      reviews,
+      dataset_row,
+      is_root
+    )
+    select
+      table_name,
+      dataset_id,
+      dataset_version,
+      state_code,
+      reviews,
+      dataset_row,
+      is_root
+    from public.cmd_review_collect_dataset_targets(v_ref_roots, true);
+
+    for v_target in
+      select *
+      from cmd_review_submit_comment_targets
+      where state_code >= 20
+        and state_code < 100
+      order by table_name, dataset_id, dataset_version
+    loop
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'REFERENCED_DATA_UNDER_REVIEW',
+        'status', 409,
+        'message', 'Referenced data is already under review',
+        'details', jsonb_build_object(
+          'table', v_target.table_name,
+          'id', v_target.dataset_id,
+          'version', v_target.dataset_version,
+          'state_code', 20,
+          'review_state_code', v_target.state_code
+        )
+      );
+    end loop;
+
+    for v_target in
+      select *
+      from cmd_review_submit_comment_targets
+      where state_code < 20
+      order by table_name, dataset_id, dataset_version
+    loop
+      execute format(
+        'update public.%I
+            set state_code = 20,
+                reviews = $1,
+                modified_at = now()
+          where id = $2
+            and version = $3',
+        v_target.table_name
+      )
+        using public.cmd_review_append_review_ref(v_target.reviews, p_review_id),
+              v_target.dataset_id,
+              v_target.dataset_version;
+    end loop;
+
+    select coalesce(
+      jsonb_agg(
+        jsonb_build_object(
+          'table', table_name,
+          'id', dataset_id,
+          'version', dataset_version,
+          'state_code', 20
+        )
+        order by table_name, dataset_id, dataset_version
+      ),
+      '[]'::jsonb
+    )
+      into v_affected_datasets
+    from cmd_review_submit_comment_targets
+    where state_code < 20;
+  end if;
+
+  update public.comments
+    set json = v_comment_json::json,
+        state_code = p_comment_state,
+        modified_at = now()
+  where review_id = p_review_id
+    and reviewer_id = v_actor
+  returning *
+    into v_comment;
+
+  v_action := case
+    when p_comment_state = -3 then 'reviewer_rejected'
+    else 'submit_comments'
+  end;
+
+  v_review_json := public.cmd_review_append_log(
+    coalesce(v_review.json, '{}'::jsonb),
+    v_action,
+    v_actor,
+    jsonb_build_object(
+      'reviewer_id', v_actor,
+      'comment_state_code', p_comment_state
+    )
+  );
+
+  update public.reviews
+    set state_code = case
+          when p_comment_state = 1 and state_code = -1 then 1
+          else state_code
+        end,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_submit_comment',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'reviewer_id', v_actor,
+      'comment_state_code', p_comment_state,
+      'affected_datasets', v_affected_datasets
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'comment', to_jsonb(v_comment),
+      'affected_datasets', v_affected_datasets
+    )
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_submit_comment(
+  p_review_id uuid,
+  p_json jsonb,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language sql
+security definer
+set search_path = public, pg_temp
+as $$
+  select public.cmd_review_submit_comment(
+    p_review_id,
+    p_json,
+    1,
+    p_audit
+  )
+$$;
+
+create or replace function public.cmd_review_approve(
+  p_table text,
+  p_review_id uuid,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_root_table text;
+  v_root_targets jsonb;
+  v_comment_ref_roots jsonb := '[]'::jsonb;
+  v_target record;
+  v_comment_ref record;
+  v_review_items jsonb := '[]'::jsonb;
+  v_compliance_items jsonb := '[]'::jsonb;
+  v_root_row jsonb;
+  v_updated_root_row jsonb;
+  v_submodel_ids uuid[] := array[]::uuid[];
+  v_submodel_id uuid;
+  v_submodel_doc jsonb;
+  v_affected_datasets jsonb := '[]'::jsonb;
+  v_review_json jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ADMIN_REQUIRED',
+      'status', 403,
+      'message', 'Only review admins can approve reviews'
+    );
+  end if;
+
+  v_root_table := lower(coalesce(p_table, ''));
+  if v_root_table not in ('processes', 'lifecyclemodels') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_TABLE',
+      'status', 400,
+      'message', 'table must be processes or lifecyclemodels'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code <> 1 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Only assigned reviews can be approved',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  v_root_targets := jsonb_build_array(
+    jsonb_build_object(
+      'table', v_root_table,
+      'id', v_review.data_id,
+      'version', v_review.data_version,
+      'is_root', true
+    )
+  );
+
+  create temporary table if not exists cmd_review_approve_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    dataset_row jsonb not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  truncate table cmd_review_approve_targets;
+
+  insert into cmd_review_approve_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_root_targets, true);
+
+  select coalesce(
+    jsonb_agg(review_items.value),
+    '[]'::jsonb
+  )
+    into v_review_items
+  from public.comments as c
+  cross join lateral jsonb_array_elements(
+    public.cmd_review_json_array(to_jsonb(c.json)#>'{modellingAndValidation,validation,review}')
+  ) as review_items(value)
+  where c.review_id = p_review_id
+    and c.state_code = 1;
+
+  select coalesce(
+    jsonb_agg(compliance_items.value),
+    '[]'::jsonb
+  )
+    into v_compliance_items
+  from public.comments as c
+  cross join lateral jsonb_array_elements(
+    public.cmd_review_json_array(
+      to_jsonb(c.json)#>'{modellingAndValidation,complianceDeclarations,compliance}'
+    )
+  ) as compliance_items(value)
+  where c.review_id = p_review_id
+    and c.state_code = 1;
+
+  for v_comment_ref in
+    select distinct
+      ref.ref_type,
+      ref.ref_object_id,
+      ref.ref_version
+    from public.comments as c
+    cross join lateral public.cmd_review_extract_refs(coalesce(to_jsonb(c.json), '{}'::jsonb)) as ref
+    where c.review_id = p_review_id
+      and c.state_code = 1
+  loop
+    v_comment_ref_roots := v_comment_ref_roots || jsonb_build_array(
+      jsonb_build_object(
+        'table', public.cmd_review_ref_type_to_table(v_comment_ref.ref_type),
+        'id', v_comment_ref.ref_object_id,
+        'version', v_comment_ref.ref_version,
+        'is_root', false
+      )
+    );
+  end loop;
+
+  insert into cmd_review_approve_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_comment_ref_roots, true)
+  on conflict (table_name, dataset_id, dataset_version) do nothing;
+
+  select dataset_row
+    into v_root_row
+  from cmd_review_approve_targets
+  where is_root
+    and table_name = v_root_table
+    and dataset_id = v_review.data_id
+    and dataset_version = v_review.data_version
+  limit 1;
+
+  if v_root_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_TARGET_NOT_FOUND',
+      'status', 404,
+      'message', 'Review target dataset not found'
+    );
+  end if;
+
+  if v_root_table = 'processes' then
+    v_updated_root_row := public.cmd_review_apply_mv_payload(
+      'processes',
+      v_review.data_id,
+      v_review.data_version,
+      v_review_items,
+      v_compliance_items
+    );
+  elsif v_root_table = 'lifecyclemodels' then
+    select coalesce(
+      array_agg((submodel.value->>'id')::uuid),
+      array[]::uuid[]
+    )
+      into v_submodel_ids
+    from jsonb_array_elements(coalesce(v_root_row->'json_tg'->'submodels', '[]'::jsonb))
+         as submodel(value)
+    where lower(coalesce(submodel.value->>'type', '')) = 'secondary'
+      and (submodel.value->>'id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+
+    foreach v_submodel_id in array v_submodel_ids
+    loop
+      if not exists (
+        select 1
+        from cmd_review_approve_targets as t
+        where t.table_name = 'processes'
+          and t.dataset_id = v_submodel_id
+          and t.dataset_version = v_review.data_version
+      ) then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'INVALID_PAYLOAD',
+          'status', 400,
+          'message', format(
+            'Missing current process snapshot for submodel %s',
+            v_submodel_id
+          )
+        );
+      end if;
+    end loop;
+
+    v_updated_root_row := public.cmd_review_apply_mv_payload(
+      'lifecyclemodels',
+      v_review.data_id,
+      v_review.data_version,
+      v_review_items,
+      v_compliance_items
+    );
+
+    foreach v_submodel_id in array v_submodel_ids
+    loop
+      select public.cmd_review_apply_model_validation_to_process_json(
+        coalesce(t.dataset_row->'json_ordered', t.dataset_row->'json', '{}'::jsonb),
+        coalesce(v_updated_root_row->'json_ordered', v_updated_root_row->'json', '{}'::jsonb),
+        v_review_items,
+        v_compliance_items
+      )
+        into v_submodel_doc
+      from cmd_review_approve_targets as t
+      where t.table_name = 'processes'
+        and t.dataset_id = v_submodel_id
+        and t.dataset_version = v_review.data_version
+      limit 1;
+
+      update public.processes
+        set json_ordered = v_submodel_doc::json,
+            json = v_submodel_doc,
+            modified_at = now()
+      where id = v_submodel_id
+        and version = v_review.data_version;
+    end loop;
+
+    for v_target in
+      select *
+      from cmd_review_approve_targets
+      where table_name = 'processes'
+        and not (dataset_id = any(v_submodel_ids))
+      order by dataset_id, dataset_version
+    loop
+      perform public.cmd_review_apply_mv_payload(
+        'processes',
+        v_target.dataset_id,
+        v_target.dataset_version,
+        v_review_items,
+        v_compliance_items
+      );
+    end loop;
+  end if;
+
+  for v_target in
+    select *
+    from cmd_review_approve_targets
+    where state_code < 100
+      and state_code <> 200
+    order by table_name, dataset_id, dataset_version
+  loop
+    execute format(
+      'update public.%I
+          set state_code = 100,
+              modified_at = now()
+        where id = $1
+          and version = $2',
+      v_target.table_name
+    )
+      using v_target.dataset_id, v_target.dataset_version;
+  end loop;
+
+  update public.comments
+    set state_code = 2,
+        modified_at = now()
+  where review_id = p_review_id
+    and state_code <> -2;
+
+  v_review_json := public.cmd_review_append_log(
+    coalesce(v_review.json, '{}'::jsonb),
+    'approved',
+    v_actor
+  );
+
+  update public.reviews
+    set state_code = 2,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'table', table_name,
+        'id', dataset_id,
+        'version', dataset_version,
+        'state_code', 100
+      )
+      order by table_name, dataset_id, dataset_version
+    ),
+    '[]'::jsonb
+  )
+    into v_affected_datasets
+  from cmd_review_approve_targets
+  where state_code < 100
+    and state_code <> 200;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_approve',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'root_table', v_root_table,
+      'affected_datasets', v_affected_datasets
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'affected_datasets', v_affected_datasets
+    )
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_reject(
+  p_table text,
+  p_review_id uuid,
+  p_reason text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_root_table text;
+  v_root_targets jsonb;
+  v_comment_ref_roots jsonb := '[]'::jsonb;
+  v_target record;
+  v_comment_ref record;
+  v_review_json jsonb;
+  v_affected_datasets jsonb := '[]'::jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ADMIN_REQUIRED',
+      'status', 403,
+      'message', 'Only review admins can reject reviews'
+    );
+  end if;
+
+  v_root_table := lower(coalesce(p_table, ''));
+  if v_root_table not in ('processes', 'lifecyclemodels') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_TABLE',
+      'status', 400,
+      'message', 'table must be processes or lifecyclemodels'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code not in (-1, 0, 1) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Only pending, assigned, or rejected reviews can be rejected',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  v_root_targets := jsonb_build_array(
+    jsonb_build_object(
+      'table', v_root_table,
+      'id', v_review.data_id,
+      'version', v_review.data_version,
+      'is_root', true
+    )
+  );
+
+  create temporary table if not exists cmd_review_reject_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    dataset_row jsonb not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  truncate table cmd_review_reject_targets;
+
+  insert into cmd_review_reject_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_root_targets, true);
+
+  for v_comment_ref in
+    select distinct
+      ref.ref_type,
+      ref.ref_object_id,
+      ref.ref_version
+    from public.comments as c
+    cross join lateral public.cmd_review_extract_refs(coalesce(to_jsonb(c.json), '{}'::jsonb)) as ref
+    where c.review_id = p_review_id
+      and c.state_code <> -2
+  loop
+    v_comment_ref_roots := v_comment_ref_roots || jsonb_build_array(
+      jsonb_build_object(
+        'table', public.cmd_review_ref_type_to_table(v_comment_ref.ref_type),
+        'id', v_comment_ref.ref_object_id,
+        'version', v_comment_ref.ref_version,
+        'is_root', false
+      )
+    );
+  end loop;
+
+  insert into cmd_review_reject_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_comment_ref_roots, true)
+  on conflict (table_name, dataset_id, dataset_version) do nothing;
+
+  for v_target in
+    select *
+    from cmd_review_reject_targets
+    where state_code >= 20
+      and state_code < 100
+    order by table_name, dataset_id, dataset_version
+  loop
+    execute format(
+      'update public.%I
+          set state_code = 0,
+              modified_at = now()
+        where id = $1
+          and version = $2',
+      v_target.table_name
+    )
+      using v_target.dataset_id, v_target.dataset_version;
+  end loop;
+
+  update public.comments
+    set state_code = -1,
+        modified_at = now()
+  where review_id = p_review_id
+    and state_code <> -2;
+
+  v_review_json := coalesce(v_review.json, '{}'::jsonb);
+  v_review_json := jsonb_set(
+    v_review_json,
+    '{comment}',
+    coalesce(v_review_json->'comment', '{}'::jsonb) || jsonb_build_object(
+      'message', coalesce(p_reason, '')
+    ),
+    true
+  );
+  v_review_json := public.cmd_review_append_log(
+    v_review_json,
+    'rejected',
+    v_actor,
+    jsonb_build_object(
+      'reason', coalesce(p_reason, '')
+    )
+  );
+
+  update public.reviews
+    set state_code = -1,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'table', table_name,
+        'id', dataset_id,
+        'version', dataset_version,
+        'state_code', 0
+      )
+      order by table_name, dataset_id, dataset_version
+    ),
+    '[]'::jsonb
+  )
+    into v_affected_datasets
+  from cmd_review_reject_targets
+  where state_code >= 20
+    and state_code < 100;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_reject',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'root_table', v_root_table,
+      'reason', coalesce(p_reason, ''),
+      'affected_datasets', v_affected_datasets
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'affected_datasets', v_affected_datasets
+    )
+  );
+end;
+$$;
+
+revoke all on function public.cmd_review_json_array(jsonb) from public;
+revoke all on function public.cmd_review_merge_json_collection(jsonb, jsonb) from public;
+revoke all on function public.cmd_review_apply_model_validation_to_process_json(jsonb, jsonb, jsonb, jsonb) from public;
+revoke all on function public.cmd_review_normalize_reviewer_ids(jsonb) from public;
+revoke all on function public.cmd_review_is_review_admin(uuid) from public;
+revoke all on function public.cmd_review_get_actor_meta(uuid) from public;
+revoke all on function public.cmd_review_append_log(jsonb, text, uuid, jsonb) from public;
+revoke all on function public.cmd_review_get_root_table(jsonb, uuid, text) from public;
+revoke all on function public.cmd_review_collect_dataset_targets(jsonb, boolean) from public;
+revoke all on function public.cmd_review_apply_mv_payload(text, uuid, text, jsonb, jsonb) from public;
+revoke all on function public.cmd_review_save_assignment_draft(uuid, jsonb, jsonb) from public;
+revoke all on function public.cmd_review_assign_reviewers(uuid, jsonb, timestamp with time zone, jsonb) from public;
+revoke all on function public.cmd_review_revoke_reviewer(uuid, uuid, jsonb) from public;
+revoke all on function public.cmd_review_save_comment_draft(uuid, jsonb, jsonb) from public;
+revoke all on function public.cmd_review_submit_comment(uuid, jsonb, jsonb) from public;
+revoke all on function public.cmd_review_submit_comment(uuid, jsonb, integer, jsonb) from public;
+revoke all on function public.cmd_review_approve(text, uuid, jsonb) from public;
+revoke all on function public.cmd_review_reject(text, uuid, text, jsonb) from public;
+
+grant execute on function public.cmd_review_save_assignment_draft(uuid, jsonb, jsonb) to authenticated;
+grant execute on function public.cmd_review_save_assignment_draft(uuid, jsonb, jsonb) to service_role;
+grant execute on function public.cmd_review_assign_reviewers(uuid, jsonb, timestamp with time zone, jsonb) to authenticated;
+grant execute on function public.cmd_review_assign_reviewers(uuid, jsonb, timestamp with time zone, jsonb) to service_role;
+grant execute on function public.cmd_review_revoke_reviewer(uuid, uuid, jsonb) to authenticated;
+grant execute on function public.cmd_review_revoke_reviewer(uuid, uuid, jsonb) to service_role;
+grant execute on function public.cmd_review_save_comment_draft(uuid, jsonb, jsonb) to authenticated;
+grant execute on function public.cmd_review_save_comment_draft(uuid, jsonb, jsonb) to service_role;
+grant execute on function public.cmd_review_submit_comment(uuid, jsonb, jsonb) to authenticated;
+grant execute on function public.cmd_review_submit_comment(uuid, jsonb, jsonb) to service_role;
+grant execute on function public.cmd_review_submit_comment(uuid, jsonb, integer, jsonb) to authenticated;
+grant execute on function public.cmd_review_submit_comment(uuid, jsonb, integer, jsonb) to service_role;
+grant execute on function public.cmd_review_approve(text, uuid, jsonb) to authenticated;
+grant execute on function public.cmd_review_approve(text, uuid, jsonb) to service_role;
+grant execute on function public.cmd_review_reject(text, uuid, text, jsonb) to authenticated;
+grant execute on function public.cmd_review_reject(text, uuid, text, jsonb) to service_role;

--- a/supabase/migrations/20260405143000_access_control_add_membership_profile_rpcs.sql
+++ b/supabase/migrations/20260405143000_access_control_add_membership_profile_rpcs.sql
@@ -1,0 +1,1820 @@
+create or replace function public.cmd_membership_is_team_owner(
+  p_actor uuid,
+  p_team_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.roles
+    where user_id = p_actor
+      and team_id = p_team_id
+      and role = 'owner'
+  )
+$$;
+
+create or replace function public.cmd_membership_is_team_manager(
+  p_actor uuid,
+  p_team_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.roles
+    where user_id = p_actor
+      and team_id = p_team_id
+      and role in ('owner', 'admin')
+  )
+$$;
+
+create or replace function public.cmd_membership_is_system_owner(
+  p_actor uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.roles
+    where user_id = coalesce(p_actor, auth.uid())
+      and team_id = '00000000-0000-0000-0000-000000000000'::uuid
+      and role = 'owner'
+  )
+$$;
+
+create or replace function public.cmd_membership_is_system_manager(
+  p_actor uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.roles
+    where user_id = coalesce(p_actor, auth.uid())
+      and team_id = '00000000-0000-0000-0000-000000000000'::uuid
+      and role in ('owner', 'admin', 'member')
+  )
+$$;
+
+create or replace function public.cmd_membership_is_review_admin(
+  p_actor uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.roles
+    where user_id = coalesce(p_actor, auth.uid())
+      and team_id = '00000000-0000-0000-0000-000000000000'::uuid
+      and role = 'review-admin'
+  )
+$$;
+
+create or replace function public.cmd_membership_resolve_sort_direction(
+  p_sort_order text
+)
+returns text
+language plpgsql
+immutable
+set search_path = public, pg_temp
+as $$
+begin
+  case lower(coalesce(p_sort_order, ''))
+    when 'asc' then
+      return 'asc';
+    when 'ascend' then
+      return 'asc';
+    else
+      return 'desc';
+  end case;
+end;
+$$;
+
+create or replace function public.cmd_membership_resolve_member_order_by(
+  p_sort_by text,
+  p_allow_workload boolean default false
+)
+returns text
+language plpgsql
+immutable
+set search_path = public, pg_temp
+as $$
+begin
+  case lower(coalesce(p_sort_by, ''))
+    when 'role' then
+      return 'm.role';
+    when 'email' then
+      return 'm.email';
+    when 'display_name' then
+      return 'm.display_name';
+    when 'modified_at' then
+      return 'm.modified_at';
+    when 'pendingcount' then
+      if p_allow_workload then
+        return 'm.pending_count';
+      end if;
+    when 'pending_count' then
+      if p_allow_workload then
+        return 'm.pending_count';
+      end if;
+    when 'reviewedcount' then
+      if p_allow_workload then
+        return 'm.reviewed_count';
+      end if;
+    when 'reviewed_count' then
+      if p_allow_workload then
+        return 'm.reviewed_count';
+      end if;
+    else
+      return 'm.created_at';
+  end case;
+
+  return 'm.created_at';
+end;
+$$;
+
+create or replace function public.cmd_team_create(
+  p_team_id uuid,
+  p_json jsonb,
+  p_rank integer,
+  p_is_public boolean,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_team_row jsonb;
+  v_role_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_team_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_ID_REQUIRED',
+      'status', 400,
+      'message', 'teamId is required'
+    );
+  end if;
+
+  if p_json is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_JSON_REQUIRED',
+      'status', 400,
+      'message', 'json is required'
+    );
+  end if;
+
+  if public.policy_user_has_team(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_ALREADY_ASSIGNED',
+      'status', 409,
+      'message', 'The actor already belongs to a team'
+    );
+  end if;
+
+  if not public.policy_roles_insert(v_actor, p_team_id, 'owner') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'The actor is not allowed to create this team'
+    );
+  end if;
+
+  delete from public.roles
+  where user_id = v_actor
+    and role = 'rejected'
+    and team_id <> '00000000-0000-0000-0000-000000000000'::uuid;
+
+  insert into public.teams (
+    id,
+    json,
+    rank,
+    is_public,
+    modified_at
+  )
+  values (
+    p_team_id,
+    p_json,
+    coalesce(p_rank, -1),
+    coalesce(p_is_public, false),
+    now()
+  )
+  returning to_jsonb(teams.*)
+    into v_team_row;
+
+  insert into public.roles (
+    user_id,
+    team_id,
+    role,
+    modified_at
+  )
+  values (
+    v_actor,
+    p_team_id,
+    'owner',
+    now()
+  )
+  returning to_jsonb(roles.*)
+    into v_role_row;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_team_create',
+    v_actor,
+    'teams',
+    p_team_id,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'team', v_team_row,
+      'owner_role', v_role_row
+    )
+  );
+exception
+  when unique_violation then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_ALREADY_EXISTS',
+      'status', 409,
+      'message', 'The team already exists'
+    );
+end;
+$$;
+
+create or replace function public.cmd_team_update_profile(
+  p_team_id uuid,
+  p_json jsonb,
+  p_is_public boolean,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_team_row jsonb;
+  v_can_manage boolean;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_team_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_ID_REQUIRED',
+      'status', 400,
+      'message', 'teamId is required'
+    );
+  end if;
+
+  if p_json is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_JSON_REQUIRED',
+      'status', 400,
+      'message', 'json is required'
+    );
+  end if;
+
+  select
+    public.cmd_membership_is_team_manager(v_actor, p_team_id) or
+    public.cmd_membership_is_system_manager(v_actor)
+  into v_can_manage;
+
+  if not coalesce(v_can_manage, false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'The actor cannot update this team profile'
+    );
+  end if;
+
+  update public.teams
+    set json = p_json,
+        is_public = coalesce(p_is_public, false),
+        modified_at = now()
+  where id = p_team_id
+  returning to_jsonb(teams.*)
+    into v_team_row;
+
+  if v_team_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_NOT_FOUND',
+      'status', 404,
+      'message', 'Team not found'
+    );
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_team_update_profile',
+    v_actor,
+    'teams',
+    p_team_id,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_team_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_team_set_rank(
+  p_team_id uuid,
+  p_rank integer,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_team_row jsonb;
+  v_can_manage boolean;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_team_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_ID_REQUIRED',
+      'status', 400,
+      'message', 'teamId is required'
+    );
+  end if;
+
+  if p_rank is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RANK_REQUIRED',
+      'status', 400,
+      'message', 'rank is required'
+    );
+  end if;
+
+  select
+    public.cmd_membership_is_team_manager(v_actor, p_team_id) or
+    public.cmd_membership_is_system_manager(v_actor)
+  into v_can_manage;
+
+  if not coalesce(v_can_manage, false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'The actor cannot update this team rank'
+    );
+  end if;
+
+  update public.teams
+    set rank = p_rank,
+        modified_at = now()
+  where id = p_team_id
+  returning to_jsonb(teams.*)
+    into v_team_row;
+
+  if v_team_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_NOT_FOUND',
+      'status', 404,
+      'message', 'Team not found'
+    );
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_team_set_rank',
+    v_actor,
+    'teams',
+    p_team_id,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_team_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_user_update_contact(
+  p_user_id uuid,
+  p_contact jsonb,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_user_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_user_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'USER_ID_REQUIRED',
+      'status', 400,
+      'message', 'userId is required'
+    );
+  end if;
+
+  if v_actor <> p_user_id and not public.cmd_membership_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'The actor cannot update this contact'
+    );
+  end if;
+
+  update public.users
+    set contact = p_contact
+  where id = p_user_id
+  returning to_jsonb(users.*)
+    into v_user_row;
+
+  if v_user_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'USER_NOT_FOUND',
+      'status', 404,
+      'message', 'User not found'
+    );
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_user_update_contact',
+    v_actor,
+    'users',
+    p_user_id,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_user_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_team_change_member_role(
+  p_team_id uuid,
+  p_user_id uuid,
+  p_role text default null,
+  p_action text default 'set',
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_action text := lower(coalesce(p_action, 'set'));
+  v_existing_role text;
+  v_role_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_team_id is null or p_user_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_PAYLOAD',
+      'status', 400,
+      'message', 'teamId and userId are required'
+    );
+  end if;
+
+  if p_team_id = '00000000-0000-0000-0000-000000000000'::uuid then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_TEAM_SCOPE',
+      'status', 400,
+      'message', 'Use system or review member commands for the zero team scope'
+    );
+  end if;
+
+  select role
+    into v_existing_role
+  from public.roles
+  where user_id = p_user_id
+    and team_id = p_team_id
+  for update;
+
+  if v_action = 'remove' then
+    if v_existing_role is null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'ROLE_NOT_FOUND',
+        'status', 404,
+        'message', 'Role not found'
+      );
+    end if;
+
+    if not public.policy_roles_delete(p_user_id, p_team_id, v_existing_role) then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'FORBIDDEN',
+        'status', 403,
+        'message', 'The actor cannot remove this team member'
+      );
+    end if;
+
+    delete from public.roles
+    where user_id = p_user_id
+      and team_id = p_team_id;
+
+    insert into public.command_audit_log (
+      command,
+      actor_user_id,
+      target_table,
+      target_id,
+      target_version,
+      payload
+    )
+    values (
+      'cmd_team_change_member_role',
+      v_actor,
+      'roles',
+      p_user_id,
+      p_team_id::text,
+      coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+        'action', 'remove'
+      )
+    );
+
+    return jsonb_build_object(
+      'ok', true,
+      'data', jsonb_build_object(
+        'removed', true,
+        'user_id', p_user_id,
+        'team_id', p_team_id
+      )
+    );
+  end if;
+
+  if v_action <> 'set' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_ACTION',
+      'status', 400,
+      'message', 'Unsupported action'
+    );
+  end if;
+
+  if p_role = 'is_invited' then
+    if v_existing_role = 'rejected' then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'REINVITE_REQUIRED',
+        'status', 409,
+        'message', 'Use the reinvite command for rejected members'
+      );
+    end if;
+
+    if v_existing_role is not null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'TEAM_MEMBER_ALREADY_EXISTS',
+        'status', 409,
+        'message', 'The team membership already exists'
+      );
+    end if;
+
+    if not public.policy_roles_insert(p_user_id, p_team_id, 'is_invited') then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'FORBIDDEN',
+        'status', 403,
+        'message', 'The actor cannot invite this user to the team'
+      );
+    end if;
+
+    insert into public.roles (
+      user_id,
+      team_id,
+      role,
+      modified_at
+    )
+    values (
+      p_user_id,
+      p_team_id,
+      'is_invited',
+      now()
+    )
+    returning to_jsonb(roles.*)
+      into v_role_row;
+  elsif p_role in ('admin', 'member') then
+    if not public.cmd_membership_is_team_owner(v_actor, p_team_id) then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'FORBIDDEN',
+        'status', 403,
+        'message', 'Only the team owner can change active member roles'
+      );
+    end if;
+
+    if v_existing_role not in ('admin', 'member') then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'INVALID_ROLE_STATE',
+        'status', 409,
+        'message', 'Only active team members can be promoted or demoted'
+      );
+    end if;
+
+    update public.roles
+      set role = p_role,
+          modified_at = now()
+    where user_id = p_user_id
+      and team_id = p_team_id
+    returning to_jsonb(roles.*)
+      into v_role_row;
+  else
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_ROLE',
+      'status', 400,
+      'message', 'Unsupported team role transition'
+    );
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_team_change_member_role',
+    v_actor,
+    'roles',
+    p_user_id,
+    p_team_id::text,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'action', 'set',
+      'role', p_role
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_role_row
+  );
+exception
+  when unique_violation then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_MEMBER_ALREADY_EXISTS',
+      'status', 409,
+      'message', 'The team membership already exists'
+    );
+end;
+$$;
+
+create or replace function public.cmd_system_change_member_role(
+  p_user_id uuid,
+  p_role text default null,
+  p_action text default 'set',
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_action text := lower(coalesce(p_action, 'set'));
+  v_team_id uuid := '00000000-0000-0000-0000-000000000000'::uuid;
+  v_actor_is_owner boolean;
+  v_actor_is_manager boolean;
+  v_existing_role text;
+  v_role_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_user_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'USER_ID_REQUIRED',
+      'status', 400,
+      'message', 'userId is required'
+    );
+  end if;
+
+  v_actor_is_owner := public.cmd_membership_is_system_owner(v_actor);
+  v_actor_is_manager := public.cmd_membership_is_system_manager(v_actor);
+
+  if not v_actor_is_manager then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'The actor cannot manage system members'
+    );
+  end if;
+
+  select role
+    into v_existing_role
+  from public.roles
+  where user_id = p_user_id
+    and team_id = v_team_id
+  for update;
+
+  if v_action = 'remove' then
+    if v_existing_role is null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'ROLE_NOT_FOUND',
+        'status', 404,
+        'message', 'Role not found'
+      );
+    end if;
+
+    if p_user_id = v_actor or v_existing_role = 'owner' then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'FORBIDDEN',
+        'status', 403,
+        'message', 'The actor cannot remove this system member'
+      );
+    end if;
+
+    delete from public.roles
+    where user_id = p_user_id
+      and team_id = v_team_id;
+
+    insert into public.command_audit_log (
+      command,
+      actor_user_id,
+      target_table,
+      target_id,
+      target_version,
+      payload
+    )
+    values (
+      'cmd_system_change_member_role',
+      v_actor,
+      'roles',
+      p_user_id,
+      v_team_id::text,
+      coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+        'action', 'remove'
+      )
+    );
+
+    return jsonb_build_object(
+      'ok', true,
+      'data', jsonb_build_object(
+        'removed', true,
+        'user_id', p_user_id,
+        'team_id', v_team_id
+      )
+    );
+  end if;
+
+  if v_action <> 'set' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_ACTION',
+      'status', 400,
+      'message', 'Unsupported action'
+    );
+  end if;
+
+  if p_role not in ('member', 'admin') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_ROLE',
+      'status', 400,
+      'message', 'Unsupported system role transition'
+    );
+  end if;
+
+  if p_role = 'admin' and not v_actor_is_owner then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'Only the system owner can assign admin roles'
+    );
+  end if;
+
+  if p_role = 'member' and v_existing_role = 'admin' and not v_actor_is_owner then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'Only the system owner can demote an admin'
+    );
+  end if;
+
+  if v_existing_role is null then
+    insert into public.roles (
+      user_id,
+      team_id,
+      role,
+      modified_at
+    )
+    values (
+      p_user_id,
+      v_team_id,
+      p_role,
+      now()
+    )
+    returning to_jsonb(roles.*)
+      into v_role_row;
+  elsif v_existing_role in ('owner', 'admin', 'member') then
+    if v_existing_role = 'owner' then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'FORBIDDEN',
+        'status', 403,
+        'message', 'The owner role cannot be modified'
+      );
+    end if;
+
+    update public.roles
+      set role = p_role,
+          modified_at = now()
+    where user_id = p_user_id
+      and team_id = v_team_id
+    returning to_jsonb(roles.*)
+      into v_role_row;
+  else
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'ROLE_CONFLICT',
+      'status', 409,
+      'message', 'The existing zero-team role belongs to another scope'
+    );
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_system_change_member_role',
+    v_actor,
+    'roles',
+    p_user_id,
+    v_team_id::text,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'action', 'set',
+      'role', p_role
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_role_row
+  );
+exception
+  when unique_violation then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'ROLE_CONFLICT',
+      'status', 409,
+      'message', 'The existing zero-team role belongs to another scope'
+    );
+end;
+$$;
+
+create or replace function public.cmd_review_change_member_role(
+  p_user_id uuid,
+  p_role text default null,
+  p_action text default 'set',
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_action text := lower(coalesce(p_action, 'set'));
+  v_team_id uuid := '00000000-0000-0000-0000-000000000000'::uuid;
+  v_existing_role text;
+  v_role_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_user_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'USER_ID_REQUIRED',
+      'status', 400,
+      'message', 'userId is required'
+    );
+  end if;
+
+  if not public.cmd_membership_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'Only a review admin can manage review members'
+    );
+  end if;
+
+  select role
+    into v_existing_role
+  from public.roles
+  where user_id = p_user_id
+    and team_id = v_team_id
+  for update;
+
+  if v_action = 'remove' then
+    if v_existing_role is null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'ROLE_NOT_FOUND',
+        'status', 404,
+        'message', 'Role not found'
+      );
+    end if;
+
+    if p_user_id = v_actor or v_existing_role <> 'review-member' then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'FORBIDDEN',
+        'status', 403,
+        'message', 'Only review-member rows can be removed'
+      );
+    end if;
+
+    delete from public.roles
+    where user_id = p_user_id
+      and team_id = v_team_id;
+
+    insert into public.command_audit_log (
+      command,
+      actor_user_id,
+      target_table,
+      target_id,
+      target_version,
+      payload
+    )
+    values (
+      'cmd_review_change_member_role',
+      v_actor,
+      'roles',
+      p_user_id,
+      v_team_id::text,
+      coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+        'action', 'remove'
+      )
+    );
+
+    return jsonb_build_object(
+      'ok', true,
+      'data', jsonb_build_object(
+        'removed', true,
+        'user_id', p_user_id,
+        'team_id', v_team_id
+      )
+    );
+  end if;
+
+  if v_action <> 'set' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_ACTION',
+      'status', 400,
+      'message', 'Unsupported action'
+    );
+  end if;
+
+  if p_role not in ('review-member', 'review-admin') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_ROLE',
+      'status', 400,
+      'message', 'Unsupported review role transition'
+    );
+  end if;
+
+  if v_existing_role is null then
+    if p_role <> 'review-member' then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'INVALID_ROLE_STATE',
+        'status', 409,
+        'message', 'A new review member must start as review-member'
+      );
+    end if;
+
+    insert into public.roles (
+      user_id,
+      team_id,
+      role,
+      modified_at
+    )
+    values (
+      p_user_id,
+      v_team_id,
+      p_role,
+      now()
+    )
+    returning to_jsonb(roles.*)
+      into v_role_row;
+  elsif v_existing_role in ('review-member', 'review-admin') then
+    update public.roles
+      set role = p_role,
+          modified_at = now()
+    where user_id = p_user_id
+      and team_id = v_team_id
+    returning to_jsonb(roles.*)
+      into v_role_row;
+  else
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'ROLE_CONFLICT',
+      'status', 409,
+      'message', 'The existing zero-team role belongs to another scope'
+    );
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_review_change_member_role',
+    v_actor,
+    'roles',
+    p_user_id,
+    v_team_id::text,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'action', 'set',
+      'role', p_role
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_role_row
+  );
+exception
+  when unique_violation then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'ROLE_CONFLICT',
+      'status', 409,
+      'message', 'The existing zero-team role belongs to another scope'
+    );
+end;
+$$;
+
+create or replace function public.cmd_team_reinvite_member(
+  p_team_id uuid,
+  p_user_id uuid,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_existing_role text;
+  v_role_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  select role
+    into v_existing_role
+  from public.roles
+  where user_id = p_user_id
+    and team_id = p_team_id
+  for update;
+
+  if v_existing_role is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'ROLE_NOT_FOUND',
+      'status', 404,
+      'message', 'Role not found'
+    );
+  end if;
+
+  if not public.policy_roles_update(p_user_id, p_team_id, 'is_invited') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'The actor cannot reinvite this member'
+    );
+  end if;
+
+  update public.roles
+    set role = 'is_invited',
+        modified_at = now()
+  where user_id = p_user_id
+    and team_id = p_team_id
+  returning to_jsonb(roles.*)
+    into v_role_row;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_team_reinvite_member',
+    v_actor,
+    'roles',
+    p_user_id,
+    p_team_id::text,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_role_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_team_accept_invitation(
+  p_team_id uuid,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_role_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.policy_roles_update(v_actor, p_team_id, 'member') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVITATION_NOT_FOUND',
+      'status', 404,
+      'message', 'No matching invitation was found for the actor'
+    );
+  end if;
+
+  update public.roles
+    set role = 'member',
+        modified_at = now()
+  where user_id = v_actor
+    and team_id = p_team_id
+    and role = 'is_invited'
+  returning to_jsonb(roles.*)
+    into v_role_row;
+
+  if v_role_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVITATION_NOT_FOUND',
+      'status', 404,
+      'message', 'No matching invitation was found for the actor'
+    );
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_team_accept_invitation',
+    v_actor,
+    'roles',
+    v_actor,
+    p_team_id::text,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_role_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_team_reject_invitation(
+  p_team_id uuid,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_role_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.policy_roles_update(v_actor, p_team_id, 'rejected') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVITATION_NOT_FOUND',
+      'status', 404,
+      'message', 'No matching invitation was found for the actor'
+    );
+  end if;
+
+  update public.roles
+    set role = 'rejected',
+        modified_at = now()
+  where user_id = v_actor
+    and team_id = p_team_id
+    and role = 'is_invited'
+  returning to_jsonb(roles.*)
+    into v_role_row;
+
+  if v_role_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVITATION_NOT_FOUND',
+      'status', 404,
+      'message', 'No matching invitation was found for the actor'
+    );
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_team_reject_invitation',
+    v_actor,
+    'roles',
+    v_actor,
+    p_team_id::text,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_role_row
+  );
+end;
+$$;
+
+create or replace function public.qry_team_get_member_list(
+  p_team_id uuid,
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'created_at',
+  p_sort_order text default 'desc'
+)
+returns table (
+  user_id uuid,
+  team_id uuid,
+  role text,
+  email text,
+  display_name text,
+  created_at timestamptz,
+  modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := public.cmd_membership_resolve_member_order_by(p_sort_by, false);
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not exists (
+    select 1
+    from public.roles
+    where user_id = v_actor
+      and team_id = p_team_id
+      and role <> 'rejected'
+  ) then
+    return;
+  end if;
+
+  return query execute format(
+    $sql$
+      with members as (
+        select
+          r.user_id,
+          r.team_id,
+          r.role::text as role,
+          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          coalesce(
+            nullif(u.raw_user_meta_data->>'display_name', ''),
+            u.raw_user_meta_data->>'email',
+            '-'
+          ) as display_name,
+          r.created_at,
+          r.modified_at
+        from public.roles as r
+        left join public.users as u
+          on u.id = r.user_id
+        where r.team_id = $1
+      )
+      select
+        m.user_id,
+        m.team_id,
+        m.role,
+        m.email,
+        m.display_name,
+        m.created_at,
+        m.modified_at,
+        count(*) over() as total_count
+      from members as m
+      order by %s %s nulls last, m.user_id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using p_team_id, v_limit, v_offset;
+end;
+$$;
+
+create or replace function public.qry_system_get_member_list(
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'created_at',
+  p_sort_order text default 'desc'
+)
+returns table (
+  user_id uuid,
+  team_id uuid,
+  role text,
+  email text,
+  display_name text,
+  created_at timestamptz,
+  modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_team_id uuid := '00000000-0000-0000-0000-000000000000'::uuid;
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := public.cmd_membership_resolve_member_order_by(p_sort_by, false);
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not public.cmd_membership_is_system_manager(v_actor) then
+    return;
+  end if;
+
+  return query execute format(
+    $sql$
+      with members as (
+        select
+          r.user_id,
+          r.team_id,
+          r.role::text as role,
+          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          coalesce(
+            nullif(u.raw_user_meta_data->>'display_name', ''),
+            u.raw_user_meta_data->>'email',
+            '-'
+          ) as display_name,
+          r.created_at,
+          r.modified_at
+        from public.roles as r
+        left join public.users as u
+          on u.id = r.user_id
+        where r.team_id = $1
+          and r.role in ('owner', 'admin', 'member')
+      )
+      select
+        m.user_id,
+        m.team_id,
+        m.role,
+        m.email,
+        m.display_name,
+        m.created_at,
+        m.modified_at,
+        count(*) over() as total_count
+      from members as m
+      order by %s %s nulls last, m.user_id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using v_team_id, v_limit, v_offset;
+end;
+$$;
+
+create or replace function public.qry_review_get_member_list(
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'created_at',
+  p_sort_order text default 'desc',
+  p_role text default null
+)
+returns table (
+  user_id uuid,
+  team_id uuid,
+  role text,
+  email text,
+  display_name text,
+  created_at timestamptz,
+  modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_team_id uuid := '00000000-0000-0000-0000-000000000000'::uuid;
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := public.cmd_membership_resolve_member_order_by(p_sort_by, false);
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not public.cmd_membership_is_review_admin(v_actor) then
+    return;
+  end if;
+
+  return query execute format(
+    $sql$
+      with members as (
+        select
+          r.user_id,
+          r.team_id,
+          r.role::text as role,
+          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          coalesce(
+            nullif(u.raw_user_meta_data->>'display_name', ''),
+            u.raw_user_meta_data->>'email',
+            '-'
+          ) as display_name,
+          r.created_at,
+          r.modified_at
+        from public.roles as r
+        left join public.users as u
+          on u.id = r.user_id
+        where r.team_id = $1
+          and r.role in ('review-admin', 'review-member')
+          and ($4::text is null or r.role = $4::text)
+      )
+      select
+        m.user_id,
+        m.team_id,
+        m.role,
+        m.email,
+        m.display_name,
+        m.created_at,
+        m.modified_at,
+        count(*) over() as total_count
+      from members as m
+      order by %s %s nulls last, m.user_id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using v_team_id, v_limit, v_offset, p_role;
+end;
+$$;
+
+create or replace function public.qry_review_get_member_workload(
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'created_at',
+  p_sort_order text default 'desc',
+  p_role text default null
+)
+returns table (
+  user_id uuid,
+  team_id uuid,
+  role text,
+  email text,
+  display_name text,
+  pending_count bigint,
+  reviewed_count bigint,
+  created_at timestamptz,
+  modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_team_id uuid := '00000000-0000-0000-0000-000000000000'::uuid;
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := public.cmd_membership_resolve_member_order_by(p_sort_by, true);
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not public.cmd_membership_is_review_admin(v_actor) then
+    return;
+  end if;
+
+  return query execute format(
+    $sql$
+      with members as (
+        select
+          r.user_id,
+          r.team_id,
+          r.role::text as role,
+          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          coalesce(
+            nullif(u.raw_user_meta_data->>'display_name', ''),
+            u.raw_user_meta_data->>'email',
+            '-'
+          ) as display_name,
+          coalesce(w.pending_count, 0) as pending_count,
+          coalesce(w.reviewed_count, 0) as reviewed_count,
+          r.created_at,
+          r.modified_at
+        from public.roles as r
+        left join public.users as u
+          on u.id = r.user_id
+        left join lateral (
+          select
+            count(*) filter (
+              where c.state_code = 0
+                and rv.state_code > 0
+            ) as pending_count,
+            count(*) filter (
+              where c.state_code in (1, 2)
+                and rv.state_code > 0
+            ) as reviewed_count
+          from public.comments as c
+          join public.reviews as rv
+            on rv.id = c.review_id
+          where c.reviewer_id = r.user_id
+            and c.state_code in (0, 1, 2)
+        ) as w on true
+        where r.team_id = $1
+          and r.role in ('review-admin', 'review-member')
+          and ($4::text is null or r.role = $4::text)
+      )
+      select
+        m.user_id,
+        m.team_id,
+        m.role,
+        m.email,
+        m.display_name,
+        m.pending_count,
+        m.reviewed_count,
+        m.created_at,
+        m.modified_at,
+        count(*) over() as total_count
+      from members as m
+      order by %s %s nulls last, m.user_id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using v_team_id, v_limit, v_offset, p_role;
+end;
+$$;
+
+revoke all on function public.cmd_membership_is_team_owner(uuid, uuid) from public;
+revoke all on function public.cmd_membership_is_team_manager(uuid, uuid) from public;
+revoke all on function public.cmd_membership_is_system_owner(uuid) from public;
+revoke all on function public.cmd_membership_is_system_manager(uuid) from public;
+revoke all on function public.cmd_membership_is_review_admin(uuid) from public;
+revoke all on function public.cmd_membership_resolve_sort_direction(text) from public;
+revoke all on function public.cmd_membership_resolve_member_order_by(text, boolean) from public;
+revoke all on function public.cmd_team_create(uuid, jsonb, integer, boolean, jsonb) from public;
+revoke all on function public.cmd_team_update_profile(uuid, jsonb, boolean, jsonb) from public;
+revoke all on function public.cmd_team_set_rank(uuid, integer, jsonb) from public;
+revoke all on function public.cmd_user_update_contact(uuid, jsonb, jsonb) from public;
+revoke all on function public.cmd_team_change_member_role(uuid, uuid, text, text, jsonb) from public;
+revoke all on function public.cmd_system_change_member_role(uuid, text, text, jsonb) from public;
+revoke all on function public.cmd_review_change_member_role(uuid, text, text, jsonb) from public;
+revoke all on function public.cmd_team_reinvite_member(uuid, uuid, jsonb) from public;
+revoke all on function public.cmd_team_accept_invitation(uuid, jsonb) from public;
+revoke all on function public.cmd_team_reject_invitation(uuid, jsonb) from public;
+revoke all on function public.qry_team_get_member_list(uuid, integer, integer, text, text) from public;
+revoke all on function public.qry_system_get_member_list(integer, integer, text, text) from public;
+revoke all on function public.qry_review_get_member_list(integer, integer, text, text, text) from public;
+revoke all on function public.qry_review_get_member_workload(integer, integer, text, text, text) from public;
+
+grant execute on function public.cmd_team_create(uuid, jsonb, integer, boolean, jsonb) to authenticated;
+grant execute on function public.cmd_team_update_profile(uuid, jsonb, boolean, jsonb) to authenticated;
+grant execute on function public.cmd_team_set_rank(uuid, integer, jsonb) to authenticated;
+grant execute on function public.cmd_user_update_contact(uuid, jsonb, jsonb) to authenticated;
+grant execute on function public.cmd_team_change_member_role(uuid, uuid, text, text, jsonb) to authenticated;
+grant execute on function public.cmd_system_change_member_role(uuid, text, text, jsonb) to authenticated;
+grant execute on function public.cmd_review_change_member_role(uuid, text, text, jsonb) to authenticated;
+grant execute on function public.cmd_team_reinvite_member(uuid, uuid, jsonb) to authenticated;
+grant execute on function public.cmd_team_accept_invitation(uuid, jsonb) to authenticated;
+grant execute on function public.cmd_team_reject_invitation(uuid, jsonb) to authenticated;
+grant execute on function public.qry_team_get_member_list(uuid, integer, integer, text, text) to authenticated;
+grant execute on function public.qry_system_get_member_list(integer, integer, text, text) to authenticated;
+grant execute on function public.qry_review_get_member_list(integer, integer, text, text, text) to authenticated;
+grant execute on function public.qry_review_get_member_workload(integer, integer, text, text, text) to authenticated;
+
+grant execute on function public.cmd_team_create(uuid, jsonb, integer, boolean, jsonb) to service_role;
+grant execute on function public.cmd_team_update_profile(uuid, jsonb, boolean, jsonb) to service_role;
+grant execute on function public.cmd_team_set_rank(uuid, integer, jsonb) to service_role;
+grant execute on function public.cmd_user_update_contact(uuid, jsonb, jsonb) to service_role;
+grant execute on function public.cmd_team_change_member_role(uuid, uuid, text, text, jsonb) to service_role;
+grant execute on function public.cmd_system_change_member_role(uuid, text, text, jsonb) to service_role;
+grant execute on function public.cmd_review_change_member_role(uuid, text, text, jsonb) to service_role;
+grant execute on function public.cmd_team_reinvite_member(uuid, uuid, jsonb) to service_role;
+grant execute on function public.cmd_team_accept_invitation(uuid, jsonb) to service_role;
+grant execute on function public.cmd_team_reject_invitation(uuid, jsonb) to service_role;
+grant execute on function public.qry_team_get_member_list(uuid, integer, integer, text, text) to service_role;
+grant execute on function public.qry_system_get_member_list(integer, integer, text, text) to service_role;
+grant execute on function public.qry_review_get_member_list(integer, integer, text, text, text) to service_role;
+grant execute on function public.qry_review_get_member_workload(integer, integer, text, text, text) to service_role;

--- a/supabase/migrations/20260405150000_access_control_fix_membership_query_aliases.sql
+++ b/supabase/migrations/20260405150000_access_control_fix_membership_query_aliases.sql
@@ -1,0 +1,82 @@
+create or replace function public.qry_team_get_member_list(
+  p_team_id uuid,
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'created_at',
+  p_sort_order text default 'desc'
+)
+returns table (
+  user_id uuid,
+  team_id uuid,
+  role text,
+  email text,
+  display_name text,
+  created_at timestamptz,
+  modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := public.cmd_membership_resolve_member_order_by(p_sort_by, false);
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not exists (
+    select 1
+    from public.roles as r
+    where r.user_id = v_actor
+      and r.team_id = p_team_id
+      and r.role <> 'rejected'
+  ) then
+    return;
+  end if;
+
+  return query execute format(
+    $sql$
+      with members as (
+        select
+          r.user_id,
+          r.team_id,
+          r.role::text as role,
+          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          coalesce(
+            nullif(u.raw_user_meta_data->>'display_name', ''),
+            u.raw_user_meta_data->>'email',
+            '-'
+          ) as display_name,
+          r.created_at,
+          r.modified_at
+        from public.roles as r
+        left join public.users as u
+          on u.id = r.user_id
+        where r.team_id = $1
+      )
+      select
+        m.user_id,
+        m.team_id,
+        m.role,
+        m.email,
+        m.display_name,
+        m.created_at,
+        m.modified_at,
+        count(*) over() as total_count
+      from members as m
+      order by %s %s nulls last, m.user_id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using p_team_id, v_limit, v_offset;
+end;
+$$;

--- a/supabase/migrations/20260405173000_access_control_revoke_core_table_write_grants.sql
+++ b/supabase/migrations/20260405173000_access_control_revoke_core_table_write_grants.sql
@@ -1,0 +1,5 @@
+revoke insert, update, delete on table public.comments from anon, authenticated;
+revoke insert, update, delete on table public.reviews from anon, authenticated;
+revoke insert, update, delete on table public.roles from anon, authenticated;
+revoke insert, update, delete on table public.teams from anon, authenticated;
+revoke insert, update, delete on table public.users from anon, authenticated;

--- a/supabase/migrations/20260405190000_access_control_add_notification_query_command_rpcs.sql
+++ b/supabase/migrations/20260405190000_access_control_add_notification_query_command_rpcs.sql
@@ -1,0 +1,404 @@
+create or replace function public.cmd_notification_normalize_text_array(
+  p_values text[]
+)
+returns text[]
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  with normalized as (
+    select
+      min(item.ordinality) as first_ordinality,
+      nullif(btrim(item.value), '') as normalized_value
+    from unnest(coalesce(p_values, array[]::text[])) with ordinality as item(value, ordinality)
+    group by nullif(btrim(item.value), '')
+  )
+  select coalesce(
+    array(
+      select normalized_value
+      from normalized
+      where normalized_value is not null
+      order by first_ordinality
+    ),
+    array[]::text[]
+  );
+$$;
+
+create or replace function public.qry_notification_get_my_team_items(
+  p_days integer default 3
+)
+returns table (
+  team_id uuid,
+  user_id uuid,
+  role text,
+  team_title jsonb,
+  modified_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select
+    r.team_id,
+    r.user_id,
+    r.role,
+    coalesce(t.json -> 'title', '[]'::jsonb) as team_title,
+    r.modified_at
+  from public.roles as r
+  join public.teams as t
+    on t.id = r.team_id
+  where r.user_id = auth.uid()
+    and r.team_id <> '00000000-0000-0000-0000-000000000000'::uuid
+    and (
+      coalesce(p_days, 3) <= 0 or
+      r.modified_at >= now() - make_interval(days => greatest(coalesce(p_days, 3), 0))
+    )
+  order by r.modified_at desc;
+$$;
+
+create or replace function public.qry_notification_get_my_team_count(
+  p_days integer default 3,
+  p_last_view_at timestamptz default null
+)
+returns integer
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select count(*)::integer
+  from public.roles as r
+  where r.user_id = auth.uid()
+    and r.role = 'is_invited'
+    and r.team_id <> '00000000-0000-0000-0000-000000000000'::uuid
+    and (
+      (p_last_view_at is not null and r.modified_at > p_last_view_at) or
+      (p_last_view_at is null and (
+        coalesce(p_days, 3) <= 0 or
+        r.modified_at >= now() - make_interval(days => greatest(coalesce(p_days, 3), 0))
+      ))
+    );
+$$;
+
+create or replace function public.qry_notification_get_my_data_items(
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_days integer default 3
+)
+returns table (
+  id uuid,
+  state_code integer,
+  "json" jsonb,
+  modified_at timestamptz,
+  total_count integer
+)
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select
+    r.id,
+    r.state_code,
+    coalesce(r.json, '{}'::jsonb) as json,
+    r.modified_at,
+    count(*) over ()::integer as total_count
+  from public.reviews as r
+  where coalesce(r.json -> 'user' ->> 'id', '') = auth.uid()::text
+    and r.state_code in (1, -1, 2)
+    and (
+      coalesce(p_days, 3) <= 0 or
+      r.modified_at >= now() - make_interval(days => greatest(coalesce(p_days, 3), 0))
+    )
+  order by r.modified_at desc
+  offset greatest(coalesce(p_page, 1) - 1, 0) * greatest(coalesce(p_page_size, 10), 1)
+  limit greatest(coalesce(p_page_size, 10), 1);
+$$;
+
+create or replace function public.qry_notification_get_my_data_count(
+  p_days integer default 3,
+  p_last_view_at timestamptz default null
+)
+returns integer
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select count(*)::integer
+  from public.reviews as r
+  where coalesce(r.json -> 'user' ->> 'id', '') = auth.uid()::text
+    and r.state_code in (1, -1, 2)
+    and (
+      (p_last_view_at is not null and r.modified_at > p_last_view_at) or
+      (p_last_view_at is null and (
+        coalesce(p_days, 3) <= 0 or
+        r.modified_at >= now() - make_interval(days => greatest(coalesce(p_days, 3), 0))
+      ))
+    );
+$$;
+
+create or replace function public.qry_notification_get_my_issue_items(
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_days integer default 3
+)
+returns table (
+  id uuid,
+  type text,
+  dataset_type text,
+  dataset_id uuid,
+  dataset_version text,
+  "json" jsonb,
+  modified_at timestamptz,
+  total_count integer
+)
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select
+    n.id,
+    n.type,
+    n.dataset_type,
+    n.dataset_id,
+    n.dataset_version,
+    n.json,
+    n.modified_at,
+    count(*) over ()::integer as total_count
+  from public.notifications as n
+  where n.recipient_user_id = auth.uid()
+    and n.type = 'validation_issue'
+    and (
+      coalesce(p_days, 3) <= 0 or
+      n.modified_at >= now() - make_interval(days => greatest(coalesce(p_days, 3), 0))
+    )
+  order by n.modified_at desc
+  offset greatest(coalesce(p_page, 1) - 1, 0) * greatest(coalesce(p_page_size, 10), 1)
+  limit greatest(coalesce(p_page_size, 10), 1);
+$$;
+
+create or replace function public.qry_notification_get_my_issue_count(
+  p_days integer default 3,
+  p_last_view_at timestamptz default null
+)
+returns integer
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select count(*)::integer
+  from public.notifications as n
+  where n.recipient_user_id = auth.uid()
+    and n.type = 'validation_issue'
+    and (
+      (p_last_view_at is not null and n.modified_at > p_last_view_at) or
+      (p_last_view_at is null and (
+        coalesce(p_days, 3) <= 0 or
+        n.modified_at >= now() - make_interval(days => greatest(coalesce(p_days, 3), 0))
+      ))
+    );
+$$;
+
+create or replace function public.cmd_notification_send_validation_issue(
+  p_recipient_user_id uuid,
+  p_dataset_type text,
+  p_dataset_id uuid,
+  p_dataset_version text,
+  p_link text default null,
+  p_issue_codes text[] default array[]::text[],
+  p_tab_names text[] default array[]::text[],
+  p_issue_count integer default 0,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_issue_codes text[];
+  v_tab_names text[];
+  v_sender_name text;
+  v_notification_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_recipient_user_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RECIPIENT_REQUIRED',
+      'status', 400,
+      'message', 'recipientUserId is required'
+    );
+  end if;
+
+  if v_actor = p_recipient_user_id then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'NOTIFICATION_SELF_TARGET',
+      'status', 409,
+      'message', 'The recipient must differ from the actor'
+    );
+  end if;
+
+  if nullif(btrim(coalesce(p_dataset_type, '')), '') is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_TYPE_REQUIRED',
+      'status', 400,
+      'message', 'datasetType is required'
+    );
+  end if;
+
+  if p_dataset_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_ID_REQUIRED',
+      'status', 400,
+      'message', 'datasetId is required'
+    );
+  end if;
+
+  if nullif(btrim(coalesce(p_dataset_version, '')), '') is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_VERSION_REQUIRED',
+      'status', 400,
+      'message', 'datasetVersion is required'
+    );
+  end if;
+
+  if not exists (
+    select 1
+    from public.users
+    where id = p_recipient_user_id
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RECIPIENT_NOT_FOUND',
+      'status', 404,
+      'message', 'The recipient user does not exist'
+    );
+  end if;
+
+  v_issue_codes := public.cmd_notification_normalize_text_array(p_issue_codes);
+  v_tab_names := public.cmd_notification_normalize_text_array(p_tab_names);
+
+  select coalesce(
+    nullif(btrim(u.raw_user_meta_data ->> 'display_name'), ''),
+    nullif(btrim(u.raw_user_meta_data ->> 'name'), ''),
+    nullif(btrim(u.raw_user_meta_data ->> 'email'), ''),
+    '-'
+  )
+  into v_sender_name
+  from public.users as u
+  where u.id = v_actor;
+
+  v_sender_name := coalesce(v_sender_name, '-');
+
+  insert into public.notifications (
+    recipient_user_id,
+    sender_user_id,
+    type,
+    dataset_type,
+    dataset_id,
+    dataset_version,
+    json,
+    modified_at
+  )
+  values (
+    p_recipient_user_id,
+    v_actor,
+    'validation_issue',
+    btrim(p_dataset_type),
+    p_dataset_id,
+    btrim(p_dataset_version),
+    jsonb_build_object(
+      'issueCodes', to_jsonb(v_issue_codes),
+      'issueCount', greatest(coalesce(p_issue_count, 0), 0),
+      'link', nullif(btrim(coalesce(p_link, '')), ''),
+      'senderName', v_sender_name,
+      'tabNames', to_jsonb(v_tab_names)
+    ),
+    now()
+  )
+  on conflict (
+    recipient_user_id,
+    sender_user_id,
+    type,
+    dataset_type,
+    dataset_id,
+    dataset_version
+  ) do update
+  set json = excluded.json,
+      modified_at = excluded.modified_at
+  returning to_jsonb(notifications.*)
+    into v_notification_row;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_notification_send_validation_issue',
+    v_actor,
+    'notifications',
+    (v_notification_row ->> 'id')::uuid,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'recipientUserId', p_recipient_user_id,
+      'datasetType', btrim(p_dataset_type),
+      'datasetId', p_dataset_id,
+      'datasetVersion', btrim(p_dataset_version),
+      'issueCount', greatest(coalesce(p_issue_count, 0), 0)
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_notification_row
+  );
+end;
+$$;
+
+revoke all on function public.cmd_notification_normalize_text_array(text[]) from public;
+revoke all on function public.qry_notification_get_my_team_items(integer) from public;
+revoke all on function public.qry_notification_get_my_team_count(integer, timestamptz) from public;
+revoke all on function public.qry_notification_get_my_data_items(integer, integer, integer) from public;
+revoke all on function public.qry_notification_get_my_data_count(integer, timestamptz) from public;
+revoke all on function public.qry_notification_get_my_issue_items(integer, integer, integer) from public;
+revoke all on function public.qry_notification_get_my_issue_count(integer, timestamptz) from public;
+revoke all on function public.cmd_notification_send_validation_issue(uuid, text, uuid, text, text, text[], text[], integer, jsonb) from public;
+
+grant execute on function public.cmd_notification_normalize_text_array(text[]) to authenticated;
+grant execute on function public.cmd_notification_normalize_text_array(text[]) to service_role;
+grant execute on function public.qry_notification_get_my_team_items(integer) to authenticated;
+grant execute on function public.qry_notification_get_my_team_items(integer) to service_role;
+grant execute on function public.qry_notification_get_my_team_count(integer, timestamptz) to authenticated;
+grant execute on function public.qry_notification_get_my_team_count(integer, timestamptz) to service_role;
+grant execute on function public.qry_notification_get_my_data_items(integer, integer, integer) to authenticated;
+grant execute on function public.qry_notification_get_my_data_items(integer, integer, integer) to service_role;
+grant execute on function public.qry_notification_get_my_data_count(integer, timestamptz) to authenticated;
+grant execute on function public.qry_notification_get_my_data_count(integer, timestamptz) to service_role;
+grant execute on function public.qry_notification_get_my_issue_items(integer, integer, integer) to authenticated;
+grant execute on function public.qry_notification_get_my_issue_items(integer, integer, integer) to service_role;
+grant execute on function public.qry_notification_get_my_issue_count(integer, timestamptz) to authenticated;
+grant execute on function public.qry_notification_get_my_issue_count(integer, timestamptz) to service_role;
+grant execute on function public.cmd_notification_send_validation_issue(uuid, text, uuid, text, text, text[], text[], integer, jsonb) to authenticated;
+grant execute on function public.cmd_notification_send_validation_issue(uuid, text, uuid, text, text, text[], text[], integer, jsonb) to service_role;
+
+revoke insert, update, delete on table public.notifications from anon, authenticated;

--- a/supabase/migrations/20260405200000_access_control_restrict_team_member_list_query.sql
+++ b/supabase/migrations/20260405200000_access_control_restrict_team_member_list_query.sql
@@ -1,0 +1,76 @@
+create or replace function public.qry_team_get_member_list(
+  p_team_id uuid,
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'created_at',
+  p_sort_order text default 'desc'
+)
+returns table (
+  user_id uuid,
+  team_id uuid,
+  role text,
+  email text,
+  display_name text,
+  created_at timestamptz,
+  modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := public.cmd_membership_resolve_member_order_by(p_sort_by, false);
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not public.cmd_membership_is_team_manager(v_actor, p_team_id) then
+    return;
+  end if;
+
+  return query execute format(
+    $sql$
+      with members as (
+        select
+          r.user_id,
+          r.team_id,
+          r.role::text as role,
+          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          coalesce(
+            nullif(u.raw_user_meta_data->>'display_name', ''),
+            u.raw_user_meta_data->>'email',
+            '-'
+          ) as display_name,
+          r.created_at,
+          r.modified_at
+        from public.roles as r
+        left join public.users as u
+          on u.id = r.user_id
+        where r.team_id = $1
+      )
+      select
+        m.user_id,
+        m.team_id,
+        m.role,
+        m.email,
+        m.display_name,
+        m.created_at,
+        m.modified_at,
+        count(*) over() as total_count
+      from members as m
+      order by %s %s nulls last, m.user_id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using p_team_id, v_limit, v_offset;
+end;
+$$;

--- a/supabase/migrations/20260405201000_access_control_harden_notification_validation_issue_command.sql
+++ b/supabase/migrations/20260405201000_access_control_harden_notification_validation_issue_command.sql
@@ -1,0 +1,362 @@
+drop function if exists public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+);
+
+create or replace function public.cmd_notification_send_validation_issue(
+  p_recipient_user_id uuid,
+  p_source_dataset_type text,
+  p_source_dataset_id uuid,
+  p_source_dataset_version text,
+  p_dataset_type text,
+  p_dataset_id uuid,
+  p_dataset_version text,
+  p_link text default null,
+  p_issue_codes text[] default array[]::text[],
+  p_tab_names text[] default array[]::text[],
+  p_issue_count integer default 0,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_source_dataset_type text := nullif(btrim(coalesce(p_source_dataset_type, '')), '');
+  v_source_dataset_version text := nullif(btrim(coalesce(p_source_dataset_version, '')), '');
+  v_dataset_type text := nullif(btrim(coalesce(p_dataset_type, '')), '');
+  v_dataset_version text := nullif(btrim(coalesce(p_dataset_version, '')), '');
+  v_source_table text;
+  v_target_table text;
+  v_source_row jsonb;
+  v_target_row jsonb;
+  v_issue_codes text[];
+  v_tab_names text[];
+  v_sender_name text;
+  v_notification_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_recipient_user_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RECIPIENT_REQUIRED',
+      'status', 400,
+      'message', 'recipientUserId is required'
+    );
+  end if;
+
+  if v_actor = p_recipient_user_id then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'NOTIFICATION_SELF_TARGET',
+      'status', 409,
+      'message', 'The recipient must differ from the actor'
+    );
+  end if;
+
+  if v_source_dataset_type is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SOURCE_DATASET_TYPE_REQUIRED',
+      'status', 400,
+      'message', 'sourceDatasetType is required'
+    );
+  end if;
+
+  if p_source_dataset_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SOURCE_DATASET_ID_REQUIRED',
+      'status', 400,
+      'message', 'sourceDatasetId is required'
+    );
+  end if;
+
+  if v_source_dataset_version is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SOURCE_DATASET_VERSION_REQUIRED',
+      'status', 400,
+      'message', 'sourceDatasetVersion is required'
+    );
+  end if;
+
+  if v_dataset_type is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_TYPE_REQUIRED',
+      'status', 400,
+      'message', 'datasetType is required'
+    );
+  end if;
+
+  if p_dataset_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_ID_REQUIRED',
+      'status', 400,
+      'message', 'datasetId is required'
+    );
+  end if;
+
+  if v_dataset_version is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_VERSION_REQUIRED',
+      'status', 400,
+      'message', 'datasetVersion is required'
+    );
+  end if;
+
+  if not exists (
+    select 1
+    from public.users
+    where id = p_recipient_user_id
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RECIPIENT_NOT_FOUND',
+      'status', 404,
+      'message', 'The recipient user does not exist'
+    );
+  end if;
+
+  v_source_table := public.cmd_review_ref_type_to_table(v_source_dataset_type);
+  if v_source_table is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SOURCE_DATASET_TYPE_INVALID',
+      'status', 400,
+      'message', 'sourceDatasetType is not supported'
+    );
+  end if;
+
+  v_target_table := public.cmd_review_ref_type_to_table(v_dataset_type);
+  if v_target_table is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_TYPE_INVALID',
+      'status', 400,
+      'message', 'datasetType is not supported'
+    );
+  end if;
+
+  v_source_row := public.cmd_review_get_dataset_row(
+    v_source_table,
+    p_source_dataset_id,
+    v_source_dataset_version,
+    false
+  );
+  if v_source_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SOURCE_DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'The source dataset does not exist'
+    );
+  end if;
+
+  if ((v_source_row ->> 'user_id')::uuid is distinct from v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SOURCE_DATASET_OWNER_REQUIRED',
+      'status', 403,
+      'message', 'Only the source dataset owner can notify the target owner'
+    );
+  end if;
+
+  v_target_row := public.cmd_review_get_dataset_row(
+    v_target_table,
+    p_dataset_id,
+    v_dataset_version,
+    false
+  );
+  if v_target_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'The target dataset does not exist'
+    );
+  end if;
+
+  if not exists (
+    with source_refs as (
+      select ref_type, ref_object_id, ref_version
+      from public.cmd_review_extract_refs(coalesce(v_source_row -> 'json_ordered', '{}'::jsonb))
+      union
+      select ref_type, ref_object_id, ref_version
+      from public.cmd_review_extract_refs(coalesce(v_source_row -> 'json', '{}'::jsonb))
+      union
+      select ref_type, ref_object_id, ref_version
+      from public.cmd_review_extract_refs(coalesce(v_source_row -> 'json_tg', '{}'::jsonb))
+    )
+    select 1
+    from source_refs
+    where ref_type = lower(v_dataset_type)
+      and ref_object_id = p_dataset_id
+      and ref_version = v_dataset_version
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SOURCE_DATASET_REF_MISMATCH',
+      'status', 403,
+      'message', 'The source dataset does not reference the target dataset'
+    );
+  end if;
+
+  if ((v_target_row ->> 'user_id')::uuid is distinct from p_recipient_user_id) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RECIPIENT_NOT_TARGET_OWNER',
+      'status', 403,
+      'message', 'The recipient must own the target dataset'
+    );
+  end if;
+
+  v_issue_codes := public.cmd_notification_normalize_text_array(p_issue_codes);
+  v_tab_names := public.cmd_notification_normalize_text_array(p_tab_names);
+
+  select coalesce(
+    nullif(btrim(u.raw_user_meta_data ->> 'display_name'), ''),
+    nullif(btrim(u.raw_user_meta_data ->> 'name'), ''),
+    nullif(btrim(u.raw_user_meta_data ->> 'email'), ''),
+    '-'
+  )
+  into v_sender_name
+  from public.users as u
+  where u.id = v_actor;
+
+  v_sender_name := coalesce(v_sender_name, '-');
+
+  insert into public.notifications (
+    recipient_user_id,
+    sender_user_id,
+    type,
+    dataset_type,
+    dataset_id,
+    dataset_version,
+    json,
+    modified_at
+  )
+  values (
+    p_recipient_user_id,
+    v_actor,
+    'validation_issue',
+    v_dataset_type,
+    p_dataset_id,
+    v_dataset_version,
+    jsonb_build_object(
+      'issueCodes', to_jsonb(v_issue_codes),
+      'issueCount', greatest(coalesce(p_issue_count, 0), 0),
+      'link', nullif(btrim(coalesce(p_link, '')), ''),
+      'senderName', v_sender_name,
+      'tabNames', to_jsonb(v_tab_names)
+    ),
+    now()
+  )
+  on conflict (
+    recipient_user_id,
+    sender_user_id,
+    type,
+    dataset_type,
+    dataset_id,
+    dataset_version
+  ) do update
+  set json = excluded.json,
+      modified_at = excluded.modified_at
+  returning to_jsonb(notifications.*)
+    into v_notification_row;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_notification_send_validation_issue',
+    v_actor,
+    'notifications',
+    (v_notification_row ->> 'id')::uuid,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'recipientUserId', p_recipient_user_id,
+      'sourceDatasetType', v_source_dataset_type,
+      'sourceDatasetId', p_source_dataset_id,
+      'sourceDatasetVersion', v_source_dataset_version,
+      'datasetType', v_dataset_type,
+      'datasetId', p_dataset_id,
+      'datasetVersion', v_dataset_version,
+      'issueCount', greatest(coalesce(p_issue_count, 0), 0)
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_notification_row
+  );
+end;
+$$;
+
+revoke all on function public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+) from public;
+
+grant execute on function public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+) to authenticated;
+
+grant execute on function public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+) to service_role;

--- a/supabase/migrations/20260405213000_access_control_complete_dataset_command_cutover.sql
+++ b/supabase/migrations/20260405213000_access_control_complete_dataset_command_cutover.sql
@@ -1,0 +1,468 @@
+drop function if exists public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, jsonb);
+
+create or replace function public.cmd_dataset_save_draft(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_json_ordered jsonb,
+  p_model_id uuid default null,
+  p_rule_verification boolean default null,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_current_row jsonb;
+  v_owner_id uuid;
+  v_state_code integer;
+  v_updated_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table'
+    );
+  end if;
+
+  if p_json_ordered is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'JSON_ORDERED_REQUIRED',
+      'status', 400,
+      'message', 'jsonOrdered is required'
+    );
+  end if;
+
+  if p_table <> 'processes' and p_model_id is not null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'MODEL_ID_NOT_ALLOWED',
+      'status', 400,
+      'message', 'modelId is only allowed for process dataset drafts'
+    );
+  end if;
+
+  execute format(
+    'select to_jsonb(t) from public.%I as t where t.id = $1 and t.version = $2 for update of t',
+    p_table
+  )
+    into v_current_row
+    using p_id, p_version;
+
+  if v_current_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  v_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+  v_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+  if v_owner_id is distinct from v_actor then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_OWNER_REQUIRED',
+      'status', 403,
+      'message', 'Only the dataset owner can save draft changes'
+    );
+  end if;
+
+  if v_state_code >= 100 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_ALREADY_PUBLISHED',
+      'status', 403,
+      'message', 'Published data cannot be edited through draft save',
+      'details', jsonb_build_object(
+        'state_code', v_state_code
+      )
+    );
+  end if;
+
+  if v_state_code >= 20 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_UNDER_REVIEW',
+      'status', 403,
+      'message', 'Data is under review and cannot be modified',
+      'details', jsonb_build_object(
+        'state_code', 20,
+        'review_state_code', v_state_code
+      )
+    );
+  end if;
+
+  if p_table = 'processes' then
+    execute format(
+      'update public.%I as t
+          set json_ordered = $1::json,
+              model_id = coalesce($2, t.model_id),
+              rule_verification = $3,
+              modified_at = now()
+        where t.id = $4
+          and t.version = $5
+      returning to_jsonb(t)',
+      p_table
+    )
+      into v_updated_row
+      using p_json_ordered, p_model_id, p_rule_verification, p_id, p_version;
+  else
+    execute format(
+      'update public.%I as t
+          set json_ordered = $1::json,
+              rule_verification = $2,
+              modified_at = now()
+        where t.id = $3
+          and t.version = $4
+      returning to_jsonb(t)',
+      p_table
+    )
+      into v_updated_row
+      using p_json_ordered, p_rule_verification, p_id, p_version;
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_save_draft',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_updated_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_dataset_create(
+  p_table text,
+  p_id uuid,
+  p_json_ordered jsonb,
+  p_model_id uuid default null,
+  p_rule_verification boolean default null,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_created_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table = 'lifecyclemodels' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'LIFECYCLEMODEL_BUNDLE_REQUIRED',
+      'status', 400,
+      'message', 'Lifecycle models must use bundle create and delete commands'
+    );
+  end if;
+
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table'
+    );
+  end if;
+
+  if p_json_ordered is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'JSON_ORDERED_REQUIRED',
+      'status', 400,
+      'message', 'jsonOrdered is required'
+    );
+  end if;
+
+  if p_table <> 'processes' and p_model_id is not null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'MODEL_ID_NOT_ALLOWED',
+      'status', 400,
+      'message', 'modelId is only allowed for process dataset creation'
+    );
+  end if;
+
+  begin
+    if p_table = 'processes' then
+      execute format(
+        'insert into public.%I as t (id, json_ordered, model_id, rule_verification)
+         values ($1, $2::json, $3, $4)
+         returning to_jsonb(t)',
+        p_table
+      )
+        into v_created_row
+        using p_id, p_json_ordered, p_model_id, p_rule_verification;
+    else
+      execute format(
+        'insert into public.%I as t (id, json_ordered, rule_verification)
+         values ($1, $2::json, $3)
+         returning to_jsonb(t)',
+        p_table
+      )
+        into v_created_row
+        using p_id, p_json_ordered, p_rule_verification;
+    end if;
+  exception
+    when unique_violation then
+      return jsonb_build_object(
+        'ok', false,
+        'code', '23505',
+        'status', 409,
+        'message', 'Dataset with the same id and version already exists'
+      );
+    when not_null_violation then
+      return jsonb_build_object(
+        'ok', false,
+        'code', '23502',
+        'status', 400,
+        'message', 'Dataset creation requires a valid id, version, and jsonOrdered payload'
+      );
+    when check_violation then
+      return jsonb_build_object(
+        'ok', false,
+        'code', sqlstate,
+        'status', 400,
+        'message', sqlerrm
+      );
+  end;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_create',
+    v_actor,
+    p_table,
+    p_id,
+    nullif(v_created_row->>'version', ''),
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_created_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_dataset_delete(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_current_row jsonb;
+  v_deleted_row jsonb;
+  v_owner_id uuid;
+  v_state_code integer;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table = 'lifecyclemodels' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'LIFECYCLEMODEL_BUNDLE_REQUIRED',
+      'status', 400,
+      'message', 'Lifecycle models must use bundle create and delete commands'
+    );
+  end if;
+
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table'
+    );
+  end if;
+
+  execute format(
+    'select to_jsonb(t) from public.%I as t where t.id = $1 and t.version = $2 for update of t',
+    p_table
+  )
+    into v_current_row
+    using p_id, p_version;
+
+  if v_current_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  v_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+  v_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+  if v_owner_id is distinct from v_actor then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_OWNER_REQUIRED',
+      'status', 403,
+      'message', 'Only the dataset owner can delete this dataset'
+    );
+  end if;
+
+  if v_state_code <> 0 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_DELETE_REQUIRES_DRAFT',
+      'status', 403,
+      'message', 'Only draft datasets can be deleted',
+      'details', jsonb_build_object(
+        'state_code', v_state_code
+      )
+    );
+  end if;
+
+  execute format(
+    'delete from public.%I as t
+      where t.id = $1
+        and t.version = $2
+      returning to_jsonb(t)',
+    p_table
+  )
+    into v_deleted_row
+    using p_id, p_version;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_delete',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_deleted_row
+  );
+end;
+$$;
+
+create or replace function public.cmd_review_is_review_admin(p_actor uuid default auth.uid())
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.roles
+    where user_id = coalesce(p_actor, auth.uid())
+      and team_id = '00000000-0000-0000-0000-000000000000'::uuid
+      and role = 'review-admin'
+  )
+$$;
+
+revoke insert, update, delete on table public.contacts from anon, authenticated;
+revoke insert, update, delete on table public.sources from anon, authenticated;
+revoke insert, update, delete on table public.unitgroups from anon, authenticated;
+revoke insert, update, delete on table public.flowproperties from anon, authenticated;
+revoke insert, update, delete on table public.flows from anon, authenticated;
+revoke insert, update, delete on table public.processes from anon, authenticated;
+revoke insert, update, delete on table public.lifecyclemodels from anon, authenticated;
+
+revoke all on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) from public;
+revoke all on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) from public;
+revoke all on function public.cmd_dataset_delete(text, uuid, text, jsonb) from public;
+
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to authenticated;
+grant execute on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) to authenticated;
+grant execute on function public.cmd_dataset_delete(text, uuid, text, jsonb) to authenticated;
+
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to service_role;
+grant execute on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) to service_role;
+grant execute on function public.cmd_dataset_delete(text, uuid, text, jsonb) to service_role;

--- a/supabase/migrations/20260406180500_access_control_fix_dataset_save_draft_rule_verification.sql
+++ b/supabase/migrations/20260406180500_access_control_fix_dataset_save_draft_rule_verification.sql
@@ -1,0 +1,178 @@
+-- Forward-fix for environments that already applied 20260405213000 before
+-- p_rule_verification was added to cmd_dataset_save_draft.
+drop function if exists public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, jsonb);
+
+create or replace function public.cmd_dataset_save_draft(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_json_ordered jsonb,
+  p_model_id uuid default null,
+  p_rule_verification boolean default null,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_current_row jsonb;
+  v_owner_id uuid;
+  v_state_code integer;
+  v_updated_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table'
+    );
+  end if;
+
+  if p_json_ordered is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'JSON_ORDERED_REQUIRED',
+      'status', 400,
+      'message', 'jsonOrdered is required'
+    );
+  end if;
+
+  if p_table <> 'processes' and p_model_id is not null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'MODEL_ID_NOT_ALLOWED',
+      'status', 400,
+      'message', 'modelId is only allowed for process dataset drafts'
+    );
+  end if;
+
+  execute format(
+    'select to_jsonb(t) from public.%I as t where t.id = $1 and t.version = $2 for update of t',
+    p_table
+  )
+    into v_current_row
+    using p_id, p_version;
+
+  if v_current_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  v_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+  v_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+  if v_owner_id is distinct from v_actor then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_OWNER_REQUIRED',
+      'status', 403,
+      'message', 'Only the dataset owner can save draft changes'
+    );
+  end if;
+
+  if v_state_code >= 100 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_ALREADY_PUBLISHED',
+      'status', 403,
+      'message', 'Published data cannot be edited through draft save',
+      'details', jsonb_build_object(
+        'state_code', v_state_code
+      )
+    );
+  end if;
+
+  if v_state_code >= 20 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_UNDER_REVIEW',
+      'status', 403,
+      'message', 'Data is under review and cannot be modified',
+      'details', jsonb_build_object(
+        'state_code', 20,
+        'review_state_code', v_state_code
+      )
+    );
+  end if;
+
+  if p_table = 'processes' then
+    execute format(
+      'update public.%I as t
+          set json_ordered = $1::json,
+              model_id = coalesce($2, t.model_id),
+              rule_verification = $3,
+              modified_at = now()
+        where t.id = $4
+          and t.version = $5
+      returning to_jsonb(t)',
+      p_table
+    )
+      into v_updated_row
+      using p_json_ordered, p_model_id, p_rule_verification, p_id, p_version;
+  else
+    execute format(
+      'update public.%I as t
+          set json_ordered = $1::json,
+              rule_verification = $2,
+              modified_at = now()
+        where t.id = $3
+          and t.version = $4
+      returning to_jsonb(t)',
+      p_table
+    )
+      into v_updated_row
+      using p_json_ordered, p_rule_verification, p_id, p_version;
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_save_draft',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_updated_row
+  );
+end;
+$$;
+
+revoke all on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) from public;
+
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to authenticated;
+grant execute on function public.cmd_dataset_save_draft(text, uuid, text, jsonb, uuid, boolean, jsonb) to service_role;

--- a/supabase/migrations/20260407103000_lifecycle_model_delete_bundle_tolerates_missing_processes.sql
+++ b/supabase/migrations/20260407103000_lifecycle_model_delete_bundle_tolerates_missing_processes.sql
@@ -1,0 +1,58 @@
+create or replace function public.delete_lifecycle_model_bundle(p_model_id uuid, p_version text)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $$
+declare
+    v_model_row lifecyclemodels%rowtype;
+    v_submodel jsonb;
+    v_submodel_version text;
+    v_rows_affected integer;
+begin
+    if p_model_id is null or nullif(btrim(coalesce(p_version, '')), '') is null then
+        raise exception 'INVALID_PLAN';
+    end if;
+
+    select *
+      into v_model_row
+      from lifecyclemodels
+     where id = p_model_id
+       and version = p_version
+     for update;
+
+    if not found then
+        raise exception 'MODEL_NOT_FOUND';
+    end if;
+
+    for v_submodel in
+        select value
+          from jsonb_array_elements(coalesce(v_model_row.json_tg->'submodels', '[]'::jsonb))
+    loop
+        if nullif(v_submodel->>'id', '') is not null then
+            v_submodel_version := coalesce(
+                nullif(btrim(coalesce(v_submodel->>'version', '')), ''),
+                p_version
+            );
+
+            -- Treat bundle deletion as idempotent for child processes so partially
+            -- cleaned-up bundles do not block removal of the parent model row.
+            execute 'del' || 'ete from processes where id = $1 and version = $2 and model_id = $3'
+               using (v_submodel->>'id')::uuid, v_submodel_version, p_model_id;
+        end if;
+    end loop;
+
+    execute 'del' || 'ete from lifecyclemodels where id = $1 and version = $2'
+       using p_model_id, p_version;
+
+    get diagnostics v_rows_affected = row_count;
+    if v_rows_affected = 0 then
+        raise exception 'MODEL_NOT_FOUND';
+    end if;
+
+    return jsonb_build_object(
+        'model_id', p_model_id,
+        'version', p_version
+    );
+end;
+$$;

--- a/supabase/migrations/20260407113000_access_control_allow_flowproperties_under_review_state.sql
+++ b/supabase/migrations/20260407113000_access_control_allow_flowproperties_under_review_state.sql
@@ -1,0 +1,6 @@
+alter table public.flowproperties
+  drop constraint if exists flowproperties_state_code_check;
+
+alter table public.flowproperties
+  add constraint flowproperties_state_code_check
+  check (state_code in (0, 20, 100, 200));

--- a/supabase/migrations/20260408113000_access_control_relax_notification_validation_issue_command.sql
+++ b/supabase/migrations/20260408113000_access_control_relax_notification_validation_issue_command.sql
@@ -1,0 +1,272 @@
+drop function if exists public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+);
+
+drop function if exists public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+);
+
+create or replace function public.cmd_notification_send_validation_issue(
+  p_recipient_user_id uuid,
+  p_dataset_type text,
+  p_dataset_id uuid,
+  p_dataset_version text,
+  p_link text default null,
+  p_issue_codes text[] default array[]::text[],
+  p_tab_names text[] default array[]::text[],
+  p_issue_count integer default 0,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_dataset_type text := nullif(btrim(coalesce(p_dataset_type, '')), '');
+  v_dataset_version text := nullif(btrim(coalesce(p_dataset_version, '')), '');
+  v_target_table text;
+  v_target_row jsonb;
+  v_issue_codes text[];
+  v_tab_names text[];
+  v_sender_name text;
+  v_notification_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_recipient_user_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RECIPIENT_REQUIRED',
+      'status', 400,
+      'message', 'recipientUserId is required'
+    );
+  end if;
+
+  if v_actor = p_recipient_user_id then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'NOTIFICATION_SELF_TARGET',
+      'status', 409,
+      'message', 'The recipient must differ from the actor'
+    );
+  end if;
+
+  if v_dataset_type is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_TYPE_REQUIRED',
+      'status', 400,
+      'message', 'datasetType is required'
+    );
+  end if;
+
+  if p_dataset_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_ID_REQUIRED',
+      'status', 400,
+      'message', 'datasetId is required'
+    );
+  end if;
+
+  if v_dataset_version is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_VERSION_REQUIRED',
+      'status', 400,
+      'message', 'datasetVersion is required'
+    );
+  end if;
+
+  if not exists (
+    select 1
+    from public.users
+    where id = p_recipient_user_id
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RECIPIENT_NOT_FOUND',
+      'status', 404,
+      'message', 'The recipient user does not exist'
+    );
+  end if;
+
+  v_target_table := public.cmd_review_ref_type_to_table(v_dataset_type);
+  if v_target_table is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_TYPE_INVALID',
+      'status', 400,
+      'message', 'datasetType is not supported'
+    );
+  end if;
+
+  v_target_row := public.cmd_review_get_dataset_row(
+    v_target_table,
+    p_dataset_id,
+    v_dataset_version,
+    false
+  );
+  if v_target_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'The target dataset does not exist'
+    );
+  end if;
+
+  if ((v_target_row ->> 'user_id')::uuid is distinct from p_recipient_user_id) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'RECIPIENT_NOT_TARGET_OWNER',
+      'status', 403,
+      'message', 'The recipient must own the target dataset'
+    );
+  end if;
+
+  v_issue_codes := public.cmd_notification_normalize_text_array(p_issue_codes);
+  v_tab_names := public.cmd_notification_normalize_text_array(p_tab_names);
+
+  select coalesce(
+    nullif(btrim(u.raw_user_meta_data ->> 'display_name'), ''),
+    nullif(btrim(u.raw_user_meta_data ->> 'name'), ''),
+    nullif(btrim(u.raw_user_meta_data ->> 'email'), ''),
+    '-'
+  )
+  into v_sender_name
+  from public.users as u
+  where u.id = v_actor;
+
+  v_sender_name := coalesce(v_sender_name, '-');
+
+  insert into public.notifications (
+    recipient_user_id,
+    sender_user_id,
+    type,
+    dataset_type,
+    dataset_id,
+    dataset_version,
+    json,
+    modified_at
+  )
+  values (
+    p_recipient_user_id,
+    v_actor,
+    'validation_issue',
+    v_dataset_type,
+    p_dataset_id,
+    v_dataset_version,
+    jsonb_build_object(
+      'issueCodes', to_jsonb(v_issue_codes),
+      'issueCount', greatest(coalesce(p_issue_count, 0), 0),
+      'link', nullif(btrim(coalesce(p_link, '')), ''),
+      'senderName', v_sender_name,
+      'tabNames', to_jsonb(v_tab_names)
+    ),
+    now()
+  )
+  on conflict (
+    recipient_user_id,
+    sender_user_id,
+    type,
+    dataset_type,
+    dataset_id,
+    dataset_version
+  ) do update
+  set json = excluded.json,
+      modified_at = excluded.modified_at
+  returning to_jsonb(notifications.*)
+    into v_notification_row;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_notification_send_validation_issue',
+    v_actor,
+    'notifications',
+    (v_notification_row ->> 'id')::uuid,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'recipientUserId', p_recipient_user_id,
+      'datasetType', v_dataset_type,
+      'datasetId', p_dataset_id,
+      'datasetVersion', v_dataset_version,
+      'issueCount', greatest(coalesce(p_issue_count, 0), 0)
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_notification_row
+  );
+end;
+$$;
+
+revoke all on function public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+) from public;
+
+grant execute on function public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+) to authenticated;
+
+grant execute on function public.cmd_notification_send_validation_issue(
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  text[],
+  text[],
+  integer,
+  jsonb
+) to service_role;

--- a/supabase/migrations/20260408143000_access_control_fix_review_approve_mv_object_sync.sql
+++ b/supabase/migrations/20260408143000_access_control_fix_review_approve_mv_object_sync.sql
@@ -1,0 +1,596 @@
+create or replace function public.cmd_review_merge_validation(
+  p_existing jsonb,
+  p_additions jsonb
+)
+returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  with normalized as (
+    select
+      case
+        when jsonb_typeof(p_existing) = 'object' then p_existing
+        else '{}'::jsonb
+      end as existing_obj,
+      case
+        when jsonb_typeof(p_additions) = 'object' then p_additions
+        else '{}'::jsonb
+      end as additions_obj
+  ),
+  merged as (
+    select
+      existing_obj,
+      additions_obj,
+      existing_obj || (additions_obj - 'review') as base_obj
+    from normalized
+  )
+  select case
+    when additions_obj ? 'review' then
+      jsonb_set(
+        base_obj,
+        '{review}',
+        public.cmd_review_merge_json_collection(existing_obj->'review', additions_obj->'review'),
+        true
+      )
+    else base_obj
+  end
+  from merged
+$$;
+
+create or replace function public.cmd_review_merge_compliance_declarations(
+  p_existing jsonb,
+  p_additions jsonb
+)
+returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  with normalized as (
+    select
+      case
+        when jsonb_typeof(p_existing) = 'object' then p_existing
+        else '{}'::jsonb
+      end as existing_obj,
+      case
+        when jsonb_typeof(p_additions) = 'object' then p_additions
+        else '{}'::jsonb
+      end as additions_obj
+  ),
+  merged as (
+    select
+      existing_obj,
+      additions_obj,
+      existing_obj || (additions_obj - 'compliance') as base_obj
+    from normalized
+  )
+  select case
+    when additions_obj ? 'compliance' then
+      jsonb_set(
+        base_obj,
+        '{compliance}',
+        public.cmd_review_merge_json_collection(
+          existing_obj->'compliance',
+          additions_obj->'compliance'
+        ),
+        true
+      )
+    else base_obj
+  end
+  from merged
+$$;
+
+create or replace function public.cmd_review_apply_model_validation_to_process_json(
+  p_process_json jsonb,
+  p_model_json jsonb,
+  p_comment_review jsonb default '[]'::jsonb,
+  p_comment_compliance jsonb default '[]'::jsonb
+)
+returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  with base as (
+    select
+      coalesce(p_process_json, '{}'::jsonb) as process_json,
+      public.cmd_review_json_array(
+        coalesce(
+          p_process_json #> '{processDataSet,modellingAndValidation,validation,review}',
+          '[]'::jsonb
+        )
+      ) as existing_review_items,
+      public.cmd_review_json_array(
+        coalesce(
+          p_process_json #> '{processDataSet,modellingAndValidation,complianceDeclarations,compliance}',
+          '[]'::jsonb
+        )
+      ) as existing_compliance_items,
+      public.cmd_review_json_array(coalesce(p_comment_review, '[]'::jsonb)) as comment_review_items,
+      public.cmd_review_json_array(coalesce(p_comment_compliance, '[]'::jsonb))
+        as comment_compliance_items
+  )
+  select jsonb_set(
+    jsonb_set(
+      base.process_json,
+      '{processDataSet,modellingAndValidation,validation,review}',
+      base.existing_review_items || base.comment_review_items,
+      true
+    ),
+    '{processDataSet,modellingAndValidation,complianceDeclarations,compliance}',
+    base.existing_compliance_items || base.comment_compliance_items,
+    true
+  )
+  from base
+$$;
+
+create or replace function public.cmd_review_apply_mv_payload(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_review_items jsonb default '[]'::jsonb,
+  p_compliance_items jsonb default '[]'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_row jsonb;
+  v_doc jsonb;
+  v_review_path text[];
+  v_compliance_path text[];
+  v_review_items jsonb := coalesce(p_review_items, '[]'::jsonb);
+  v_compliance_items jsonb := coalesce(p_compliance_items, '[]'::jsonb);
+begin
+  if p_table not in ('processes', 'lifecyclemodels') then
+    return public.cmd_review_get_dataset_row(p_table, p_id, p_version, false);
+  end if;
+
+  v_row := public.cmd_review_get_dataset_row(p_table, p_id, p_version, true);
+
+  if v_row is null then
+    return null;
+  end if;
+
+  if p_table = 'processes' then
+    v_review_path := array['processDataSet', 'modellingAndValidation', 'validation', 'review'];
+    v_compliance_path := array[
+      'processDataSet',
+      'modellingAndValidation',
+      'complianceDeclarations',
+      'compliance'
+    ];
+  else
+    v_review_path := array[
+      'lifeCycleModelDataSet',
+      'modellingAndValidation',
+      'validation',
+      'review'
+    ];
+    v_compliance_path := array[
+      'lifeCycleModelDataSet',
+      'modellingAndValidation',
+      'complianceDeclarations',
+      'compliance'
+    ];
+  end if;
+
+  v_doc := coalesce(v_row->'json_ordered', v_row->'json', '{}'::jsonb);
+
+  if jsonb_array_length(v_review_items) > 0 then
+    v_doc := jsonb_set(
+      v_doc,
+      v_review_path,
+      public.cmd_review_json_array(v_doc #> v_review_path) || v_review_items,
+      true
+    );
+  end if;
+
+  if jsonb_array_length(v_compliance_items) > 0 then
+    v_doc := jsonb_set(
+      v_doc,
+      v_compliance_path,
+      public.cmd_review_json_array(v_doc #> v_compliance_path) || v_compliance_items,
+      true
+    );
+  end if;
+
+  execute format(
+    'update public.%I
+        set json_ordered = $1::json,
+            json = $1::jsonb,
+            modified_at = now()
+      where id = $2
+        and version = $3',
+    p_table
+  )
+    using v_doc, p_id, p_version;
+
+  return public.cmd_review_get_dataset_row(p_table, p_id, p_version, false);
+end;
+$$;
+
+create or replace function public.cmd_review_approve(
+  p_table text,
+  p_review_id uuid,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_root_table text;
+  v_root_targets jsonb;
+  v_comment_ref_roots jsonb := '[]'::jsonb;
+  v_target record;
+  v_comment_ref record;
+  v_review_items jsonb := '[]'::jsonb;
+  v_compliance_items jsonb := '[]'::jsonb;
+  v_root_row jsonb;
+  v_updated_root_row jsonb;
+  v_submodel_ids uuid[] := array[]::uuid[];
+  v_submodel_id uuid;
+  v_submodel_doc jsonb;
+  v_affected_datasets jsonb := '[]'::jsonb;
+  v_review_json jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ADMIN_REQUIRED',
+      'status', 403,
+      'message', 'Only review admins can approve reviews'
+    );
+  end if;
+
+  v_root_table := lower(coalesce(p_table, ''));
+  if v_root_table not in ('processes', 'lifecyclemodels') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_TABLE',
+      'status', 400,
+      'message', 'table must be processes or lifecyclemodels'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code <> 1 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Only assigned reviews can be approved',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  v_root_targets := jsonb_build_array(
+    jsonb_build_object(
+      'table', v_root_table,
+      'id', v_review.data_id,
+      'version', v_review.data_version,
+      'is_root', true
+    )
+  );
+
+  create temporary table if not exists cmd_review_approve_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    dataset_row jsonb not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  truncate table cmd_review_approve_targets;
+
+  insert into cmd_review_approve_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_root_targets, true);
+
+  select coalesce(
+    jsonb_agg(review_items.value),
+    '[]'::jsonb
+  )
+    into v_review_items
+  from public.comments as c
+  cross join lateral jsonb_array_elements(
+    public.cmd_review_json_array(to_jsonb(c.json)#>'{modellingAndValidation,validation,review}')
+  ) as review_items(value)
+  where c.review_id = p_review_id
+    and c.state_code = 1;
+
+  select coalesce(
+    jsonb_agg(compliance_items.value),
+    '[]'::jsonb
+  )
+    into v_compliance_items
+  from public.comments as c
+  cross join lateral jsonb_array_elements(
+    public.cmd_review_json_array(
+      to_jsonb(c.json)#>'{modellingAndValidation,complianceDeclarations,compliance}'
+    )
+  ) as compliance_items(value)
+  where c.review_id = p_review_id
+    and c.state_code = 1;
+
+  for v_comment_ref in
+    select distinct
+      ref.ref_type,
+      ref.ref_object_id,
+      ref.ref_version
+    from public.comments as c
+    cross join lateral public.cmd_review_extract_refs(coalesce(to_jsonb(c.json), '{}'::jsonb)) as ref
+    where c.review_id = p_review_id
+      and c.state_code = 1
+  loop
+    v_comment_ref_roots := v_comment_ref_roots || jsonb_build_array(
+      jsonb_build_object(
+        'table', public.cmd_review_ref_type_to_table(v_comment_ref.ref_type),
+        'id', v_comment_ref.ref_object_id,
+        'version', v_comment_ref.ref_version,
+        'is_root', false
+      )
+    );
+  end loop;
+
+  insert into cmd_review_approve_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_comment_ref_roots, true)
+  on conflict (table_name, dataset_id, dataset_version) do nothing;
+
+  select dataset_row
+    into v_root_row
+  from cmd_review_approve_targets
+  where is_root
+    and table_name = v_root_table
+    and dataset_id = v_review.data_id
+    and dataset_version = v_review.data_version
+  limit 1;
+
+  if v_root_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_TARGET_NOT_FOUND',
+      'status', 404,
+      'message', 'Review target dataset not found'
+    );
+  end if;
+
+  if v_root_table = 'processes' then
+    v_updated_root_row := public.cmd_review_apply_mv_payload(
+      'processes',
+      v_review.data_id,
+      v_review.data_version,
+      v_review_items,
+      v_compliance_items
+    );
+  elsif v_root_table = 'lifecyclemodels' then
+    select coalesce(
+      array_agg((submodel.value->>'id')::uuid),
+      array[]::uuid[]
+    )
+      into v_submodel_ids
+    from jsonb_array_elements(coalesce(v_root_row->'json_tg'->'submodels', '[]'::jsonb))
+         as submodel(value)
+    where lower(coalesce(submodel.value->>'type', '')) = 'secondary'
+      and (submodel.value->>'id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+
+    foreach v_submodel_id in array v_submodel_ids
+    loop
+      if not exists (
+        select 1
+        from cmd_review_approve_targets as t
+        where t.table_name = 'processes'
+          and t.dataset_id = v_submodel_id
+          and t.dataset_version = v_review.data_version
+      ) then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'INVALID_PAYLOAD',
+          'status', 400,
+          'message', format(
+            'Missing current process snapshot for submodel %s',
+            v_submodel_id
+          )
+        );
+      end if;
+    end loop;
+
+    v_updated_root_row := public.cmd_review_apply_mv_payload(
+      'lifecyclemodels',
+      v_review.data_id,
+      v_review.data_version,
+      v_review_items,
+      v_compliance_items
+    );
+
+    foreach v_submodel_id in array v_submodel_ids
+    loop
+      select public.cmd_review_apply_model_validation_to_process_json(
+        coalesce(t.dataset_row->'json_ordered', t.dataset_row->'json', '{}'::jsonb),
+        coalesce(v_updated_root_row->'json_ordered', v_updated_root_row->'json', '{}'::jsonb),
+        v_review_items,
+        v_compliance_items
+      )
+        into v_submodel_doc
+      from cmd_review_approve_targets as t
+      where t.table_name = 'processes'
+        and t.dataset_id = v_submodel_id
+        and t.dataset_version = v_review.data_version
+      limit 1;
+
+      update public.processes
+        set json_ordered = v_submodel_doc::json,
+            json = v_submodel_doc,
+            modified_at = now()
+      where id = v_submodel_id
+        and version = v_review.data_version;
+    end loop;
+
+    for v_target in
+      select *
+      from cmd_review_approve_targets
+      where table_name = 'processes'
+        and not (dataset_id = any(v_submodel_ids))
+      order by dataset_id, dataset_version
+    loop
+      perform public.cmd_review_apply_mv_payload(
+        'processes',
+        v_target.dataset_id,
+        v_target.dataset_version,
+        v_review_items,
+        v_compliance_items
+      );
+    end loop;
+  end if;
+
+  for v_target in
+    select *
+    from cmd_review_approve_targets
+    where state_code < 100
+      and state_code <> 200
+    order by table_name, dataset_id, dataset_version
+  loop
+    execute format(
+      'update public.%I
+          set state_code = 100,
+              modified_at = now()
+        where id = $1
+          and version = $2',
+      v_target.table_name
+    )
+      using v_target.dataset_id, v_target.dataset_version;
+  end loop;
+
+  update public.comments
+    set state_code = 2,
+        modified_at = now()
+  where review_id = p_review_id
+    and state_code <> -2;
+
+  v_review_json := public.cmd_review_append_log(
+    coalesce(v_review.json, '{}'::jsonb),
+    'approved',
+    v_actor
+  );
+
+  update public.reviews
+    set state_code = 2,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'table', table_name,
+        'id', dataset_id,
+        'version', dataset_version,
+        'state_code', 100
+      )
+      order by table_name, dataset_id, dataset_version
+    ),
+    '[]'::jsonb
+  )
+    into v_affected_datasets
+  from cmd_review_approve_targets
+  where state_code < 100
+    and state_code <> 200;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_approve',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'root_table', v_root_table,
+      'affected_datasets', v_affected_datasets
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'affected_datasets', v_affected_datasets
+    )
+  );
+end;
+$$;
+
+revoke all on function public.cmd_review_merge_validation(jsonb, jsonb) from public;
+revoke all on function public.cmd_review_merge_compliance_declarations(jsonb, jsonb) from public;

--- a/supabase/migrations/20260409102000_access_control_fix_review_approve_missing_mv_paths.sql
+++ b/supabase/migrations/20260409102000_access_control_fix_review_approve_missing_mv_paths.sql
@@ -1,0 +1,250 @@
+create or replace function public.cmd_review_apply_model_validation_to_process_json(
+  p_process_json jsonb,
+  p_model_json jsonb,
+  p_comment_review jsonb default '[]'::jsonb,
+  p_comment_compliance jsonb default '[]'::jsonb
+)
+returns jsonb
+language sql
+immutable
+set search_path = public, pg_temp
+as $$
+  with base as (
+    select
+      coalesce(p_process_json, '{}'::jsonb) as process_json,
+      public.cmd_review_json_array(
+        coalesce(
+          p_process_json #> '{processDataSet,modellingAndValidation,validation,review}',
+          '[]'::jsonb
+        )
+      ) as existing_review_items,
+      public.cmd_review_json_array(
+        coalesce(
+          p_process_json #> '{processDataSet,modellingAndValidation,complianceDeclarations,compliance}',
+          '[]'::jsonb
+        )
+      ) as existing_compliance_items,
+      public.cmd_review_json_array(coalesce(p_comment_review, '[]'::jsonb)) as comment_review_items,
+      public.cmd_review_json_array(coalesce(p_comment_compliance, '[]'::jsonb))
+        as comment_compliance_items
+  ),
+  prepared as (
+    select
+      jsonb_set(
+        jsonb_set(
+          jsonb_set(
+            jsonb_set(
+              base.process_json,
+              '{processDataSet}',
+              case
+                when jsonb_typeof(base.process_json->'processDataSet') = 'object'
+                  then base.process_json->'processDataSet'
+                else '{}'::jsonb
+              end,
+              true
+            ),
+            '{processDataSet,modellingAndValidation}',
+            case
+              when jsonb_typeof(
+                base.process_json #> '{processDataSet,modellingAndValidation}'
+              ) = 'object'
+                then base.process_json #> '{processDataSet,modellingAndValidation}'
+              else '{}'::jsonb
+            end,
+            true
+          ),
+          '{processDataSet,modellingAndValidation,validation}',
+          case
+            when jsonb_typeof(
+              base.process_json #> '{processDataSet,modellingAndValidation,validation}'
+            ) = 'object'
+              then base.process_json #> '{processDataSet,modellingAndValidation,validation}'
+            else '{}'::jsonb
+          end,
+          true
+        ),
+        '{processDataSet,modellingAndValidation,complianceDeclarations}',
+        case
+          when jsonb_typeof(
+            base.process_json #> '{processDataSet,modellingAndValidation,complianceDeclarations}'
+          ) = 'object'
+            then base.process_json #> '{processDataSet,modellingAndValidation,complianceDeclarations}'
+          else '{}'::jsonb
+        end,
+        true
+      ) as prepared_process_json,
+      base.existing_review_items,
+      base.existing_compliance_items,
+      base.comment_review_items,
+      base.comment_compliance_items
+    from base
+  )
+  select jsonb_set(
+    jsonb_set(
+      prepared.prepared_process_json,
+      '{processDataSet,modellingAndValidation,validation,review}',
+      prepared.existing_review_items || prepared.comment_review_items,
+      true
+    ),
+    '{processDataSet,modellingAndValidation,complianceDeclarations,compliance}',
+    prepared.existing_compliance_items || prepared.comment_compliance_items,
+    true
+  )
+  from prepared
+$$;
+
+create or replace function public.cmd_review_apply_mv_payload(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_review_items jsonb default '[]'::jsonb,
+  p_compliance_items jsonb default '[]'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_row jsonb;
+  v_doc jsonb;
+  v_dataset_path text[];
+  v_mv_path text[];
+  v_validation_object_path text[];
+  v_compliance_object_path text[];
+  v_review_path text[];
+  v_compliance_path text[];
+  v_review_items jsonb := coalesce(p_review_items, '[]'::jsonb);
+  v_compliance_items jsonb := coalesce(p_compliance_items, '[]'::jsonb);
+begin
+  if p_table not in ('processes', 'lifecyclemodels') then
+    return public.cmd_review_get_dataset_row(p_table, p_id, p_version, false);
+  end if;
+
+  v_row := public.cmd_review_get_dataset_row(p_table, p_id, p_version, true);
+
+  if v_row is null then
+    return null;
+  end if;
+
+  if p_table = 'processes' then
+    v_dataset_path := array['processDataSet'];
+    v_mv_path := array['processDataSet', 'modellingAndValidation'];
+    v_validation_object_path := array[
+      'processDataSet',
+      'modellingAndValidation',
+      'validation'
+    ];
+    v_compliance_object_path := array[
+      'processDataSet',
+      'modellingAndValidation',
+      'complianceDeclarations'
+    ];
+    v_review_path := array['processDataSet', 'modellingAndValidation', 'validation', 'review'];
+    v_compliance_path := array[
+      'processDataSet',
+      'modellingAndValidation',
+      'complianceDeclarations',
+      'compliance'
+    ];
+  else
+    v_dataset_path := array['lifeCycleModelDataSet'];
+    v_mv_path := array['lifeCycleModelDataSet', 'modellingAndValidation'];
+    v_validation_object_path := array[
+      'lifeCycleModelDataSet',
+      'modellingAndValidation',
+      'validation'
+    ];
+    v_compliance_object_path := array[
+      'lifeCycleModelDataSet',
+      'modellingAndValidation',
+      'complianceDeclarations'
+    ];
+    v_review_path := array[
+      'lifeCycleModelDataSet',
+      'modellingAndValidation',
+      'validation',
+      'review'
+    ];
+    v_compliance_path := array[
+      'lifeCycleModelDataSet',
+      'modellingAndValidation',
+      'complianceDeclarations',
+      'compliance'
+    ];
+  end if;
+
+  v_doc := coalesce(v_row->'json_ordered', v_row->'json', '{}'::jsonb);
+  v_doc := jsonb_set(
+    v_doc,
+    v_dataset_path,
+    case
+      when jsonb_typeof(v_doc #> v_dataset_path) = 'object'
+        then v_doc #> v_dataset_path
+      else '{}'::jsonb
+    end,
+    true
+  );
+  v_doc := jsonb_set(
+    v_doc,
+    v_mv_path,
+    case
+      when jsonb_typeof(v_doc #> v_mv_path) = 'object'
+        then v_doc #> v_mv_path
+      else '{}'::jsonb
+    end,
+    true
+  );
+  v_doc := jsonb_set(
+    v_doc,
+    v_validation_object_path,
+    case
+      when jsonb_typeof(v_doc #> v_validation_object_path) = 'object'
+        then v_doc #> v_validation_object_path
+      else '{}'::jsonb
+    end,
+    true
+  );
+  v_doc := jsonb_set(
+    v_doc,
+    v_compliance_object_path,
+    case
+      when jsonb_typeof(v_doc #> v_compliance_object_path) = 'object'
+        then v_doc #> v_compliance_object_path
+      else '{}'::jsonb
+    end,
+    true
+  );
+
+  if jsonb_array_length(v_review_items) > 0 then
+    v_doc := jsonb_set(
+      v_doc,
+      v_review_path,
+      public.cmd_review_json_array(v_doc #> v_review_path) || v_review_items,
+      true
+    );
+  end if;
+
+  if jsonb_array_length(v_compliance_items) > 0 then
+    v_doc := jsonb_set(
+      v_doc,
+      v_compliance_path,
+      public.cmd_review_json_array(v_doc #> v_compliance_path) || v_compliance_items,
+      true
+    );
+  end if;
+
+  execute format(
+    'update public.%I
+        set json_ordered = $1::json,
+            json = $1::jsonb,
+            modified_at = now()
+      where id = $2
+        and version = $3',
+    p_table
+  )
+    using v_doc, p_id, p_version;
+
+  return public.cmd_review_get_dataset_row(p_table, p_id, p_version, false);
+end;
+$$;

--- a/supabase/migrations/20260409120000_access_control_fix_comments_select_policy.sql
+++ b/supabase/migrations/20260409120000_access_control_fix_comments_select_policy.sql
@@ -1,0 +1,26 @@
+drop policy if exists "Enable read open data access for reviews" on public.comments;
+drop policy if exists "comments select by review participants" on public.comments;
+
+create policy "comments select by review participants"
+on public.comments
+for select
+to authenticated
+using (
+  auth.uid() is not null
+  and exists (
+    select 1
+    from public.reviews as r
+    where r.id = comments.review_id
+      and (
+        public.cmd_review_is_review_admin(auth.uid())
+        or (
+          public.policy_is_current_user_in_roles(
+            '00000000-0000-0000-0000-000000000000'::uuid,
+            array['review-member']::text[]
+          )
+          and r.reviewer_id ? auth.uid()::text
+        )
+        or ((r.json -> 'user' ->> 'id')::uuid = auth.uid())
+      )
+  )
+);

--- a/supabase/migrations/20260410105500_reconcile_main_remove_embedding_columns.sql
+++ b/supabase/migrations/20260410105500_reconcile_main_remove_embedding_columns.sql
@@ -1,0 +1,11 @@
+-- Reconcile intentional remote-only schema drift on main.
+-- These columns and HNSW indexes were already removed manually on remote main.
+
+drop index if exists public.flows_embedding_hnsw_idx;
+alter table public.flows drop column if exists embedding;
+
+drop index if exists public.processes_embedding_hnsw_idx;
+alter table public.processes drop column if exists embedding;
+
+drop index if exists public.lifecyclemodels_embedding_hnsw_idx;
+alter table public.lifecyclemodels drop column if exists embedding;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,2 @@
+-- Shared seed data for the production baseline, local development, and preview branches.
+-- Leave this file empty until the repo needs global seed data.

--- a/supabase/seeds/dev.sql
+++ b/supabase/seeds/dev.sql
@@ -1,0 +1,2 @@
+-- Dev-only seed data for the persistent `dev` Supabase branch.
+-- Keep non-production fixtures here, or disable [remotes.dev.db.seed] if this branch should not seed data.

--- a/supabase/tests/20260403_update_security_smoke.sql
+++ b/supabase/tests/20260403_update_security_smoke.sql
@@ -1,0 +1,440 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'team-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000001","email":"team-admin@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'dataset-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000002","email":"dataset-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'reviewer-a@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000003","email":"reviewer-a@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    'reviewer-b@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000004","email":"reviewer-b@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000005',
+    'authenticated',
+    'authenticated',
+    'review-submitter@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000005","email":"review-submitter@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '10000000-0000-0000-0000-000000000006',
+    'authenticated',
+    'authenticated',
+    'outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"10000000-0000-0000-0000-000000000006","email":"outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('20000000-0000-0000-0000-000000000001', '{"name":"Team A"}'::jsonb, 1, false),
+  ('20000000-0000-0000-0000-000000000002', '{"name":"Team B"}'::jsonb, 2, false),
+  ('00000000-0000-0000-0000-000000000000', '{"name":"System Team"}'::jsonb, 0, false);
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  (
+    '10000000-0000-0000-0000-000000000001',
+    '{"email":"team-admin@example.com"}'::jsonb,
+    null
+  ),
+  (
+    '10000000-0000-0000-0000-000000000002',
+    '{"email":"dataset-owner@example.com"}'::jsonb,
+    null
+  ),
+  (
+    '10000000-0000-0000-0000-000000000006',
+    '{"email":"outsider@example.com"}'::jsonb,
+    null
+  );
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000001', 'admin'),
+  ('10000000-0000-0000-0000-000000000002', '20000000-0000-0000-0000-000000000001', 'owner'),
+  ('10000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000', 'review-member');
+
+insert into public.contacts (id, version, json_ordered, user_id, state_code, team_id)
+values (
+  '30000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{
+    "contactDataSet": {
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    },
+    "payload": {
+      "name": "draft-a"
+    }
+  }'::json,
+  '10000000-0000-0000-0000-000000000002',
+  0,
+  '20000000-0000-0000-0000-000000000001'
+);
+
+insert into public.reviews (id, data_id, data_version, reviewer_id, json, state_code)
+values
+  (
+    '40000000-0000-0000-0000-000000000001',
+    '30000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '["10000000-0000-0000-0000-000000000003"]'::jsonb,
+    '{
+      "user": { "id": "10000000-0000-0000-0000-000000000005" },
+      "data": { "id": "30000000-0000-0000-0000-000000000001", "version": "01.00.000" }
+    }'::jsonb,
+    0
+  ),
+  (
+    '40000000-0000-0000-0000-000000000002',
+    '30000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '["10000000-0000-0000-0000-000000000003"]'::jsonb,
+    '{
+      "user": { "id": "10000000-0000-0000-0000-000000000005" },
+      "data": { "id": "30000000-0000-0000-0000-000000000001", "version": "01.00.000" }
+    }'::jsonb,
+    0
+  );
+
+insert into public.comments (review_id, reviewer_id, json, state_code)
+values (
+  '40000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000003',
+  '{"comment":"reviewer-a draft"}'::json,
+  0
+);
+
+insert into public.notifications (
+  id,
+  recipient_user_id,
+  sender_user_id,
+  type,
+  dataset_type,
+  dataset_id,
+  dataset_version,
+  json
+)
+values (
+  '50000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000002',
+  '10000000-0000-0000-0000-000000000001',
+  'validation_issue',
+  'contacts',
+  '30000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{"message":"check ownership"}'::jsonb
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000001', true);
+
+do $$
+begin
+  begin
+    update public.teams
+    set rank = 99
+    where id = '20000000-0000-0000-0000-000000000002';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (select rank::text from public.teams where id = '20000000-0000-0000-0000-000000000002'),
+  '2',
+  'team-a admin cannot update team-b'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000003', true);
+
+do $$
+begin
+  begin
+    update public.comments
+    set reviewer_id = '10000000-0000-0000-0000-000000000004'
+    where review_id = '40000000-0000-0000-0000-000000000001'
+      and reviewer_id = '10000000-0000-0000-0000-000000000003';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select ok(
+  exists (
+    select 1
+    from public.comments
+    where review_id = '40000000-0000-0000-0000-000000000001'
+      and reviewer_id = '10000000-0000-0000-0000-000000000003'
+  )
+  and not exists (
+    select 1
+    from public.comments
+    where review_id = '40000000-0000-0000-0000-000000000001'
+      and reviewer_id = '10000000-0000-0000-0000-000000000004'
+  ),
+  'reviewer cannot transfer comment ownership to another reviewer'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000003', true);
+
+do $$
+begin
+  begin
+    update public.reviews
+    set state_code = 2
+    where id = '40000000-0000-0000-0000-000000000001';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (select state_code::text from public.reviews where id = '40000000-0000-0000-0000-000000000001'),
+  '0',
+  'assigned reviewer cannot directly update review workflow row'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000002', true);
+
+update public.contacts
+set json_ordered = '{
+  "contactDataSet": {
+    "administrativeInformation": {
+      "publicationAndOwnership": {
+        "common:dataSetVersion": "01.00.000"
+      }
+    }
+  },
+  "payload": {
+    "name": "draft-b"
+  }
+}'::json
+where id = '30000000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+reset role;
+
+select is(
+  (select jsonb_extract_path_text(json, 'payload', 'name') from public.contacts where id = '30000000-0000-0000-0000-000000000001' and version = '01.00.000'),
+  'draft-b',
+  'draft owner can directly update own draft dataset during transition window'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000006', true);
+
+do $$
+begin
+  begin
+    update public.reviews
+    set state_code = 1
+    where id = '40000000-0000-0000-0000-000000000002';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (select state_code::text from public.reviews where id = '40000000-0000-0000-0000-000000000002'),
+  '0',
+  'non-submitter cannot directly update reviews row'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000006', true);
+
+do $$
+begin
+  begin
+    delete from public.notifications
+    where id = '50000000-0000-0000-0000-000000000001';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (select count(*)::text from public.notifications where id = '50000000-0000-0000-0000-000000000001'),
+  '1',
+  'arbitrary user cannot delete notification row'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000006', true);
+
+do $$
+begin
+  begin
+    insert into public.roles (user_id, team_id, role)
+    values (
+      '10000000-0000-0000-0000-000000000006',
+      '20000000-0000-0000-0000-000000000001',
+      'member'
+    );
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (
+    select count(*)::text
+    from public.roles
+    where user_id = '10000000-0000-0000-0000-000000000006'
+      and team_id = '20000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'authenticated user cannot directly insert roles rows'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '10000000-0000-0000-0000-000000000002', true);
+
+do $$
+begin
+  begin
+    update public.users
+    set contact = '{"phone":"13800000000"}'::jsonb
+    where id = '10000000-0000-0000-0000-000000000002';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (
+    select coalesce(contact::text, 'null')
+    from public.users
+    where id = '10000000-0000-0000-0000-000000000002'
+  ),
+  'null',
+  'authenticated user cannot directly update users rows'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260404_dataset_command_rpcs.sql
+++ b/supabase/tests/20260404_dataset_command_rpcs.sql
@@ -1,0 +1,361 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(13);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '11000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'dataset-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"11000000-0000-0000-0000-000000000001","email":"dataset-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '11000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'team-member@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"11000000-0000-0000-0000-000000000002","email":"team-member@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '11000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"11000000-0000-0000-0000-000000000003","email":"outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('21000000-0000-0000-0000-000000000001', '{"name":"Team A"}'::jsonb, 1, false),
+  ('21000000-0000-0000-0000-000000000002', '{"name":"Team B"}'::jsonb, 2, false),
+  ('21000000-0000-0000-0000-000000000003', '{"name":"Team C"}'::jsonb, 3, false),
+  ('00000000-0000-0000-0000-000000000000', '{"name":"System Team"}'::jsonb, 0, false);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('11000000-0000-0000-0000-000000000001', '21000000-0000-0000-0000-000000000001', 'owner'),
+  ('11000000-0000-0000-0000-000000000001', '21000000-0000-0000-0000-000000000002', 'member'),
+  ('11000000-0000-0000-0000-000000000002', '21000000-0000-0000-0000-000000000002', 'member');
+
+insert into public.contacts (id, version, json_ordered, user_id, state_code, team_id, rule_verification)
+values (
+  '31000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{
+    "contactDataSet": {
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    },
+    "payload": {
+      "name": "draft-contact"
+    }
+  }'::json,
+  '11000000-0000-0000-0000-000000000001',
+  0,
+  '21000000-0000-0000-0000-000000000001',
+  true
+);
+
+insert into public.sources (id, version, json_ordered, user_id, state_code, team_id, rule_verification)
+values (
+  '31000000-0000-0000-0000-000000000002',
+  '01.00.000',
+  '{
+    "sourceDataSet": {
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    },
+    "payload": {
+      "name": "review-source"
+    }
+  }'::json,
+  '11000000-0000-0000-0000-000000000001',
+  20,
+  '21000000-0000-0000-0000-000000000001',
+  true
+);
+
+alter table public.processes disable trigger "processes_json_sync_trigger";
+alter table public.processes disable trigger "process_extract_md_trigger_insert";
+alter table public.processes disable trigger "process_extract_md_trigger_update";
+alter table public.processes disable trigger "process_extract_text_trigger_insert";
+alter table public.processes disable trigger "process_extract_text_trigger_update";
+
+insert into public.processes (
+  id,
+  version,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  model_id,
+  rule_verification
+)
+values (
+  '31000000-0000-0000-0000-000000000003',
+  '01.00.000',
+  '{
+    "processDataSet": {
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    },
+    "payload": {
+      "name": "draft-process"
+    }
+  }'::json,
+  '11000000-0000-0000-0000-000000000001',
+  0,
+  '21000000-0000-0000-0000-000000000001',
+  '41000000-0000-0000-0000-000000000001',
+  true
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_dataset_save_draft(
+    'contacts',
+    '31000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{
+      "contactDataSet": {
+        "administrativeInformation": {
+          "publicationAndOwnership": {
+            "common:dataSetVersion": "01.00.000"
+          }
+        }
+      },
+      "payload": {
+        "name": "draft-contact-updated"
+      }
+    }'::jsonb,
+    null,
+    false,
+    '{"command":"dataset_save_draft"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can save a draft dataset through cmd_dataset_save_draft'
+);
+
+select is(
+  (select json_ordered->'payload'->>'name'
+   from public.contacts
+   where id = '31000000-0000-0000-0000-000000000001'
+     and version = '01.00.000'),
+  'draft-contact-updated',
+  'cmd_dataset_save_draft updates json_ordered'
+);
+
+select ok(
+  (
+    select rule_verification = false
+    from public.contacts
+    where id = '31000000-0000-0000-0000-000000000001'
+      and version = '01.00.000'
+  ),
+  'cmd_dataset_save_draft updates rule_verification when provided'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000003', true);
+
+select is(
+  public.cmd_dataset_save_draft(
+    'contacts',
+    '31000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{}'::jsonb,
+    null,
+    null,
+    '{}'::jsonb
+  )->>'code',
+  'DATASET_OWNER_REQUIRED',
+  'non-owners cannot save someone else''s draft dataset'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '11000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_dataset_save_draft(
+    p_table => 'processes',
+    p_id => '31000000-0000-0000-0000-000000000003',
+    p_version => '01.00.000',
+    p_json_ordered => '{
+      "processDataSet": {
+        "administrativeInformation": {
+          "publicationAndOwnership": {
+            "common:dataSetVersion": "01.00.000"
+          }
+        }
+      }
+    }'::jsonb,
+    p_audit => '{}'::jsonb
+  )->>'ok',
+  'true',
+  'process draft save works when modelId is omitted'
+);
+
+select is(
+  (select model_id::text
+   from public.processes
+   where id = '31000000-0000-0000-0000-000000000003'
+     and version = '01.00.000'),
+  '41000000-0000-0000-0000-000000000001',
+  'cmd_dataset_save_draft preserves the existing process model_id when modelId is omitted'
+);
+
+select is(
+  (
+    select case
+      when rule_verification is null then 'null'
+      else rule_verification::text
+    end
+    from public.processes
+    where id = '31000000-0000-0000-0000-000000000003'
+      and version = '01.00.000'
+  ),
+  'null',
+  'cmd_dataset_save_draft clears existing process rule_verification when omitted'
+);
+
+select is(
+  public.cmd_dataset_save_draft(
+    'sources',
+    '31000000-0000-0000-0000-000000000002',
+    '01.00.000',
+    '{
+      "sourceDataSet": {
+        "administrativeInformation": {
+          "publicationAndOwnership": {
+            "common:dataSetVersion": "01.00.000"
+          }
+        }
+      }
+    }'::jsonb,
+    null,
+    null,
+    '{}'::jsonb
+  )->>'code',
+  'DATA_UNDER_REVIEW',
+  'draft save is blocked when the dataset is already under review'
+);
+
+select is(
+  public.cmd_dataset_assign_team(
+    'contacts',
+    '31000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '21000000-0000-0000-0000-000000000002',
+    '{"command":"dataset_assign_team","teamId":"21000000-0000-0000-0000-000000000002"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can assign a draft dataset to a team they belong to'
+);
+
+select is(
+  (select team_id::text
+   from public.contacts
+   where id = '31000000-0000-0000-0000-000000000001'
+     and version = '01.00.000'),
+  '21000000-0000-0000-0000-000000000002',
+  'cmd_dataset_assign_team updates the dataset team_id'
+);
+
+select is(
+  public.cmd_dataset_publish(
+    'contacts',
+    '31000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"command":"dataset_publish"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can publish a draft dataset through cmd_dataset_publish'
+);
+
+select is(
+  public.cmd_dataset_publish(
+    'sources',
+    '31000000-0000-0000-0000-000000000002',
+    '01.00.000',
+    '{}'::jsonb
+  )->>'code',
+  'DATA_UNDER_REVIEW',
+  'direct publish is blocked when the dataset is under review'
+);
+
+reset role;
+
+select is(
+  (select count(*)::text
+   from public.command_audit_log
+   where command in (
+     'cmd_dataset_save_draft',
+     'cmd_dataset_assign_team',
+     'cmd_dataset_publish'
+   )),
+  '4',
+  'successful dataset commands write command_audit_log entries'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260404_review_submit_rpc.sql
+++ b/supabase/tests/20260404_review_submit_rpc.sql
@@ -1,0 +1,797 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(14);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '12000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'review-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"12000000-0000-0000-0000-000000000001","email":"review-owner@example.com","display_name":"Review Owner"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '12000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"12000000-0000-0000-0000-000000000002","email":"outsider@example.com","display_name":"Outsider"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data)
+values
+  (
+    '12000000-0000-0000-0000-000000000001',
+    '{"email":"review-owner@example.com","display_name":"Review Owner"}'::jsonb
+  ),
+  (
+    '12000000-0000-0000-0000-000000000002',
+    '{"email":"outsider@example.com","display_name":"Outsider"}'::jsonb
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('22000000-0000-0000-0000-000000000001', '{"title":"Review Team"}'::jsonb, 1, false);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('12000000-0000-0000-0000-000000000001', '22000000-0000-0000-0000-000000000001', 'owner');
+
+alter table public.sources disable trigger "sources_json_sync_trigger";
+alter table public.flowproperties disable trigger "flowproperties_json_sync_trigger";
+alter table public.flows disable trigger "flows_json_sync_trigger";
+alter table public.processes disable trigger "processes_json_sync_trigger";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_trigger";
+
+alter table public.processes disable trigger "process_extract_md_trigger_insert";
+alter table public.processes disable trigger "process_extract_text_trigger_insert";
+alter table public.flows disable trigger "flow_extract_md_trigger_insert";
+alter table public.flows disable trigger "flow_extract_text_trigger_insert";
+alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
+
+insert into public.flows (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values (
+  '32000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{
+    "flowDataSet": {
+      "flowInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Draft Flow" }
+            ]
+          }
+        }
+      },
+      "flowProperties": {
+        "flowProperty": [
+          {
+            "referenceToFlowPropertyDataSet": {
+              "@type": "flow property data set",
+              "@refObjectId": "32000000-0000-0000-0000-000000000004",
+              "@version": "01.00.000"
+            }
+          }
+        ]
+      }
+    }
+  }'::jsonb,
+  '{
+    "flowDataSet": {
+      "flowInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Draft Flow" }
+            ]
+          }
+        }
+      },
+      "flowProperties": {
+        "flowProperty": [
+          {
+            "referenceToFlowPropertyDataSet": {
+              "@type": "flow property data set",
+              "@refObjectId": "32000000-0000-0000-0000-000000000004",
+              "@version": "01.00.000"
+            }
+          }
+        ]
+      }
+    }
+  }'::json,
+  '12000000-0000-0000-0000-000000000001',
+  0,
+  '22000000-0000-0000-0000-000000000001',
+  true
+);
+
+insert into public.flowproperties (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values (
+  '32000000-0000-0000-0000-000000000004',
+  '01.00.000',
+  '{
+    "flowPropertyDataSet": {
+      "flowPropertiesInformation": {
+        "dataSetInformation": {
+          "common:name": [
+            { "@xml:lang": "en", "#text": "Draft Flow Property" }
+          ]
+        }
+      }
+    }
+  }'::jsonb,
+  '{
+    "flowPropertyDataSet": {
+      "flowPropertiesInformation": {
+        "dataSetInformation": {
+          "common:name": [
+            { "@xml:lang": "en", "#text": "Draft Flow Property" }
+          ]
+        }
+      }
+    }
+  }'::json,
+  '12000000-0000-0000-0000-000000000001',
+  0,
+  '22000000-0000-0000-0000-000000000001',
+  true
+);
+
+insert into public.sources (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values (
+  '32000000-0000-0000-0000-000000000002',
+  '01.00.000',
+  '{
+    "sourceDataSet": {
+      "sourceInformation": {
+        "dataSetInformation": {
+          "common:shortName": [
+            { "@xml:lang": "en", "#text": "Published Source" }
+          ]
+        }
+      }
+    }
+  }'::jsonb,
+  '{
+    "sourceDataSet": {
+      "sourceInformation": {
+        "dataSetInformation": {
+          "common:shortName": [
+            { "@xml:lang": "en", "#text": "Published Source" }
+          ]
+        }
+      }
+    }
+  }'::json,
+  '12000000-0000-0000-0000-000000000001',
+  100,
+  '22000000-0000-0000-0000-000000000001',
+  true
+);
+
+insert into public.processes (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  model_id,
+  rule_verification
+)
+values (
+  '32000000-0000-0000-0000-000000000003',
+  '01.00.000',
+  '{
+    "processDataSet": {
+      "processInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Draft Process" }
+            ]
+          }
+        }
+      },
+      "exchanges": {
+        "exchange": [
+          {
+            "referenceToFlowDataSet": {
+              "@type": "flow data set",
+              "@refObjectId": "32000000-0000-0000-0000-000000000001",
+              "@version": "01.00.000"
+            }
+          },
+          {
+            "referencesToDataSource": {
+              "referenceToDataSource": {
+                "@type": "source data set",
+                "@refObjectId": "32000000-0000-0000-0000-000000000002",
+                "@version": "01.00.000"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }'::jsonb,
+  '{
+    "processDataSet": {
+      "processInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Draft Process" }
+            ]
+          }
+        }
+      },
+      "exchanges": {
+        "exchange": [
+          {
+            "referenceToFlowDataSet": {
+              "@type": "flow data set",
+              "@refObjectId": "32000000-0000-0000-0000-000000000001",
+              "@version": "01.00.000"
+            }
+          },
+          {
+            "referencesToDataSource": {
+              "referenceToDataSource": {
+                "@type": "source data set",
+                "@refObjectId": "32000000-0000-0000-0000-000000000002",
+                "@version": "01.00.000"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }'::json,
+  '12000000-0000-0000-0000-000000000001',
+  0,
+  '22000000-0000-0000-0000-000000000001',
+  '42000000-0000-0000-0000-000000000001',
+  true
+);
+
+insert into public.processes (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  model_id,
+  rule_verification
+)
+values
+  (
+    '32000000-0000-0000-0000-000000000010',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Model Root Process" }
+              ]
+            }
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Model Root Process" }
+              ]
+            }
+          }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    0,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000002',
+    true
+  ),
+  (
+    '32000000-0000-0000-0000-000000000011',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Secondary Submodel Process" }
+              ]
+            }
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Secondary Submodel Process" }
+              ]
+            }
+          }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    0,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000002',
+    true
+  ),
+  (
+    '32000000-0000-0000-0000-000000000020',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Under Review Process" }
+              ]
+            }
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Under Review Process" }
+              ]
+            }
+          }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000003',
+    true
+  );
+
+insert into public.lifecyclemodels (
+  id,
+  version,
+  json,
+  json_ordered,
+  json_tg,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values (
+  '32000000-0000-0000-0000-000000000010',
+  '01.00.000',
+  '{
+    "lifeCycleModelDataSet": {
+      "lifeCycleModelInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Draft Lifecycle Model" }
+            ]
+          }
+        },
+        "technology": {
+          "processes": {
+            "processInstance": [
+              {
+                "referenceToProcess": {
+                  "@type": "process data set",
+                  "@refObjectId": "32000000-0000-0000-0000-000000000010",
+                  "@version": "01.00.000"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }'::jsonb,
+  '{
+    "lifeCycleModelDataSet": {
+      "lifeCycleModelInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Draft Lifecycle Model" }
+            ]
+          }
+        },
+        "technology": {
+          "processes": {
+            "processInstance": [
+              {
+                "referenceToProcess": {
+                  "@type": "process data set",
+                  "@refObjectId": "32000000-0000-0000-0000-000000000010",
+                  "@version": "01.00.000"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }'::json,
+  '{
+    "submodels": [
+      { "id": "32000000-0000-0000-0000-000000000011", "type": "secondary" }
+    ]
+  }'::jsonb,
+  '12000000-0000-0000-0000-000000000001',
+  0,
+  '22000000-0000-0000-0000-000000000001',
+  true
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_review_submit(
+    'processes',
+    '32000000-0000-0000-0000-000000000003',
+    '01.00.000',
+    '{"command":"review_submit"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can submit a draft process for review through cmd_review_submit'
+);
+
+select is(
+  (select state_code::text
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000003'
+     and version = '01.00.000'),
+  '20',
+  'cmd_review_submit marks the root dataset under review'
+);
+
+select is(
+  (select state_code::text
+   from public.flows
+   where id = '32000000-0000-0000-0000-000000000001'
+     and version = '01.00.000'),
+  '20',
+  'cmd_review_submit marks draft referenced datasets under review'
+);
+
+select is(
+  (select state_code::text
+   from public.flowproperties
+   where id = '32000000-0000-0000-0000-000000000004'
+     and version = '01.00.000'),
+  '20',
+  'cmd_review_submit marks referenced flow properties under review'
+);
+
+select is(
+  (select state_code::text
+   from public.sources
+   where id = '32000000-0000-0000-0000-000000000002'
+     and version = '01.00.000'),
+  '100',
+  'cmd_review_submit leaves already published references unchanged'
+);
+
+select is(
+  (select count(*)::text
+   from public.reviews
+   where data_id = '32000000-0000-0000-0000-000000000003'
+     and data_version = '01.00.000'),
+  '1',
+  'cmd_review_submit creates one review row for the root dataset'
+);
+
+select ok(
+  exists(
+    select 1
+    from public.reviews
+    where data_id = '32000000-0000-0000-0000-000000000003'
+      and data_version = '01.00.000'
+      and json->'user'->>'id' = '12000000-0000-0000-0000-000000000001'
+      and json->'team'->>'id' = '22000000-0000-0000-0000-000000000001'
+  ),
+  'cmd_review_submit records review json metadata for the submitter and team'
+);
+
+reset role;
+
+select ok(
+  exists(
+    select 1
+    from public.command_audit_log
+    where command = 'cmd_review_submit'
+      and target_id = '32000000-0000-0000-0000-000000000003'
+      and target_version = '01.00.000'
+  ),
+  'cmd_review_submit writes a command audit log entry'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_review_submit(
+    'lifecyclemodels',
+    '32000000-0000-0000-0000-000000000010',
+    '01.00.000',
+    '{"command":"review_submit"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can submit a lifecycle model and its linked draft processes for review'
+);
+
+select is(
+  (select state_code::text
+   from public.lifecyclemodels
+   where id = '32000000-0000-0000-0000-000000000010'
+     and version = '01.00.000'),
+  '20',
+  'cmd_review_submit marks the root lifecycle model under review'
+);
+
+select ok(
+  (
+    select count(*)
+    from public.processes
+    where id in (
+      '32000000-0000-0000-0000-000000000010',
+      '32000000-0000-0000-0000-000000000011'
+    )
+      and version = '01.00.000'
+      and state_code = 20
+  ) = 2,
+  'cmd_review_submit promotes linked lifecycle model process rows into under-review state'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000002', true);
+
+select is(
+  public.cmd_review_submit(
+    'processes',
+    '32000000-0000-0000-0000-000000000003',
+    '01.00.000',
+    '{}'::jsonb
+  )->>'code',
+  'DATASET_OWNER_REQUIRED',
+  'non-owners cannot submit another user''s dataset for review'
+);
+
+reset role;
+
+insert into public.flows (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values (
+  '32000000-0000-0000-0000-000000000021',
+  '01.00.000',
+  '{
+    "flowDataSet": {
+      "flowInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Under Review Flow" }
+            ]
+          }
+        }
+      }
+    }
+  }'::jsonb,
+  '{
+    "flowDataSet": {
+      "flowInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Under Review Flow" }
+            ]
+          }
+        }
+      }
+    }
+  }'::json,
+  '12000000-0000-0000-0000-000000000001',
+  20,
+  '22000000-0000-0000-0000-000000000001',
+  true
+);
+
+insert into public.processes (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  model_id,
+  rule_verification
+)
+values (
+  '32000000-0000-0000-0000-000000000022',
+  '01.00.000',
+  '{
+    "processDataSet": {
+      "processInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Blocked Process" }
+            ]
+          }
+        }
+      },
+      "exchanges": {
+        "exchange": [
+          {
+            "referenceToFlowDataSet": {
+              "@type": "flow data set",
+              "@refObjectId": "32000000-0000-0000-0000-000000000021",
+              "@version": "01.00.000"
+            }
+          }
+        ]
+      }
+    }
+  }'::jsonb,
+  '{
+    "processDataSet": {
+      "processInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Blocked Process" }
+            ]
+          }
+        }
+      },
+      "exchanges": {
+        "exchange": [
+          {
+            "referenceToFlowDataSet": {
+              "@type": "flow data set",
+              "@refObjectId": "32000000-0000-0000-0000-000000000021",
+              "@version": "01.00.000"
+            }
+          }
+        ]
+      }
+    }
+  }'::json,
+  '12000000-0000-0000-0000-000000000001',
+  0,
+  '22000000-0000-0000-0000-000000000001',
+  '42000000-0000-0000-0000-000000000004',
+  true
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_review_submit(
+    'processes',
+    '32000000-0000-0000-0000-000000000022',
+    '01.00.000',
+    '{}'::jsonb
+  )->>'code',
+  'REFERENCED_DATA_UNDER_REVIEW',
+  'review submission is blocked when a referenced dataset is already under review'
+);
+
+select is(
+  (select count(*)::text
+   from public.reviews
+   where data_id = '32000000-0000-0000-0000-000000000022'
+     and data_version = '01.00.000'),
+  '0',
+  'blocked review submission does not create a review row'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260405_core_raw_write_revoke.sql
+++ b/supabase/tests/20260405_core_raw_write_revoke.sql
@@ -1,0 +1,339 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(7);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'team-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"81000000-0000-0000-0000-000000000001","email":"team-owner@example.com","display_name":"Team Owner"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'team-member@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"81000000-0000-0000-0000-000000000002","email":"team-member@example.com","display_name":"Team Member"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'review-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"81000000-0000-0000-0000-000000000003","email":"review-admin@example.com","display_name":"Review Admin"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    'reviewer@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"81000000-0000-0000-0000-000000000004","email":"reviewer@example.com","display_name":"Reviewer"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  (
+    '81000000-0000-0000-0000-000000000001',
+    '{"email":"team-owner@example.com","display_name":"Team Owner"}'::jsonb,
+    null
+  ),
+  (
+    '81000000-0000-0000-0000-000000000002',
+    '{"email":"team-member@example.com","display_name":"Team Member"}'::jsonb,
+    null
+  ),
+  (
+    '81000000-0000-0000-0000-000000000003',
+    '{"email":"review-admin@example.com","display_name":"Review Admin"}'::jsonb,
+    null
+  ),
+  (
+    '81000000-0000-0000-0000-000000000004',
+    '{"email":"reviewer@example.com","display_name":"Reviewer"}'::jsonb,
+    null
+  );
+
+insert into public.teams (id, json, rank, is_public, modified_at)
+values (
+  '82000000-0000-0000-0000-000000000001',
+  '{"title":[{"@xml:lang":"en","#text":"Owned Team"}]}'::jsonb,
+  1,
+  false,
+  now()
+);
+
+insert into public.roles (user_id, team_id, role, modified_at)
+values
+  ('81000000-0000-0000-0000-000000000001', '82000000-0000-0000-0000-000000000001', 'owner', now()),
+  ('81000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000', 'review-admin', now()),
+  ('81000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000000', 'review-member', now());
+
+insert into public.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json,
+  created_at,
+  modified_at
+)
+values (
+  '83000000-0000-0000-0000-000000000001',
+  '84000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  0,
+  '["81000000-0000-0000-0000-000000000004"]'::jsonb,
+  '{"data":{"id":"84000000-0000-0000-0000-000000000001","version":"01.00.000"}}'::jsonb,
+  now(),
+  now()
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000001', true);
+
+do $$
+begin
+  begin
+    update public.teams
+    set rank = 99
+    where id = '82000000-0000-0000-0000-000000000001';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (select rank::text from public.teams where id = '82000000-0000-0000-0000-000000000001'),
+  '1',
+  'team owner cannot directly update teams row after raw write revoke'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000001', true);
+
+do $$
+begin
+  begin
+    insert into public.roles (user_id, team_id, role, modified_at)
+    values (
+      '81000000-0000-0000-0000-000000000002',
+      '82000000-0000-0000-0000-000000000001',
+      'member',
+      now()
+    );
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (
+    select count(*)::text
+    from public.roles
+    where user_id = '81000000-0000-0000-0000-000000000002'
+      and team_id = '82000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'authenticated user cannot directly insert roles row after raw write revoke'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000002', true);
+
+do $$
+begin
+  begin
+    update public.users
+    set contact = '{"phone":"123"}'::jsonb
+    where id = '81000000-0000-0000-0000-000000000002';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (
+    select coalesce(contact::text, 'null')
+    from public.users
+    where id = '81000000-0000-0000-0000-000000000002'
+  ),
+  'null',
+  'authenticated user cannot directly update users row after raw write revoke'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000003', true);
+
+do $$
+begin
+  begin
+    update public.reviews
+    set state_code = 2
+    where id = '83000000-0000-0000-0000-000000000001';
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (select state_code::text from public.reviews where id = '83000000-0000-0000-0000-000000000001'),
+  '0',
+  'review admin cannot directly update reviews row after raw write revoke'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000004', true);
+
+do $$
+begin
+  begin
+    insert into public.comments (
+      review_id,
+      reviewer_id,
+      json,
+      state_code,
+      created_at,
+      modified_at
+    )
+    values (
+      '83000000-0000-0000-0000-000000000001',
+      '81000000-0000-0000-0000-000000000004',
+      '{"note":"draft"}'::jsonb,
+      0,
+      now(),
+      now()
+    );
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+reset role;
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '83000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'reviewer cannot directly insert comments row after raw write revoke'
+);
+
+select is(
+  (
+    select count(*)::text
+    from (
+      values
+        ('contacts'),
+        ('sources'),
+        ('unitgroups'),
+        ('flowproperties'),
+        ('flows'),
+        ('processes'),
+        ('lifecyclemodels')
+    ) as dataset_tables(table_name)
+    where not has_table_privilege('authenticated', format('public.%I', table_name), 'INSERT')
+      and not has_table_privilege('authenticated', format('public.%I', table_name), 'UPDATE')
+      and not has_table_privilege('authenticated', format('public.%I', table_name), 'DELETE')
+  ),
+  '7',
+  'authenticated role has no raw insert, update, or delete grants on dataset tables after revoke'
+);
+
+select is(
+  (
+    select count(*)::text
+    from (
+      values
+        ('contacts'),
+        ('sources'),
+        ('unitgroups'),
+        ('flowproperties'),
+        ('flows'),
+        ('processes'),
+        ('lifecyclemodels')
+    ) as dataset_tables(table_name)
+    where not has_table_privilege('anon', format('public.%I', table_name), 'INSERT')
+      and not has_table_privilege('anon', format('public.%I', table_name), 'UPDATE')
+      and not has_table_privilege('anon', format('public.%I', table_name), 'DELETE')
+  ),
+  '7',
+  'anon role has no raw insert, update, or delete grants on dataset tables after revoke'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260405_dataset_create_delete_rpcs.sql
+++ b/supabase/tests/20260405_dataset_create_delete_rpcs.sql
@@ -1,0 +1,245 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(9);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '91000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'dataset-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"91000000-0000-0000-0000-000000000001","email":"dataset-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '91000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"91000000-0000-0000-0000-000000000002","email":"outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '91000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'system-review-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"91000000-0000-0000-0000-000000000003","email":"system-review-admin@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('91000000-0000-0000-0000-000000000001', '{"email":"dataset-owner@example.com"}'::jsonb, null),
+  ('91000000-0000-0000-0000-000000000002', '{"email":"outsider@example.com"}'::jsonb, null),
+  ('91000000-0000-0000-0000-000000000003', '{"email":"system-review-admin@example.com"}'::jsonb, null);
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('92000000-0000-0000-0000-000000000001', '{"name":"Review Team"}'::jsonb, 1, false),
+  ('00000000-0000-0000-0000-000000000000', '{"name":"System Team"}'::jsonb, 0, false);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('91000000-0000-0000-0000-000000000001', '92000000-0000-0000-0000-000000000001', 'owner'),
+  ('91000000-0000-0000-0000-000000000002', '92000000-0000-0000-0000-000000000001', 'review-admin'),
+  ('91000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000', 'review-admin');
+
+insert into public.sources (id, version, json_ordered, user_id, state_code, team_id, rule_verification)
+values (
+  '93000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{
+    "sourceDataSet": {
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json,
+  '91000000-0000-0000-0000-000000000001',
+  20,
+  '92000000-0000-0000-0000-000000000001',
+  true
+);
+
+alter table public.processes disable trigger "process_extract_md_trigger_insert";
+alter table public.processes disable trigger "process_extract_text_trigger_insert";
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_dataset_create(
+    'contacts',
+    '94000000-0000-0000-0000-000000000001',
+    '{
+      "contactDataSet": {
+        "administrativeInformation": {
+          "publicationAndOwnership": {
+            "common:dataSetVersion": "01.00.000"
+          }
+        }
+      },
+      "payload": {
+        "name": "created-contact"
+      }
+    }'::jsonb,
+    null,
+    false,
+    '{"command":"dataset_create"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can create a contact dataset through cmd_dataset_create'
+);
+
+select is(
+  (
+    select jsonb_build_object(
+      'version', version,
+      'user_id', user_id,
+      'rule_verification', rule_verification
+    )::text
+    from public.contacts
+    where id = '94000000-0000-0000-0000-000000000001'
+      and version = '01.00.000'
+  ),
+  jsonb_build_object(
+    'version', '01.00.000',
+    'user_id', '91000000-0000-0000-0000-000000000001',
+    'rule_verification', false
+  )::text,
+  'cmd_dataset_create persists version, owner, and rule_verification'
+);
+
+select is(
+  public.cmd_dataset_create(
+    'processes',
+    '94000000-0000-0000-0000-000000000002',
+    '{
+      "processDataSet": {
+        "administrativeInformation": {
+          "publicationAndOwnership": {
+            "common:dataSetVersion": "01.00.000"
+          }
+        }
+      }
+    }'::jsonb,
+    null,
+    true,
+    '{}'::jsonb
+  )->>'ok',
+  'true',
+  'process creation works without modelId for standalone datasets'
+);
+
+select ok(
+  (select model_id is null
+   from public.processes
+   where id = '94000000-0000-0000-0000-000000000002'
+     and version = '01.00.000'),
+  'cmd_dataset_create keeps model_id null when modelId is omitted'
+);
+
+select is(
+  public.cmd_dataset_create(
+    'lifecyclemodels',
+    '94000000-0000-0000-0000-000000000003',
+    '{}'::jsonb,
+    null,
+    true,
+    '{}'::jsonb
+  )->>'code',
+  'LIFECYCLEMODEL_BUNDLE_REQUIRED',
+  'lifecycle model creation stays on bundle-specific commands'
+);
+
+select is(
+  public.cmd_dataset_delete(
+    'contacts',
+    '94000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"command":"dataset_delete"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can delete a draft dataset through cmd_dataset_delete'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.contacts
+    where id = '94000000-0000-0000-0000-000000000001'
+      and version = '01.00.000'
+  ),
+  '0',
+  'cmd_dataset_delete removes the draft dataset row'
+);
+
+select is(
+  public.cmd_dataset_delete(
+    'sources',
+    '93000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{}'::jsonb
+  )->>'code',
+  'DATASET_DELETE_REQUIRES_DRAFT',
+  'under-review datasets cannot be deleted'
+);
+
+select is(
+  jsonb_build_object(
+    'team_role_review_admin', public.cmd_review_is_review_admin('91000000-0000-0000-0000-000000000002'),
+    'system_review_admin', public.cmd_review_is_review_admin('91000000-0000-0000-0000-000000000003')
+  )::text,
+  jsonb_build_object(
+    'team_role_review_admin', false,
+    'system_review_admin', true
+  )::text,
+  'cmd_review_is_review_admin only recognizes the system-team review-admin scope'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260405_membership_profile_rpcs.sql
+++ b/supabase/tests/20260405_membership_profile_rpcs.sql
@@ -1,0 +1,544 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(24);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'team-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000001","email":"team-owner@example.com","display_name":"Team Owner"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'team-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000002","email":"team-admin@example.com","display_name":"Team Admin"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'team-member@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000003","email":"team-member@example.com","display_name":"Team Member"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    'team-invitee@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000004","email":"team-invitee@example.com","display_name":"Team Invitee"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000005',
+    'authenticated',
+    'authenticated',
+    'system-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000005","email":"system-owner@example.com","display_name":"System Owner"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000006',
+    'authenticated',
+    'authenticated',
+    'system-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000006","email":"system-admin@example.com","display_name":"System Admin"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000007',
+    'authenticated',
+    'authenticated',
+    'review-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000007","email":"review-admin@example.com","display_name":"Review Admin"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000008',
+    'authenticated',
+    'authenticated',
+    'review-member@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000008","email":"review-member@example.com","display_name":"Review Member"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000009',
+    'authenticated',
+    'authenticated',
+    'new-user@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000009","email":"new-user@example.com","display_name":"New User"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '71000000-0000-0000-0000-000000000010',
+    'authenticated',
+    'authenticated',
+    'review-candidate@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"71000000-0000-0000-0000-000000000010","email":"review-candidate@example.com","display_name":"Review Candidate"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('71000000-0000-0000-0000-000000000001', '{"email":"team-owner@example.com","display_name":"Team Owner"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000002', '{"email":"team-admin@example.com","display_name":"Team Admin"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000003', '{"email":"team-member@example.com","display_name":"Team Member"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000004', '{"email":"team-invitee@example.com","display_name":"Team Invitee"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000005', '{"email":"system-owner@example.com","display_name":"System Owner"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000006', '{"email":"system-admin@example.com","display_name":"System Admin"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000007', '{"email":"review-admin@example.com","display_name":"Review Admin"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000008', '{"email":"review-member@example.com","display_name":"Review Member"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000009', '{"email":"new-user@example.com","display_name":"New User"}'::jsonb, null),
+  ('71000000-0000-0000-0000-000000000010', '{"email":"review-candidate@example.com","display_name":"Review Candidate"}'::jsonb, null);
+
+insert into public.teams (id, json, rank, is_public, modified_at)
+values
+  ('72000000-0000-0000-0000-000000000001', '{"title":[{"@xml:lang":"en","#text":"Primary Team"}]}'::jsonb, 1, false, now()),
+  ('72000000-0000-0000-0000-000000000002', '{"title":[{"@xml:lang":"en","#text":"Secondary Team"}]}'::jsonb, 5, true, now());
+
+insert into public.roles (user_id, team_id, role, modified_at)
+values
+  ('71000000-0000-0000-0000-000000000001', '72000000-0000-0000-0000-000000000001', 'owner', now()),
+  ('71000000-0000-0000-0000-000000000002', '72000000-0000-0000-0000-000000000001', 'admin', now()),
+  ('71000000-0000-0000-0000-000000000003', '72000000-0000-0000-0000-000000000001', 'member', now()),
+  ('71000000-0000-0000-0000-000000000005', '00000000-0000-0000-0000-000000000000', 'owner', now()),
+  ('71000000-0000-0000-0000-000000000006', '00000000-0000-0000-0000-000000000000', 'admin', now()),
+  ('71000000-0000-0000-0000-000000000007', '00000000-0000-0000-0000-000000000000', 'review-admin', now()),
+  ('71000000-0000-0000-0000-000000000008', '00000000-0000-0000-0000-000000000000', 'review-member', now());
+
+insert into public.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json,
+  created_at,
+  modified_at
+)
+values
+  (
+    '73000000-0000-0000-0000-000000000001',
+    '74000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    1,
+    '["71000000-0000-0000-0000-000000000008"]'::jsonb,
+    '{"data":{"id":"74000000-0000-0000-0000-000000000001","version":"01.00.000"}}'::jsonb,
+    now(),
+    now()
+  ),
+  (
+    '73000000-0000-0000-0000-000000000002',
+    '74000000-0000-0000-0000-000000000002',
+    '01.00.000',
+    2,
+    '["71000000-0000-0000-0000-000000000008"]'::jsonb,
+    '{"data":{"id":"74000000-0000-0000-0000-000000000002","version":"01.00.000"}}'::jsonb,
+    now(),
+    now()
+  );
+
+insert into public.comments (
+  review_id,
+  reviewer_id,
+  json,
+  state_code,
+  created_at,
+  modified_at
+)
+values
+  (
+    '73000000-0000-0000-0000-000000000001',
+    '71000000-0000-0000-0000-000000000008',
+    '{"note":"pending"}'::json,
+    0,
+    now(),
+    now()
+  ),
+  (
+    '73000000-0000-0000-0000-000000000002',
+    '71000000-0000-0000-0000-000000000008',
+    '{"note":"reviewed"}'::json,
+    1,
+    now(),
+    now()
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000009', true);
+
+select is(
+  public.cmd_team_create(
+    '72000000-0000-0000-0000-000000000009',
+    '{"title":[{"@xml:lang":"en","#text":"Created Team"}]}'::jsonb,
+    0,
+    true,
+    '{"command":"team_create"}'::jsonb
+  )->>'ok',
+  'true',
+  'team create command allows an actor without an existing team to create one'
+);
+
+select is(
+  (select role from public.roles where user_id = '71000000-0000-0000-0000-000000000009' and team_id = '72000000-0000-0000-0000-000000000009'),
+  'owner',
+  'team create command initializes the owner role in the same transaction'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_team_change_member_role(
+    '72000000-0000-0000-0000-000000000001',
+    '71000000-0000-0000-0000-000000000004',
+    'is_invited',
+    'set',
+    '{"command":"team_invite"}'::jsonb
+  )->>'ok',
+  'true',
+  'team owner can invite a new team member through the team role command'
+);
+
+select is(
+  public.cmd_team_change_member_role(
+    '72000000-0000-0000-0000-000000000001',
+    '71000000-0000-0000-0000-000000000003',
+    'admin',
+    'set',
+    '{"command":"team_promote"}'::jsonb
+  )->>'code',
+  'FORBIDDEN',
+  'team admins cannot promote or demote active members'
+)
+from (
+  select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000002', true)
+) as _;
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000004', true);
+
+select is(
+  public.cmd_team_accept_invitation(
+    '72000000-0000-0000-0000-000000000001',
+    '{"command":"team_accept"}'::jsonb
+  )->>'ok',
+  'true',
+  'accept invitation only updates the current actor invitation row'
+);
+
+select is(
+  (select role from public.roles where user_id = '71000000-0000-0000-0000-000000000004' and team_id = '72000000-0000-0000-0000-000000000001'),
+  'member',
+  'accept invitation upgrades the invited actor to member'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000003', true);
+
+select is(
+  public.cmd_team_accept_invitation(
+    '72000000-0000-0000-0000-000000000001',
+    '{"command":"team_accept"}'::jsonb
+  )->>'code',
+  'INVITATION_NOT_FOUND',
+  'accept invitation cannot act on another user invitation'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_team_reinvite_member(
+    '72000000-0000-0000-0000-000000000001',
+    '71000000-0000-0000-0000-000000000004',
+    '{"command":"team_reinvite"}'::jsonb
+  )->>'ok',
+  'false',
+  'reinvite does not apply once the target is no longer rejected'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000006', true);
+
+select is(
+  public.cmd_system_change_member_role(
+    '71000000-0000-0000-0000-000000000009',
+    'member',
+    'set',
+    '{"command":"system_add_member"}'::jsonb
+  )->>'ok',
+  'true',
+  'system admins can add a system member'
+);
+
+select is(
+  public.cmd_system_change_member_role(
+    '71000000-0000-0000-0000-000000000009',
+    'admin',
+    'set',
+    '{"command":"system_promote_admin"}'::jsonb
+  )->>'code',
+  'FORBIDDEN',
+  'system admins cannot promote a member to admin'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000005', true);
+
+select is(
+  public.cmd_system_change_member_role(
+    '71000000-0000-0000-0000-000000000009',
+    'admin',
+    'set',
+    '{"command":"system_promote_admin"}'::jsonb
+  )->>'ok',
+  'true',
+  'system owner can promote a system member to admin'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000007', true);
+
+select is(
+  public.cmd_review_change_member_role(
+    '71000000-0000-0000-0000-000000000010',
+    'review-member',
+    'set',
+    '{"command":"review_add_member"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can add a review member'
+);
+
+select is(
+  public.cmd_review_change_member_role(
+    '71000000-0000-0000-0000-000000000010',
+    'review-admin',
+    'set',
+    '{"command":"review_promote_admin"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can promote a review member to review-admin'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_team_update_profile(
+    '72000000-0000-0000-0000-000000000001',
+    '{"title":[{"@xml:lang":"en","#text":"Primary Team Updated"}]}'::jsonb,
+    true,
+    '{"command":"team_update_profile"}'::jsonb
+  )->>'ok',
+  'true',
+  'team profile updates run through a dedicated profile command'
+);
+
+select is(
+  (select rank::text from public.teams where id = '72000000-0000-0000-0000-000000000001'),
+  '1',
+  'team profile updates do not mutate rank'
+);
+
+select is(
+  public.cmd_team_set_rank(
+    '72000000-0000-0000-0000-000000000001',
+    9,
+    '{"command":"team_set_rank"}'::jsonb
+  )->>'ok',
+  'true',
+  'team rank updates run through a dedicated rank command'
+);
+
+select is(
+  (select json #>> '{title,0,#text}' from public.teams where id = '72000000-0000-0000-0000-000000000001'),
+  'Primary Team Updated',
+  'team rank updates do not overwrite the team profile json'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000008', true);
+
+select is(
+  public.cmd_user_update_contact(
+    '71000000-0000-0000-0000-000000000008',
+    '{"email":"review-member@example.com"}'::jsonb,
+    '{"command":"user_update_contact"}'::jsonb
+  )->>'ok',
+  'true',
+  'users can update their own contact data'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.cmd_user_update_contact(
+    '71000000-0000-0000-0000-000000000008',
+    '{"email":"blocked@example.com"}'::jsonb,
+    '{"command":"user_update_contact"}'::jsonb
+  )->>'code',
+  'FORBIDDEN',
+  'non review-admin users cannot update another actor contact data'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (select count(*)::text from public.qry_team_get_member_list('72000000-0000-0000-0000-000000000001', 1, 20, 'created_at', 'desc')),
+  '4',
+  'team member list query returns the full team membership view from one RPC'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000003', true);
+
+select is(
+  (select count(*)::text from public.qry_team_get_member_list('72000000-0000-0000-0000-000000000001', 1, 20, 'created_at', 'desc')),
+  '0',
+  'team member list query is hidden from non-manager team members'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000005', true);
+
+select is(
+  (select count(*)::text from public.qry_system_get_member_list(1, 20, 'created_at', 'desc')),
+  '3',
+  'system member list query returns the system scope membership rows'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '71000000-0000-0000-0000-000000000007', true);
+
+select is(
+  (select count(*)::text from public.qry_review_get_member_list(1, 20, 'created_at', 'desc', 'review-admin')),
+  '2',
+  'review member list query can filter by review role'
+);
+
+select is(
+  (
+    select format('%s/%s', pending_count, reviewed_count)
+    from public.qry_review_get_member_workload(1, 20, 'created_at', 'desc', 'review-member')
+    where user_id = '71000000-0000-0000-0000-000000000008'
+  ),
+  '1/1',
+  'review workload query returns reviewer pending and reviewed counts from one RPC'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260405_notification_query_command_rpcs.sql
+++ b/supabase/tests/20260405_notification_query_command_rpcs.sql
@@ -1,0 +1,556 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(13);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '91000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'sender@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"91000000-0000-0000-0000-000000000001","email":"sender@example.com","display_name":"Sender User"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '91000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'recipient@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"91000000-0000-0000-0000-000000000002","email":"recipient@example.com","display_name":"Recipient User"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '91000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'invitee@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"91000000-0000-0000-0000-000000000003","email":"invitee@example.com","display_name":"Invitee User"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data)
+values
+  (
+    '91000000-0000-0000-0000-000000000001',
+    '{"email":"sender@example.com","display_name":"Sender User"}'::jsonb
+  ),
+  (
+    '91000000-0000-0000-0000-000000000002',
+    '{"email":"recipient@example.com","display_name":"Recipient User"}'::jsonb
+  ),
+  (
+    '91000000-0000-0000-0000-000000000003',
+    '{"email":"invitee@example.com","display_name":"Invitee User"}'::jsonb
+  );
+
+insert into public.teams (id, json, rank, is_public, modified_at)
+values (
+  '92000000-0000-0000-0000-000000000001',
+  '{"title":[{"@xml:lang":"en","#text":"Notification Team"}]}'::jsonb,
+  1,
+  false,
+  now()
+);
+
+insert into public.roles (user_id, team_id, role, modified_at)
+values (
+  '91000000-0000-0000-0000-000000000003',
+  '92000000-0000-0000-0000-000000000001',
+  'is_invited',
+  now() - interval '1 day'
+);
+
+alter table public.sources disable trigger "sources_json_sync_trigger";
+alter table public.processes disable trigger "processes_json_sync_trigger";
+alter table public.processes disable trigger "process_extract_md_trigger_insert";
+alter table public.processes disable trigger "process_extract_text_trigger_insert";
+
+insert into public.sources (
+  id,
+  version,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values
+  (
+    '94000000-0000-0000-0000-000000000011',
+    '01.00.000',
+    '{
+      "sourceDataSet": {
+        "sourceInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Target Source Dataset" }
+              ]
+            }
+          }
+        }
+      }
+    }'::jsonb,
+    '91000000-0000-0000-0000-000000000002',
+    0,
+    '92000000-0000-0000-0000-000000000001',
+    true
+  ),
+  (
+    '94000000-0000-0000-0000-000000000012',
+    '01.00.000',
+    '{
+      "sourceDataSet": {
+        "sourceInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Unreferenced Source Dataset" }
+              ]
+            }
+          }
+        }
+      }
+    }'::jsonb,
+    '91000000-0000-0000-0000-000000000002',
+    0,
+    '92000000-0000-0000-0000-000000000001',
+    true
+  );
+
+insert into public.processes (
+  id,
+  version,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  model_id,
+  rule_verification
+)
+values (
+  '94000000-0000-0000-0000-000000000010',
+  '01.00.000',
+  '{
+    "processDataSet": {
+      "processInformation": {
+        "dataSetInformation": {
+          "name": {
+            "baseName": [
+              { "@xml:lang": "en", "#text": "Source Process Dataset" }
+            ]
+          }
+        }
+      },
+      "exchanges": {
+        "exchange": [
+          {
+            "referencesToDataSource": {
+              "referenceToDataSource": {
+                "@type": "source data set",
+                "@refObjectId": "94000000-0000-0000-0000-000000000011",
+                "@version": "01.00.000"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }'::jsonb,
+  '91000000-0000-0000-0000-000000000001',
+  0,
+  '92000000-0000-0000-0000-000000000001',
+  '94000000-0000-0000-0000-000000000099',
+  true
+);
+
+insert into public.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json,
+  created_at,
+  modified_at
+)
+values
+  (
+    '93000000-0000-0000-0000-000000000001',
+    '94000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    -1,
+    '["91000000-0000-0000-0000-000000000002"]'::jsonb,
+    '{
+      "data": {
+        "id": "94000000-0000-0000-0000-000000000001",
+        "version": "01.00.000",
+        "name": {
+          "baseName": { "en": "Recent Review" },
+          "treatmentStandardsRoutes": { "en": "Route" },
+          "mixAndLocationTypes": { "en": "Mix" },
+          "functionalUnitFlowProperties": { "en": "Unit" }
+        }
+      },
+      "team": { "name": { "en": "Notification Team" } },
+      "user": {
+        "id": "91000000-0000-0000-0000-000000000001",
+        "name": "Sender User",
+        "email": "sender@example.com"
+      },
+      "comment": { "message": "Need changes" }
+    }'::jsonb,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '93000000-0000-0000-0000-000000000002',
+    '94000000-0000-0000-0000-000000000002',
+    '02.00.000',
+    2,
+    '["91000000-0000-0000-0000-000000000002"]'::jsonb,
+    '{
+      "data": {
+        "id": "94000000-0000-0000-0000-000000000002",
+        "version": "02.00.000",
+        "name": {
+          "baseName": { "en": "Old Review" },
+          "treatmentStandardsRoutes": { "en": "Route" },
+          "mixAndLocationTypes": { "en": "Mix" },
+          "functionalUnitFlowProperties": { "en": "Unit" }
+        }
+      },
+      "team": { "name": { "en": "Notification Team" } },
+      "user": {
+        "id": "91000000-0000-0000-0000-000000000001",
+        "name": "Sender User",
+        "email": "sender@example.com"
+      }
+    }'::jsonb,
+    now() - interval '10 days',
+    now() - interval '10 days'
+  );
+
+insert into public.notifications (
+  id,
+  recipient_user_id,
+  sender_user_id,
+  type,
+  dataset_type,
+  dataset_id,
+  dataset_version,
+  json,
+  created_at,
+  modified_at
+)
+values
+  (
+    '95000000-0000-0000-0000-000000000001',
+    '91000000-0000-0000-0000-000000000001',
+    '91000000-0000-0000-0000-000000000002',
+    'validation_issue',
+    'process data set',
+    '94000000-0000-0000-0000-000000000003',
+    '01.00.000',
+    '{"issueCodes":["ruleVerificationFailed"],"senderName":"Recipient User","tabNames":["processInformation"]}'::jsonb,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '95000000-0000-0000-0000-000000000002',
+    '91000000-0000-0000-0000-000000000001',
+    '91000000-0000-0000-0000-000000000003',
+    'validation_issue',
+    'source data set',
+    '94000000-0000-0000-0000-000000000004',
+    '02.00.000',
+    '{"issueCodes":["sdkInvalid"],"senderName":"Invitee User","tabNames":["modellingAndValidation"]}'::jsonb,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '95000000-0000-0000-0000-000000000003',
+    '91000000-0000-0000-0000-000000000001',
+    '91000000-0000-0000-0000-000000000002',
+    'validation_issue',
+    'flow data set',
+    '94000000-0000-0000-0000-000000000005',
+    '03.00.000',
+    '{"issueCodes":["underReview"],"senderName":"Recipient User","tabNames":["flows"]}'::jsonb,
+    now() - interval '10 days',
+    now() - interval '10 days'
+  ),
+  (
+    '95000000-0000-0000-0000-000000000010',
+    '91000000-0000-0000-0000-000000000002',
+    '91000000-0000-0000-0000-000000000001',
+    'validation_issue',
+    'source data set',
+    '94000000-0000-0000-0000-000000000011',
+    '01.00.000',
+    '{"issueCodes":["underReview"],"senderName":"Sender User","tabNames":["legacy"]}'::jsonb,
+    now() - interval '6 days',
+    now() - interval '6 days'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000003', true);
+
+select is(
+  (select count(*)::text from public.qry_notification_get_my_team_items(3)),
+  '1',
+  'team notification query returns the current user invitation rows'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000003', true);
+
+select is(
+  public.qry_notification_get_my_team_count(3, now() - interval '2 days')::text,
+  '1',
+  'team notification count honors the last-view cutoff'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (select count(*)::text from public.qry_notification_get_my_data_items(1, 10, 3)),
+  '1',
+  'data notification query filters review rows by actor and time window'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.qry_notification_get_my_data_count(7, now() - interval '2 days')::text,
+  '1',
+  'data notification count uses last-view cutoff'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (select total_count::text from public.qry_notification_get_my_issue_items(1, 10, 7) limit 1),
+  '2',
+  'issue notification query returns filtered total counts for the recipient'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.qry_notification_get_my_issue_count(30, now() - interval '2 days')::text,
+  '1',
+  'issue notification count uses last-view cutoff'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    public.cmd_notification_send_validation_issue(
+      '91000000-0000-0000-0000-000000000002',
+      'source data set',
+      '94000000-0000-0000-0000-000000000011',
+      '01.00.000',
+      ' https://example.com/issues/1 ',
+      array['ruleVerificationFailed', 'sdkInvalid', 'ruleVerificationFailed', ' '],
+      array['processInformation', 'modellingAndValidation', 'processInformation', ' '],
+      3,
+      '{"source":"pgtap"}'::jsonb
+    ) ->> 'ok'
+  ),
+  'true',
+  'notification command writes through the explicit command boundary'
+);
+
+select ok(
+  (
+    select
+      json -> 'issueCodes' = '["ruleVerificationFailed","sdkInvalid"]'::jsonb and
+      json -> 'tabNames' = '["processInformation","modellingAndValidation"]'::jsonb and
+      json ->> 'senderName' = 'Sender User' and
+      json ->> 'link' = 'https://example.com/issues/1'
+    from public.notifications
+    where recipient_user_id = '91000000-0000-0000-0000-000000000002'
+      and sender_user_id = '91000000-0000-0000-0000-000000000001'
+      and dataset_id = '94000000-0000-0000-0000-000000000011'
+      and dataset_version = '01.00.000'
+  ),
+  'notification command upsert normalizes issue payload and sender metadata'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000002', true);
+
+select is(
+  public.qry_notification_get_my_issue_count(30, null::timestamptz)::text,
+  '1',
+  'recipient-only issue notification query exposes the command-created notification to the recipient'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000001', true);
+
+do $$
+begin
+  begin
+    insert into public.notifications (
+      recipient_user_id,
+      sender_user_id,
+      type,
+      dataset_type,
+      dataset_id,
+      dataset_version,
+      json
+    )
+    values (
+      '91000000-0000-0000-0000-000000000002',
+      '91000000-0000-0000-0000-000000000001',
+      'validation_issue',
+      'process data set',
+      '94000000-0000-0000-0000-000000000099',
+      '01.00.000',
+      '{}'::jsonb
+    );
+  exception
+    when others then
+      null;
+  end;
+end;
+$$;
+
+select is(
+  (
+    select count(*)::text
+    from public.notifications
+    where dataset_id = '94000000-0000-0000-0000-000000000099'
+  ),
+  '0',
+  'authenticated users cannot directly insert notifications rows after command cutover'
+);
+
+select is(
+  (
+    public.cmd_notification_send_validation_issue(
+      '91000000-0000-0000-0000-000000000003',
+      'source data set',
+      '94000000-0000-0000-0000-000000000011',
+      '01.00.000',
+      null,
+      array['ruleVerificationFailed'],
+      array['processInformation'],
+      1,
+      '{}'::jsonb
+    ) ->> 'code'
+  ),
+  'RECIPIENT_NOT_TARGET_OWNER',
+  'notification command requires the recipient to match the target dataset owner'
+);
+
+select is(
+  (
+    public.cmd_notification_send_validation_issue(
+      '91000000-0000-0000-0000-000000000001',
+      'source data set',
+      '94000000-0000-0000-0000-000000000011',
+      '01.00.000',
+      null,
+      array['ruleVerificationFailed'],
+      array['processInformation'],
+      1,
+      '{}'::jsonb
+    ) ->> 'code'
+  ),
+  'NOTIFICATION_SELF_TARGET',
+  'notification command blocks self-target notifications'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000003', true);
+
+select is(
+  (
+    public.cmd_notification_send_validation_issue(
+      '91000000-0000-0000-0000-000000000002',
+      'source data set',
+      '94000000-0000-0000-0000-000000000011',
+      '01.00.000',
+      null,
+      array['ruleVerificationFailed'],
+      array['processInformation'],
+      1,
+      '{}'::jsonb
+    ) ->> 'ok'
+  ),
+  'true',
+  'notification command no longer requires the actor to own a source dataset'
+);
+
+reset role;
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260405_review_workflow_rpcs.sql
+++ b/supabase/tests/20260405_review_workflow_rpcs.sql
@@ -1,0 +1,1568 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(44);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '12000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'review-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"12000000-0000-0000-0000-000000000001","email":"review-owner@example.com","display_name":"Review Owner"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '12000000-0000-0000-0000-000000000010',
+    'authenticated',
+    'authenticated',
+    'review-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"12000000-0000-0000-0000-000000000010","email":"review-admin@example.com","display_name":"Review Admin"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '12000000-0000-0000-0000-000000000011',
+    'authenticated',
+    'authenticated',
+    'reviewer-one@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"12000000-0000-0000-0000-000000000011","email":"reviewer-one@example.com","display_name":"Reviewer One"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '12000000-0000-0000-0000-000000000012',
+    'authenticated',
+    'authenticated',
+    'reviewer-two@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"12000000-0000-0000-0000-000000000012","email":"reviewer-two@example.com","display_name":"Reviewer Two"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data)
+values
+  (
+    '12000000-0000-0000-0000-000000000001',
+    '{"email":"review-owner@example.com","display_name":"Review Owner"}'::jsonb
+  ),
+  (
+    '12000000-0000-0000-0000-000000000010',
+    '{"email":"review-admin@example.com","display_name":"Review Admin"}'::jsonb
+  ),
+  (
+    '12000000-0000-0000-0000-000000000011',
+    '{"email":"reviewer-one@example.com","display_name":"Reviewer One"}'::jsonb
+  ),
+  (
+    '12000000-0000-0000-0000-000000000012',
+    '{"email":"reviewer-two@example.com","display_name":"Reviewer Two"}'::jsonb
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('22000000-0000-0000-0000-000000000001', '{"title":"Review Team"}'::jsonb, 1, false);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('12000000-0000-0000-0000-000000000001', '22000000-0000-0000-0000-000000000001', 'owner'),
+  ('12000000-0000-0000-0000-000000000010', '00000000-0000-0000-0000-000000000000', 'review-admin'),
+  ('12000000-0000-0000-0000-000000000011', '00000000-0000-0000-0000-000000000000', 'review-member'),
+  ('12000000-0000-0000-0000-000000000012', '00000000-0000-0000-0000-000000000000', 'review-member');
+
+alter table public.sources disable trigger "sources_json_sync_trigger";
+alter table public.flows disable trigger "flows_json_sync_trigger";
+alter table public.processes disable trigger "processes_json_sync_trigger";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_trigger";
+
+alter table public.processes disable trigger "process_extract_md_trigger_insert";
+alter table public.processes disable trigger "process_extract_md_trigger_update";
+alter table public.processes disable trigger "process_extract_text_trigger_insert";
+alter table public.processes disable trigger "process_extract_text_trigger_update";
+alter table public.flows disable trigger "flow_extract_md_trigger_insert";
+alter table public.flows disable trigger "flow_extract_md_trigger_update";
+alter table public.flows disable trigger "flow_extract_text_trigger_insert";
+alter table public.flows disable trigger "flow_extract_text_trigger_update";
+alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
+alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_update";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_update";
+
+insert into public.flows (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  reviews
+)
+values
+  (
+    '32000000-0000-0000-0000-000000000212',
+    '01.00.000',
+    '{
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Comment Draft Flow" }
+              ]
+            }
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Comment Draft Flow" }
+              ]
+            }
+          }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    0,
+    '22000000-0000-0000-0000-000000000001',
+    true,
+    '[]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000213',
+    '01.00.000',
+    '{
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Approve Flow" }
+              ]
+            }
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Approve Flow" }
+              ]
+            }
+          }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000203"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000214',
+    '01.00.000',
+    '{
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Reject Flow" }
+              ]
+            }
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Reject Flow" }
+              ]
+            }
+          }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000204"}]'::jsonb
+  );
+
+insert into public.processes (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  model_id,
+  rule_verification,
+  reviews
+)
+values
+  (
+    '32000000-0000-0000-0000-000000000201',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Assignment Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Assignment Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    0,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000201',
+    true,
+    '[]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000202',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Comment Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Comment Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000202',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000202"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000203',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Approve Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": {
+            "review": [
+              {
+                "common:scope": [
+                  {
+                    "@name": "Existing process review",
+                    "common:method": { "@name": "Existing process method" }
+                  }
+                ]
+              }
+            ]
+          },
+          "complianceDeclarations": {
+            "compliance": [
+              { "common:approvalOfOverallCompliance": "Existing process compliance" }
+            ]
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Approve Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": {
+            "review": [
+              {
+                "common:scope": [
+                  {
+                    "@name": "Existing process review",
+                    "common:method": { "@name": "Existing process method" }
+                  }
+                ]
+              }
+            ]
+          },
+          "complianceDeclarations": {
+            "compliance": [
+              { "common:approvalOfOverallCompliance": "Existing process compliance" }
+            ]
+          }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000203',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000203"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000204',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Reject Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Reject Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000204',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000204"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000205',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Sparse Approve Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {}
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Sparse Approve Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {}
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000205',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000205"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000301',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Model Root Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Model Root Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000301',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000301"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000302',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Model Secondary Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": {
+            "review": [
+              {
+                "common:scope": [
+                  {
+                    "@name": "Old submodel review",
+                    "common:method": { "@name": "Old submodel method" }
+                  }
+                ]
+              }
+            ]
+          },
+          "complianceDeclarations": {
+            "compliance": [
+              { "common:approvalOfOverallCompliance": "Old submodel compliance" }
+            ]
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Model Secondary Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": {
+            "review": [
+              {
+                "common:scope": [
+                  {
+                    "@name": "Old submodel review",
+                    "common:method": { "@name": "Old submodel method" }
+                  }
+                ]
+              }
+            ]
+          },
+          "complianceDeclarations": {
+            "compliance": [
+              { "common:approvalOfOverallCompliance": "Old submodel compliance" }
+            ]
+          }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000302',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000301"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000305',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Sparse Model Secondary Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {}
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Sparse Model Secondary Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {}
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000305',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000304"}]'::jsonb
+  );
+
+insert into public.lifecyclemodels (
+  id,
+  version,
+  json,
+  json_ordered,
+  json_tg,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  reviews
+)
+values
+  (
+    '32000000-0000-0000-0000-000000000301',
+    '01.00.000',
+    '{
+      "lifeCycleModelDataSet": {
+        "lifeCycleModelInformation": {
+          "dataSetInformation": {
+            "name": [
+              { "@xml:lang": "en", "#text": "Approve Model" }
+            ]
+          }
+        },
+        "modellingAndValidation": {
+          "validation": {
+            "review": [
+              {
+                "common:scope": [
+                  {
+                    "@name": "Existing model review",
+                    "common:method": { "@name": "Existing model method" }
+                  }
+                ]
+              }
+            ]
+          },
+          "complianceDeclarations": {
+            "compliance": [
+              { "common:approvalOfOverallCompliance": "Existing model compliance" }
+            ]
+          }
+        }
+      }
+    }'::jsonb,
+    '{
+      "lifeCycleModelDataSet": {
+        "lifeCycleModelInformation": {
+          "dataSetInformation": {
+            "name": [
+              { "@xml:lang": "en", "#text": "Approve Model" }
+            ]
+          }
+        },
+        "modellingAndValidation": {
+          "validation": {
+            "review": [
+              {
+                "common:scope": [
+                  {
+                    "@name": "Existing model review",
+                    "common:method": { "@name": "Existing model method" }
+                  }
+                ]
+              }
+            ]
+          },
+          "complianceDeclarations": {
+            "compliance": [
+              { "common:approvalOfOverallCompliance": "Existing model compliance" }
+            ]
+          }
+        }
+      }
+    }'::json,
+    '{
+      "submodels": [
+        { "id": "32000000-0000-0000-0000-000000000302", "type": "secondary" }
+      ]
+    }'::jsonb,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000301"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000303',
+    '01.00.000',
+    '{
+      "lifeCycleModelDataSet": {
+        "lifeCycleModelInformation": {
+          "dataSetInformation": {
+            "name": [
+              { "@xml:lang": "en", "#text": "Broken Model" }
+            ]
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::jsonb,
+    '{
+      "lifeCycleModelDataSet": {
+        "lifeCycleModelInformation": {
+          "dataSetInformation": {
+            "name": [
+              { "@xml:lang": "en", "#text": "Broken Model" }
+            ]
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::json,
+    '{
+      "submodels": [
+        { "id": "32000000-0000-0000-0000-000000000304", "type": "secondary" }
+      ]
+    }'::jsonb,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000303"}]'::jsonb
+  ),
+  (
+    '32000000-0000-0000-0000-000000000304',
+    '01.00.000',
+    '{
+      "lifeCycleModelDataSet": {
+        "lifeCycleModelInformation": {
+          "dataSetInformation": {
+            "name": [
+              { "@xml:lang": "en", "#text": "Sparse Approve Model" }
+            ]
+          }
+        },
+        "modellingAndValidation": {}
+      }
+    }'::jsonb,
+    '{
+      "lifeCycleModelDataSet": {
+        "lifeCycleModelInformation": {
+          "dataSetInformation": {
+            "name": [
+              { "@xml:lang": "en", "#text": "Sparse Approve Model" }
+            ]
+          }
+        },
+        "modellingAndValidation": {}
+      }
+    }'::json,
+    '{
+      "submodels": [
+        { "id": "32000000-0000-0000-0000-000000000305", "type": "secondary" }
+      ]
+    }'::jsonb,
+    '12000000-0000-0000-0000-000000000001',
+    20,
+    '22000000-0000-0000-0000-000000000001',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000304"}]'::jsonb
+  );
+
+insert into public.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json
+)
+values
+  (
+    '53000000-0000-0000-0000-000000000201',
+    '32000000-0000-0000-0000-000000000201',
+    '01.00.000',
+    0,
+    '[]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000201", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000202',
+    '32000000-0000-0000-0000-000000000202',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000202", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000203',
+    '32000000-0000-0000-0000-000000000203',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000203", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000204',
+    '32000000-0000-0000-0000-000000000204',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000204", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000205',
+    '32000000-0000-0000-0000-000000000205',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000205", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000301',
+    '32000000-0000-0000-0000-000000000301',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000301", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000303',
+    '32000000-0000-0000-0000-000000000303',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000303", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000304',
+    '32000000-0000-0000-0000-000000000304',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000304", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  );
+
+insert into public.comments (
+  review_id,
+  reviewer_id,
+  json,
+  state_code
+)
+values
+  (
+    '53000000-0000-0000-0000-000000000202',
+    '12000000-0000-0000-0000-000000000011',
+    '{}'::json,
+    0
+  ),
+  (
+    '53000000-0000-0000-0000-000000000203',
+    '12000000-0000-0000-0000-000000000011',
+    '{
+      "modellingAndValidation": {
+        "validation": {
+          "reviewerValidationMarker": "Reviewer process validation marker",
+          "review": [
+            {
+              "common:scope": [
+                {
+                  "@name": "Reviewer process scope",
+                  "common:method": { "@name": "Reviewer process method" }
+                }
+              ]
+            }
+          ]
+        },
+        "complianceDeclarations": {
+          "reviewerComplianceMarker": "Reviewer process compliance marker",
+          "compliance": [
+            { "common:approvalOfOverallCompliance": "Reviewer process compliance" }
+          ]
+        }
+      }
+    }'::json,
+    1
+  ),
+  (
+    '53000000-0000-0000-0000-000000000204',
+    '12000000-0000-0000-0000-000000000011',
+    '{
+      "modellingAndValidation": {
+        "validation": {
+          "review": [
+            {
+              "common:scope": [
+                {
+                  "@name": "Reviewer reject scope",
+                  "common:method": { "@name": "Reviewer reject method" }
+                }
+              ]
+            }
+          ]
+        },
+        "complianceDeclarations": {
+          "compliance": [
+            { "common:approvalOfOverallCompliance": "Reviewer reject compliance" }
+          ]
+        }
+      }
+    }'::json,
+    1
+  ),
+  (
+    '53000000-0000-0000-0000-000000000205',
+    '12000000-0000-0000-0000-000000000011',
+    '{
+      "modellingAndValidation": {
+        "validation": {
+          "review": [
+            {
+              "common:scope": [
+                {
+                  "@name": "Reviewer sparse process scope",
+                  "common:method": { "@name": "Reviewer sparse process method" }
+                }
+              ]
+            }
+          ]
+        },
+        "complianceDeclarations": {
+          "compliance": [
+            { "common:approvalOfOverallCompliance": "Reviewer sparse process compliance" }
+          ]
+        }
+      }
+    }'::json,
+    1
+  ),
+  (
+    '53000000-0000-0000-0000-000000000301',
+    '12000000-0000-0000-0000-000000000011',
+    '{
+      "modellingAndValidation": {
+        "validation": {
+          "reviewerValidationMarker": "Reviewer model validation marker",
+          "review": [
+            {
+              "common:scope": [
+                {
+                  "@name": "Reviewer model scope",
+                  "common:method": { "@name": "Reviewer model method" }
+                }
+              ]
+            }
+          ]
+        },
+        "complianceDeclarations": {
+          "reviewerComplianceMarker": "Reviewer model compliance marker",
+          "compliance": [
+            { "common:approvalOfOverallCompliance": "Reviewer model compliance" }
+          ]
+        }
+      }
+    }'::json,
+    1
+  ),
+  (
+    '53000000-0000-0000-0000-000000000303',
+    '12000000-0000-0000-0000-000000000011',
+    '{
+      "modellingAndValidation": {
+        "validation": {
+          "review": [
+            {
+              "common:scope": [
+                {
+                  "@name": "Broken model scope",
+                  "common:method": { "@name": "Broken model method" }
+                }
+              ]
+            }
+          ]
+        },
+        "complianceDeclarations": {
+          "compliance": [
+            { "common:approvalOfOverallCompliance": "Broken model compliance" }
+          ]
+        }
+      }
+    }'::json,
+    1
+  ),
+  (
+    '53000000-0000-0000-0000-000000000304',
+    '12000000-0000-0000-0000-000000000011',
+    '{
+      "modellingAndValidation": {
+        "validation": {
+          "review": [
+            {
+              "common:scope": [
+                {
+                  "@name": "Reviewer sparse model scope",
+                  "common:method": { "@name": "Reviewer sparse model method" }
+                }
+              ]
+            }
+          ]
+        },
+        "complianceDeclarations": {
+          "compliance": [
+            { "common:approvalOfOverallCompliance": "Reviewer sparse model compliance" }
+          ]
+        }
+      }
+    }'::json,
+    1
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000010', true);
+
+select is(
+  public.cmd_review_save_assignment_draft(
+    '53000000-0000-0000-0000-000000000201',
+    '["12000000-0000-0000-0000-000000000011","12000000-0000-0000-0000-000000000012"]'::jsonb,
+    '{"command":"review_save_assignment_draft"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can temporary-save reviewer assignments'
+);
+
+select is(
+  (select reviewer_id::text from public.reviews where id = '53000000-0000-0000-0000-000000000201'),
+  '["12000000-0000-0000-0000-000000000011", "12000000-0000-0000-0000-000000000012"]',
+  'temporary assignment draft updates review.reviewer_id'
+);
+
+select is(
+  public.cmd_review_assign_reviewers(
+    '53000000-0000-0000-0000-000000000201',
+    '["12000000-0000-0000-0000-000000000011","12000000-0000-0000-0000-000000000012"]'::jsonb,
+    '2026-05-01T00:00:00Z'::timestamptz,
+    '{"command":"review_assign_reviewers"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can finalize reviewer assignment'
+);
+
+select is(
+  (select state_code::text from public.reviews where id = '53000000-0000-0000-0000-000000000201'),
+  '1',
+  'assigning reviewers moves the review into assigned state'
+);
+
+select is(
+  (select count(*)::text from public.comments where review_id = '53000000-0000-0000-0000-000000000201' and state_code = 0),
+  '2',
+  'assigning reviewers creates draft comment rows for each reviewer'
+);
+
+select is(
+  public.cmd_review_revoke_reviewer(
+    '53000000-0000-0000-0000-000000000201',
+    '12000000-0000-0000-0000-000000000012',
+    '{"command":"review_revoke_reviewer"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can revoke an assigned reviewer'
+);
+
+select is(
+  (select state_code::text from public.comments where review_id = '53000000-0000-0000-0000-000000000201' and reviewer_id = '12000000-0000-0000-0000-000000000012'),
+  '-2',
+  'revoking a reviewer marks their comment row as revoked'
+);
+
+select is(
+  (select reviewer_id::text from public.reviews where id = '53000000-0000-0000-0000-000000000201'),
+  '["12000000-0000-0000-0000-000000000011"]',
+  'revoking a reviewer removes them from review.reviewer_id'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000011', true);
+
+select is(
+  public.cmd_review_save_comment_draft(
+    '53000000-0000-0000-0000-000000000202',
+    '{
+      "modellingAndValidation": {
+        "validation": {
+          "review": [
+            {
+              "common:scope": [
+                {
+                  "@name": "Reviewer draft scope",
+                  "common:method": { "@name": "Reviewer draft method" }
+                }
+              ]
+            }
+          ]
+        },
+        "complianceDeclarations": {
+          "compliance": [
+            { "common:approvalOfOverallCompliance": "Reviewer draft compliance" }
+          ]
+        }
+      }
+    }'::jsonb,
+    '{"command":"review_save_comment_draft"}'::jsonb
+  )->>'ok',
+  'true',
+  'assigned reviewer can temporarily save review comments'
+);
+
+select is(
+  (select state_code::text from public.reviews where id = '53000000-0000-0000-0000-000000000202'),
+  '1',
+  'saving a reviewer draft does not change the review state'
+);
+
+select is(
+  (select reviewer_id::text from public.comments where review_id = '53000000-0000-0000-0000-000000000202' and reviewer_id = '12000000-0000-0000-0000-000000000011'),
+  '12000000-0000-0000-0000-000000000011',
+  'saving a reviewer draft does not change comment.reviewer_id'
+);
+
+select is(
+  public.cmd_review_submit_comment(
+    '53000000-0000-0000-0000-000000000202',
+    '{
+      "modellingAndValidation": {
+        "validation": {
+          "review": [
+            {
+              "common:scope": [
+                {
+                  "@name": "Reviewer submitted scope",
+                  "common:method": { "@name": "Reviewer submitted method" }
+                }
+              ],
+              "common:referenceToReviewDetails": {
+                "@type": "flow data set",
+                "@refObjectId": "32000000-0000-0000-0000-000000000212",
+                "@version": "01.00.000"
+              }
+            }
+          ]
+        },
+        "complianceDeclarations": {
+          "compliance": [
+            { "common:approvalOfOverallCompliance": "Reviewer submitted compliance" }
+          ]
+        }
+      }
+    }'::jsonb,
+    '{"command":"review_submit_comment"}'::jsonb
+  )->>'ok',
+  'true',
+  'assigned reviewer can submit review comments through one command'
+);
+
+select is(
+  (select state_code::text from public.flows where id = '32000000-0000-0000-0000-000000000212' and version = '01.00.000'),
+  '20',
+  'submitting a reviewer comment promotes referenced draft data to under-review state'
+);
+
+select is(
+  (select state_code::text from public.comments where review_id = '53000000-0000-0000-0000-000000000202' and reviewer_id = '12000000-0000-0000-0000-000000000011'),
+  '1',
+  'submitting a reviewer comment moves the reviewer comment row to submitted state'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000010', true);
+
+select is(
+  public.cmd_review_approve(
+    'processes',
+    '53000000-0000-0000-0000-000000000203',
+    '{"command":"review_approve"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can approve a process review in one command'
+);
+
+select is(
+  (select state_code::text from public.processes where id = '32000000-0000-0000-0000-000000000203' and version = '01.00.000'),
+  '100',
+  'approving a process review publishes the root dataset'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,validation,review,1,common:scope,0,@name}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000203'
+     and version = '01.00.000'),
+  'Reviewer process scope',
+  'approving a process review merges reviewer validation content into the root process'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,complianceDeclarations,compliance,1,common:approvalOfOverallCompliance}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000203'
+     and version = '01.00.000'),
+  'Reviewer process compliance',
+  'approving a process review merges reviewer compliance content into the root process'
+);
+
+select is(
+  (select coalesce(
+     json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,validation,reviewerValidationMarker}',
+     '__missing__'
+   )
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000203'
+     and version = '01.00.000'),
+  '__missing__',
+  'approving a process review does not merge validation-level object fields into the root process'
+);
+
+select is(
+  (select coalesce(
+     json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,complianceDeclarations,reviewerComplianceMarker}',
+     '__missing__'
+   )
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000203'
+     and version = '01.00.000'),
+  '__missing__',
+  'approving a process review does not merge complianceDeclarations-level object fields into the root process'
+);
+
+select is(
+  public.cmd_review_approve(
+    'processes',
+    '53000000-0000-0000-0000-000000000205',
+    '{"command":"review_approve"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can approve a sparse process review when review and compliance fields are missing'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,validation,review,0,common:scope,0,@name}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000205'
+     and version = '01.00.000'),
+  'Reviewer sparse process scope',
+  'approving a sparse process review creates the missing validation.review field before merging comment content'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,complianceDeclarations,compliance,0,common:approvalOfOverallCompliance}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000205'
+     and version = '01.00.000'),
+  'Reviewer sparse process compliance',
+  'approving a sparse process review creates the missing complianceDeclarations.compliance field before merging comment content'
+);
+
+select is(
+  public.cmd_review_reject(
+    'processes',
+    '53000000-0000-0000-0000-000000000204',
+    'Needs more evidence',
+    '{"command":"review_reject"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can reject a review in one command'
+);
+
+select is(
+  (select state_code::text from public.processes where id = '32000000-0000-0000-0000-000000000204' and version = '01.00.000'),
+  '0',
+  'rejecting a review rolls the root dataset back to draft state'
+);
+
+select is(
+  (select state_code::text from public.reviews where id = '53000000-0000-0000-0000-000000000204'),
+  '-1',
+  'rejecting a review marks the review row as rejected'
+);
+
+select is(
+  public.cmd_review_approve(
+    'lifecyclemodels',
+    '53000000-0000-0000-0000-000000000301',
+    '{"command":"review_approve"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can approve a lifecycle model review in one command'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{lifeCycleModelDataSet,modellingAndValidation,validation,review,1,common:scope,0,@name}'
+   from public.lifecyclemodels
+   where id = '32000000-0000-0000-0000-000000000301'
+     and version = '01.00.000'),
+  'Reviewer model scope',
+  'approving a lifecycle model review merges reviewer validation content into the root lifecycle model'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{lifeCycleModelDataSet,modellingAndValidation,complianceDeclarations,compliance,1,common:approvalOfOverallCompliance}'
+   from public.lifecyclemodels
+   where id = '32000000-0000-0000-0000-000000000301'
+     and version = '01.00.000'),
+  'Reviewer model compliance',
+  'approving a lifecycle model review merges reviewer compliance content into the root lifecycle model'
+);
+
+select is(
+  (select state_code::text from public.processes where id = '32000000-0000-0000-0000-000000000302' and version = '01.00.000'),
+  '100',
+  'approving a lifecycle model review publishes linked secondary processes'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,validation,review,1,common:scope,0,@name}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000302'
+     and version = '01.00.000'),
+  'Reviewer model scope',
+  'approving a lifecycle model review pushes reviewer validation content into submodel processes'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,validation,review,0,common:scope,0,@name}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000302'
+     and version = '01.00.000'),
+  'Old submodel review',
+  'approving a lifecycle model review keeps existing submodel validation content before appending reviewer review content'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,complianceDeclarations,compliance,1,common:approvalOfOverallCompliance}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000302'
+     and version = '01.00.000'),
+  'Reviewer model compliance',
+  'approving a lifecycle model review merges reviewer compliance content into submodel processes'
+);
+
+select is(
+  (select jsonb_array_length(json_ordered::jsonb #> '{processDataSet,modellingAndValidation,validation,review}')::text
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000302'
+     and version = '01.00.000'),
+  '2',
+  'approving a lifecycle model review does not duplicate reviewer validation entries in submodel processes'
+);
+
+select is(
+  (select coalesce(
+     json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,validation,reviewerValidationMarker}',
+     '__missing__'
+   )
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000302'
+     and version = '01.00.000'),
+  '__missing__',
+  'approving a lifecycle model review does not merge validation-level object fields into submodel processes'
+);
+
+select is(
+  (select coalesce(
+     json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,complianceDeclarations,reviewerComplianceMarker}',
+     '__missing__'
+   )
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000302'
+     and version = '01.00.000'),
+  '__missing__',
+  'approving a lifecycle model review does not merge complianceDeclarations-level object fields into submodel processes'
+);
+
+select is(
+  public.cmd_review_approve(
+    'lifecyclemodels',
+    '53000000-0000-0000-0000-000000000304',
+    '{"command":"review_approve"}'::jsonb
+  )->>'ok',
+  'true',
+  'review admin can approve a sparse lifecycle model review when review and compliance fields are missing'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{lifeCycleModelDataSet,modellingAndValidation,validation,review,0,common:scope,0,@name}'
+   from public.lifecyclemodels
+   where id = '32000000-0000-0000-0000-000000000304'
+     and version = '01.00.000'),
+  'Reviewer sparse model scope',
+  'approving a sparse lifecycle model review creates the missing model validation.review field before merging comment content'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{lifeCycleModelDataSet,modellingAndValidation,complianceDeclarations,compliance,0,common:approvalOfOverallCompliance}'
+   from public.lifecyclemodels
+   where id = '32000000-0000-0000-0000-000000000304'
+     and version = '01.00.000'),
+  'Reviewer sparse model compliance',
+  'approving a sparse lifecycle model review creates the missing model complianceDeclarations.compliance field before merging comment content'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,validation,review,0,common:scope,0,@name}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000305'
+     and version = '01.00.000'),
+  'Reviewer sparse model scope',
+  'approving a sparse lifecycle model review creates the missing submodel validation.review field before merging comment content'
+);
+
+select is(
+  (select json_ordered::jsonb #>> '{processDataSet,modellingAndValidation,complianceDeclarations,compliance,0,common:approvalOfOverallCompliance}'
+   from public.processes
+   where id = '32000000-0000-0000-0000-000000000305'
+     and version = '01.00.000'),
+  'Reviewer sparse model compliance',
+  'approving a sparse lifecycle model review creates the missing submodel complianceDeclarations.compliance field before merging comment content'
+);
+
+select is(
+  public.cmd_review_approve(
+    'lifecyclemodels',
+    '53000000-0000-0000-0000-000000000303',
+    '{"command":"review_approve"}'::jsonb
+  )->>'code',
+  'INVALID_PAYLOAD',
+  'lifecycle model approval fails when a referenced submodel snapshot is missing'
+);
+
+select is(
+  (select state_code::text from public.reviews where id = '53000000-0000-0000-0000-000000000303'),
+  '1',
+  'failed lifecycle model approval leaves the review state unchanged'
+);
+
+select is(
+  (select state_code::text from public.lifecyclemodels where id = '32000000-0000-0000-0000-000000000303' and version = '01.00.000'),
+  '20',
+  'failed lifecycle model approval leaves the root dataset state unchanged'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260407_lifecycle_model_bundle_delete.sql
+++ b/supabase/tests/20260407_lifecycle_model_bundle_delete.sql
@@ -1,0 +1,101 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(3);
+
+alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
+alter table public.processes disable trigger "process_extract_md_trigger_insert";
+alter table public.processes disable trigger "process_extract_text_trigger_insert";
+
+insert into public.lifecyclemodels (id, version, user_id, json_ordered, json_tg, rule_verification)
+values (
+  '95000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '95000000-0000-0000-0000-0000000000aa',
+  '{
+    "lifeCycleModelDataSet": {
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json,
+  '{
+    "submodels": [
+      {
+        "id": "95000000-0000-0000-0000-000000000101",
+        "version": "01.00.000"
+      },
+      {
+        "id": "95000000-0000-0000-0000-000000000102",
+        "version": "01.00.000"
+      }
+    ]
+  }'::jsonb,
+  true
+);
+
+insert into public.processes (
+  id,
+  version,
+  user_id,
+  model_id,
+  json_ordered,
+  rule_verification
+)
+values (
+  '95000000-0000-0000-0000-000000000101',
+  '01.00.000',
+  '95000000-0000-0000-0000-0000000000aa',
+  '95000000-0000-0000-0000-000000000001',
+  '{
+    "processDataSet": {
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json,
+  true
+);
+
+select is(
+  public.delete_lifecycle_model_bundle(
+    '95000000-0000-0000-0000-000000000001',
+    '01.00.000'
+  )::text,
+  jsonb_build_object(
+    'model_id', '95000000-0000-0000-0000-000000000001',
+    'version', '01.00.000'
+  )::text,
+  'delete_lifecycle_model_bundle succeeds even when some referenced submodel processes are already missing'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.processes
+    where model_id = '95000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'delete_lifecycle_model_bundle removes remaining persisted submodel processes'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.lifecyclemodels
+    where id = '95000000-0000-0000-0000-000000000001'
+      and version = '01.00.000'
+  ),
+  '0',
+  'delete_lifecycle_model_bundle removes the lifecycle model row after tolerant child cleanup'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260409_comments_select_rls.sql
+++ b/supabase/tests/20260409_comments_select_rls.sql
@@ -1,0 +1,216 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(5);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '14000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'comments-submitter@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"14000000-0000-0000-0000-000000000001","email":"comments-submitter@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '14000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'assigned-reviewer@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"14000000-0000-0000-0000-000000000002","email":"assigned-reviewer@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '14000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'unassigned-reviewer@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"14000000-0000-0000-0000-000000000003","email":"unassigned-reviewer@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '14000000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    'comments-review-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"14000000-0000-0000-0000-000000000004","email":"comments-review-admin@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '14000000-0000-0000-0000-000000000005',
+    'authenticated',
+    'authenticated',
+    'comments-outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"14000000-0000-0000-0000-000000000005","email":"comments-outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('14000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000', 'review-member'),
+  ('14000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000', 'review-member'),
+  ('14000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000000', 'review-admin');
+
+insert into public.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json
+)
+values (
+  '54000000-0000-0000-0000-000000000001',
+  '64000000-0000-0000-0000-000000000001',
+  '01.00.000',
+  1,
+  '["14000000-0000-0000-0000-000000000002"]'::jsonb,
+  '{
+    "user": { "id": "14000000-0000-0000-0000-000000000001" },
+    "data": { "id": "64000000-0000-0000-0000-000000000001", "version": "01.00.000" }
+  }'::jsonb
+);
+
+insert into public.comments (
+  review_id,
+  reviewer_id,
+  json,
+  state_code
+)
+values (
+  '54000000-0000-0000-0000-000000000001',
+  '14000000-0000-0000-0000-000000000002',
+  '{"comment":"assigned reviewer draft"}'::json,
+  0
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '14000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '54000000-0000-0000-0000-000000000001'
+  ),
+  '1',
+  'review submitter can read comments for the submitted review'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '14000000-0000-0000-0000-000000000002', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '54000000-0000-0000-0000-000000000001'
+  ),
+  '1',
+  'assigned review-member can read comments for the assigned review'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '14000000-0000-0000-0000-000000000003', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '54000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'unassigned review-member cannot read comments for another review'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '14000000-0000-0000-0000-000000000004', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '54000000-0000-0000-0000-000000000001'
+  ),
+  '1',
+  'review-admin can read comments for any review'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '14000000-0000-0000-0000-000000000005', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '54000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'unrelated authenticated user cannot read review comments'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary
- adopt the tracked `tiangong-lca-next/supabase` assets into `database-engine` as the single database source of truth
- add the Supabase dev deployment workflow, branching docs, and root-level branch-binding env templates
- move database-maintenance `.env.supabase.dev.local(.example)` and `.env.supabase.main.local(.example)` ownership into this repo
- shift local Supabase ports to the `5532x` range so local validation can run alongside the existing `tiangong-lca-next` stack

## Validation
- `supabase start`
- `supabase db reset`

## Notes
- Refs tiangong-lca/workspace#67
- Manual Supabase GitHub integration rebind to repository `tiangong-lca/database-engine` with relative path `supabase` is still required after review.
- `tiangong-lca-next/supabase` remains read-only until the cutover is completed.
