### PR TITLE
test: validate preview branch cutover

### DIFF
--- a/supabase/migrations/20260414151605_preview_branch_validation_comment.sql
+++ b/supabase/migrations/20260414151605_preview_branch_validation_comment.sql
@@ -1,0 +1,2 @@
+comment on table public.command_audit_log is
+  'Validation-only migration for database-engine preview branch cutover on 2026-04-14.';


### PR DESCRIPTION
## Summary
- add a validation-only migration that updates the comment on `public.command_audit_log`
- use this PR to verify that Supabase preview branches now follow `tiangong-lca/database-engine` PRs after the repository cutover

## Change
- `comment on table public.command_audit_log is 'Validation-only migration for database-engine preview branch cutover on 2026-04-14.';`

## Validation
- `supabase start`
- `supabase db reset`
- `supabase stop --project-id database-engine`

## Notes
- Refs tiangong-lca/workspace#67
- This PR is intentionally low-risk and exists only to validate preview-branch creation/update from the new repo binding.
