### PR TITLE
fix: tighten review read boundaries

### DIFF
--- a/supabase/migrations/20260415120000_access_control_fix_review_read_boundaries.sql
+++ b/supabase/migrations/20260415120000_access_control_fix_review_read_boundaries.sql
@@ -1,0 +1,453 @@
+create or replace function public.cmd_review_is_review_member(p_actor uuid default auth.uid())
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.roles
+    where user_id = coalesce(p_actor, auth.uid())
+      and team_id = '00000000-0000-0000-0000-000000000000'::uuid
+      and role = 'review-member'
+  )
+$$;
+
+create or replace function public.policy_review_can_read(
+  p_review_id uuid,
+  p_actor uuid default auth.uid()
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.reviews as r
+    where r.id = p_review_id
+      and coalesce(p_actor, auth.uid()) is not null
+      and (
+        public.cmd_review_is_review_admin(coalesce(p_actor, auth.uid()))
+        or ((r.json -> 'user' ->> 'id')::uuid = coalesce(p_actor, auth.uid()))
+        or (
+          public.cmd_review_is_review_member(coalesce(p_actor, auth.uid()))
+          and (
+            coalesce(r.reviewer_id, '[]'::jsonb) ? coalesce(p_actor, auth.uid())::text
+            or exists (
+              select 1
+              from public.comments as c
+              where c.review_id = r.id
+                and c.reviewer_id = coalesce(p_actor, auth.uid())
+            )
+          )
+        )
+      )
+  )
+$$;
+
+create or replace function public.cmd_review_resolve_queue_order_by(
+  p_sort_by text,
+  p_allow_comment_modified boolean default false
+)
+returns text
+language plpgsql
+immutable
+set search_path = public, pg_temp
+as $$
+begin
+  case lower(coalesce(p_sort_by, ''))
+    when 'created_at' then
+      return 'q.created_at';
+    when 'createat' then
+      return 'q.created_at';
+    when 'deadline' then
+      return 'q.deadline';
+    when 'state_code' then
+      return 'q.state_code';
+    when 'statecode' then
+      return 'q.state_code';
+    when 'comment_modified_at' then
+      if p_allow_comment_modified then
+        return 'q.comment_modified_at';
+      end if;
+    when 'commentmodifiedat' then
+      if p_allow_comment_modified then
+        return 'q.comment_modified_at';
+      end if;
+    else
+      return 'q.modified_at';
+  end case;
+
+  return 'q.modified_at';
+end;
+$$;
+
+drop policy if exists "Enable read open data access for reviews" on public.reviews;
+drop policy if exists "reviews select by review participants" on public.reviews;
+
+create policy "reviews select by review participants"
+on public.reviews
+for select
+to authenticated
+using (
+  auth.uid() is not null
+  and public.policy_review_can_read(id, auth.uid())
+);
+
+drop policy if exists "comments select by review participants" on public.comments;
+
+create policy "comments select by review participants"
+on public.comments
+for select
+to authenticated
+using (
+  auth.uid() is not null
+  and public.policy_review_can_read(review_id, auth.uid())
+  and (
+    public.cmd_review_is_review_admin(auth.uid())
+    or exists (
+      select 1
+      from public.reviews as r
+      where r.id = comments.review_id
+        and ((r.json -> 'user' ->> 'id')::uuid = auth.uid())
+    )
+    or comments.reviewer_id = auth.uid()
+  )
+);
+
+create or replace function public.qry_review_get_admin_queue_items(
+  p_status text default null,
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'modified_at',
+  p_sort_order text default 'desc'
+)
+returns table (
+  id uuid,
+  data_id uuid,
+  data_version text,
+  state_code integer,
+  reviewer_id jsonb,
+  "json" jsonb,
+  deadline timestamptz,
+  created_at timestamptz,
+  modified_at timestamptz,
+  comment_state_codes jsonb,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := public.cmd_review_resolve_queue_order_by(p_sort_by, false);
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+  v_status text := lower(coalesce(p_status, ''));
+  v_state_code integer;
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return;
+  end if;
+
+  case v_status
+    when '', 'all' then
+      v_state_code := null;
+    when 'unassigned' then
+      v_state_code := 0;
+    when 'assigned' then
+      v_state_code := 1;
+    when 'admin-rejected' then
+      v_state_code := -1;
+    else
+      return;
+  end case;
+
+  return query execute format(
+    $sql$
+      with q as (
+        select
+          r.id,
+          r.data_id,
+          r.data_version::text as data_version,
+          r.state_code,
+          coalesce(r.reviewer_id, '[]'::jsonb) as reviewer_id,
+          coalesce(r.json, '{}'::jsonb) as json,
+          r.deadline,
+          r.created_at,
+          r.modified_at,
+          coalesce(
+            jsonb_agg(to_jsonb(c.state_code) order by c.created_at asc, c.reviewer_id asc)
+              filter (where c.reviewer_id is not null),
+            '[]'::jsonb
+          ) as comment_state_codes
+        from public.reviews as r
+        left join public.comments as c
+          on c.review_id = r.id
+        where ($1::integer is null or r.state_code = $1::integer)
+        group by
+          r.id,
+          r.data_id,
+          r.data_version,
+          r.state_code,
+          r.reviewer_id,
+          r.json,
+          r.deadline,
+          r.created_at,
+          r.modified_at
+      )
+      select
+        q.id,
+        q.data_id,
+        q.data_version,
+        q.state_code,
+        q.reviewer_id,
+        q.json,
+        q.deadline,
+        q.created_at,
+        q.modified_at,
+        q.comment_state_codes,
+        count(*) over() as total_count
+      from q
+      order by %s %s nulls last, q.id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using v_state_code, v_limit, v_offset;
+end;
+$$;
+
+create or replace function public.qry_review_get_member_queue_items(
+  p_status text default 'pending',
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'modified_at',
+  p_sort_order text default 'desc'
+)
+returns table (
+  id uuid,
+  data_id uuid,
+  data_version text,
+  review_state_code integer,
+  reviewer_id jsonb,
+  "json" jsonb,
+  deadline timestamptz,
+  created_at timestamptz,
+  modified_at timestamptz,
+  comment_state_code integer,
+  comment_json jsonb,
+  comment_created_at timestamptz,
+  comment_modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := public.cmd_review_resolve_queue_order_by(p_sort_by, true);
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+  v_status text := lower(coalesce(p_status, 'pending'));
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not public.cmd_review_is_review_member(v_actor) then
+    return;
+  end if;
+
+  if v_status not in ('pending', 'reviewed', 'reviewer-rejected') then
+    return;
+  end if;
+
+  return query execute format(
+    $sql$
+      with q as (
+        select
+          r.id,
+          r.data_id,
+          r.data_version::text as data_version,
+          r.state_code as review_state_code,
+          coalesce(r.reviewer_id, '[]'::jsonb) as reviewer_id,
+          coalesce(r.json, '{}'::jsonb) as json,
+          r.deadline,
+          r.created_at,
+          r.modified_at,
+          c.state_code as comment_state_code,
+          coalesce(c.json::jsonb, '{}'::jsonb) as comment_json,
+          c.created_at as comment_created_at,
+          c.modified_at as comment_modified_at
+        from public.comments as c
+        join public.reviews as r
+          on r.id = c.review_id
+        where c.reviewer_id = $1
+          and public.policy_review_can_read(r.id, $1)
+          and (
+            ($4::text = 'pending' and c.state_code = 0 and r.state_code > 0)
+            or ($4::text = 'reviewed' and c.state_code = any (array[1, 2, -3]) and r.state_code > 0)
+            or ($4::text = 'reviewer-rejected' and c.state_code = -1 and r.state_code = -1)
+          )
+      )
+      select
+        q.id,
+        q.data_id,
+        q.data_version,
+        q.review_state_code,
+        q.reviewer_id,
+        q.json,
+        q.deadline,
+        q.created_at,
+        q.modified_at,
+        q.comment_state_code,
+        q.comment_json,
+        q.comment_created_at,
+        q.comment_modified_at,
+        count(*) over() as total_count
+      from q
+      order by %s %s nulls last, q.id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using v_actor, v_limit, v_offset, v_status;
+end;
+$$;
+
+create or replace function public.qry_review_get_items(
+  p_review_ids uuid[] default null,
+  p_data_id uuid default null,
+  p_data_version text default null,
+  p_state_codes integer[] default null
+)
+returns table (
+  id uuid,
+  data_id uuid,
+  data_version text,
+  state_code integer,
+  reviewer_id jsonb,
+  "json" jsonb,
+  deadline timestamptz,
+  created_at timestamptz,
+  modified_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select
+    r.id,
+    r.data_id,
+    r.data_version::text as data_version,
+    r.state_code,
+    coalesce(r.reviewer_id, '[]'::jsonb) as reviewer_id,
+    coalesce(r.json, '{}'::jsonb) as json,
+    r.deadline,
+    r.created_at,
+    r.modified_at
+  from public.reviews as r
+  where (p_review_ids is null or r.id = any (p_review_ids))
+    and (
+      p_data_id is null
+      or r.data_id = p_data_id
+      or coalesce(r.json -> 'data' ->> 'id', '') = p_data_id::text
+    )
+    and (
+      p_data_version is null
+      or r.data_version = p_data_version
+      or coalesce(r.json -> 'data' ->> 'version', '') = p_data_version
+    )
+    and (p_state_codes is null or r.state_code = any (p_state_codes))
+    and public.policy_review_can_read(r.id, auth.uid())
+  order by r.modified_at desc, r.id desc
+$$;
+
+create or replace function public.qry_review_get_comment_items(
+  p_review_id uuid,
+  p_scope text default 'auto'
+)
+returns table (
+  review_id uuid,
+  reviewer_id uuid,
+  state_code integer,
+  "json" jsonb,
+  created_at timestamptz,
+  modified_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  with actor as (
+    select
+      auth.uid() as actor_id,
+      public.cmd_review_is_review_admin(auth.uid()) as is_review_admin,
+      exists (
+        select 1
+        from public.reviews as r
+        where r.id = p_review_id
+          and ((r.json -> 'user' ->> 'id')::uuid = auth.uid())
+      ) as is_owner
+  )
+  select
+    c.review_id,
+    c.reviewer_id,
+    c.state_code,
+    coalesce(c.json::jsonb, '{}'::jsonb) as json,
+    c.created_at,
+    c.modified_at
+  from public.comments as c
+  cross join actor as a
+  where c.review_id = p_review_id
+    and public.policy_review_can_read(p_review_id, a.actor_id)
+    and (
+      a.is_review_admin
+      or a.is_owner
+      or c.reviewer_id = a.actor_id
+    )
+    and (
+      lower(coalesce(p_scope, 'auto')) not in ('mine', 'self')
+      or c.reviewer_id = a.actor_id
+    )
+  order by c.created_at asc, c.reviewer_id asc
+$$;
+
+revoke all on function public.cmd_review_is_review_member(uuid) from public;
+revoke all on function public.policy_review_can_read(uuid, uuid) from public;
+revoke all on function public.qry_review_get_admin_queue_items(text, integer, integer, text, text) from public;
+revoke all on function public.qry_review_get_member_queue_items(text, integer, integer, text, text) from public;
+revoke all on function public.qry_review_get_items(uuid[], uuid, text, integer[]) from public;
+revoke all on function public.qry_review_get_comment_items(uuid, text) from public;
+
+grant execute on function public.cmd_review_is_review_member(uuid) to authenticated;
+grant execute on function public.policy_review_can_read(uuid, uuid) to authenticated;
+grant execute on function public.qry_review_get_admin_queue_items(text, integer, integer, text, text) to authenticated;
+grant execute on function public.qry_review_get_member_queue_items(text, integer, integer, text, text) to authenticated;
+grant execute on function public.qry_review_get_items(uuid[], uuid, text, integer[]) to authenticated;
+grant execute on function public.qry_review_get_comment_items(uuid, text) to authenticated;
+
+grant execute on function public.cmd_review_is_review_member(uuid) to service_role;
+grant execute on function public.policy_review_can_read(uuid, uuid) to service_role;
+grant execute on function public.qry_review_get_admin_queue_items(text, integer, integer, text, text) to service_role;
+grant execute on function public.qry_review_get_member_queue_items(text, integer, integer, text, text) to service_role;
+grant execute on function public.qry_review_get_items(uuid[], uuid, text, integer[]) to service_role;
+grant execute on function public.qry_review_get_comment_items(uuid, text) to service_role;

--- a/supabase/tests/20260415_review_read_query_boundaries.sql
+++ b/supabase/tests/20260415_review_read_query_boundaries.sql
@@ -1,0 +1,583 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(22);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'review-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"15000000-0000-0000-0000-000000000001","email":"review-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'assigned-reviewer@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"15000000-0000-0000-0000-000000000002","email":"assigned-reviewer@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'peer-reviewer@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"15000000-0000-0000-0000-000000000003","email":"peer-reviewer@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    'unassigned-reviewer@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"15000000-0000-0000-0000-000000000004","email":"unassigned-reviewer@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-0000-0000-000000000005',
+    'authenticated',
+    'authenticated',
+    'review-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"15000000-0000-0000-0000-000000000005","email":"review-admin@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-0000-0000-000000000006',
+    'authenticated',
+    'authenticated',
+    'outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"15000000-0000-0000-0000-000000000006","email":"outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-0000-0000-000000000007',
+    'authenticated',
+    'authenticated',
+    'team-review-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"15000000-0000-0000-0000-000000000007","email":"team-review-admin@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-0000-0000-000000000008',
+    'authenticated',
+    'authenticated',
+    'former-reviewer@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"15000000-0000-0000-0000-000000000008","email":"former-reviewer@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data)
+values
+  ('15000000-0000-0000-0000-000000000001', '{"email":"review-owner@example.com"}'::jsonb),
+  ('15000000-0000-0000-0000-000000000002', '{"email":"assigned-reviewer@example.com"}'::jsonb),
+  ('15000000-0000-0000-0000-000000000003', '{"email":"peer-reviewer@example.com"}'::jsonb),
+  ('15000000-0000-0000-0000-000000000004', '{"email":"unassigned-reviewer@example.com"}'::jsonb),
+  ('15000000-0000-0000-0000-000000000005', '{"email":"review-admin@example.com"}'::jsonb),
+  ('15000000-0000-0000-0000-000000000006', '{"email":"outsider@example.com"}'::jsonb),
+  ('15000000-0000-0000-0000-000000000007', '{"email":"team-review-admin@example.com"}'::jsonb),
+  ('15000000-0000-0000-0000-000000000008', '{"email":"former-reviewer@example.com"}'::jsonb);
+
+insert into public.teams (id, json, rank, is_public)
+values (
+  '25000000-0000-0000-0000-000000000001',
+  '{"title":[{"@xml:lang":"en","#text":"Review Scope Team"}]}'::jsonb,
+  1,
+  false
+);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('15000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000', 'review-member'),
+  ('15000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000', 'review-member'),
+  ('15000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000000', 'review-member'),
+  ('15000000-0000-0000-0000-000000000005', '00000000-0000-0000-0000-000000000000', 'review-admin'),
+  ('15000000-0000-0000-0000-000000000007', '25000000-0000-0000-0000-000000000001', 'review-admin'),
+  ('15000000-0000-0000-0000-000000000008', '00000000-0000-0000-0000-000000000000', 'review-member');
+
+insert into public.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json,
+  created_at,
+  modified_at
+)
+values
+  (
+    '55000000-0000-0000-0000-000000000001',
+    '65000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    1,
+    '["15000000-0000-0000-0000-000000000002","15000000-0000-0000-0000-000000000003"]'::jsonb,
+    '{
+      "user": { "id": "15000000-0000-0000-0000-000000000001" },
+      "data": { "id": "65000000-0000-0000-0000-000000000001", "version": "01.00.000" }
+    }'::jsonb,
+    now() - interval '3 days',
+    now() - interval '1 day'
+  ),
+  (
+    '55000000-0000-0000-0000-000000000002',
+    '65000000-0000-0000-0000-000000000002',
+    '01.00.000',
+    2,
+    '["15000000-0000-0000-0000-000000000002"]'::jsonb,
+    '{
+      "user": { "id": "15000000-0000-0000-0000-000000000001" },
+      "data": { "id": "65000000-0000-0000-0000-000000000002", "version": "01.00.000" }
+    }'::jsonb,
+    now() - interval '4 days',
+    now() - interval '2 days'
+  ),
+  (
+    '55000000-0000-0000-0000-000000000003',
+    '65000000-0000-0000-0000-000000000003',
+    '01.00.000',
+    -1,
+    '["15000000-0000-0000-0000-000000000002"]'::jsonb,
+    '{
+      "user": { "id": "15000000-0000-0000-0000-000000000001" },
+      "data": { "id": "65000000-0000-0000-0000-000000000003", "version": "01.00.000" }
+    }'::jsonb,
+    now() - interval '5 days',
+    now() - interval '3 days'
+  ),
+  (
+    '55000000-0000-0000-0000-000000000004',
+    '65000000-0000-0000-0000-000000000004',
+    '01.00.000',
+    2,
+    '[]'::jsonb,
+    '{
+      "user": { "id": "15000000-0000-0000-0000-000000000001" },
+      "data": { "id": "65000000-0000-0000-0000-000000000004", "version": "01.00.000" }
+    }'::jsonb,
+    now() - interval '6 days',
+    now() - interval '4 days'
+  );
+
+insert into public.comments (
+  review_id,
+  reviewer_id,
+  json,
+  state_code,
+  created_at,
+  modified_at
+)
+values
+  (
+    '55000000-0000-0000-0000-000000000001',
+    '15000000-0000-0000-0000-000000000002',
+    '{"comment":"assigned reviewer draft"}'::json,
+    0,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    '55000000-0000-0000-0000-000000000001',
+    '15000000-0000-0000-0000-000000000003',
+    '{"comment":"peer reviewer finished"}'::json,
+    1,
+    now() - interval '36 hours',
+    now() - interval '36 hours'
+  ),
+  (
+    '55000000-0000-0000-0000-000000000002',
+    '15000000-0000-0000-0000-000000000002',
+    '{"comment":"assigned reviewer approved"}'::json,
+    1,
+    now() - interval '3 days',
+    now() - interval '3 days'
+  ),
+  (
+    '55000000-0000-0000-0000-000000000003',
+    '15000000-0000-0000-0000-000000000002',
+    '{"comment":"assigned reviewer rejected"}'::json,
+    -1,
+    now() - interval '4 days',
+    now() - interval '4 days'
+  ),
+  (
+    '55000000-0000-0000-0000-000000000004',
+    '15000000-0000-0000-0000-000000000008',
+    '{"comment":"former reviewer history"}'::json,
+    1,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000006', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.reviews
+    where id in (
+      '55000000-0000-0000-0000-000000000001',
+      '55000000-0000-0000-0000-000000000002',
+      '55000000-0000-0000-0000-000000000003'
+    )
+  ),
+  '0',
+  'outsider cannot read submitted, reviewed, or rejected review rows directly'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000007', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.reviews
+    where id = '55000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'team-scoped review-admin cannot use a non-system role to read review rows'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.reviews
+    where id in (
+      '55000000-0000-0000-0000-000000000001',
+      '55000000-0000-0000-0000-000000000002',
+      '55000000-0000-0000-0000-000000000003',
+      '55000000-0000-0000-0000-000000000004'
+    )
+  ),
+  '4',
+  'review owner can read all of their own review rows regardless of state'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000002', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.reviews
+    where id in (
+      '55000000-0000-0000-0000-000000000001',
+      '55000000-0000-0000-0000-000000000002',
+      '55000000-0000-0000-0000-000000000003',
+      '55000000-0000-0000-0000-000000000004'
+    )
+  ),
+  '3',
+  'assigned review-member can only read their assigned review rows'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '55000000-0000-0000-0000-000000000001'
+  ),
+  '1',
+  'review-member can only read their own comment rows on an assigned review'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_member_queue_items('pending', 1, 10, 'modified_at', 'desc')
+  ),
+  '1',
+  'member pending queue RPC only returns the actor pending rows'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_member_queue_items('reviewed', 1, 10, 'modified_at', 'desc')
+  ),
+  '1',
+  'member reviewed queue RPC only returns the actor reviewed rows'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_member_queue_items('reviewer-rejected', 1, 10, 'modified_at', 'desc')
+  ),
+  '1',
+  'member rejected queue RPC only returns the actor rejected rows'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_comment_items('55000000-0000-0000-0000-000000000001', 'all')
+  ),
+  '1',
+  'review-member comment query RPC still collapses all-scope requests down to the actor own rows'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000008', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.reviews
+    where id = '55000000-0000-0000-0000-000000000004'
+  ),
+  '1',
+  'former review participant can still read review history via their own comment participation'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000004', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.reviews
+    where id = '55000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'unassigned review-member cannot read another review row'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000005', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.reviews
+    where id in (
+      '55000000-0000-0000-0000-000000000001',
+      '55000000-0000-0000-0000-000000000002',
+      '55000000-0000-0000-0000-000000000003',
+      '55000000-0000-0000-0000-000000000004'
+    )
+  ),
+  '4',
+  'system review-admin can read every review row'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '55000000-0000-0000-0000-000000000001'
+  ),
+  '2',
+  'system review-admin can read all comments for a review'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_admin_queue_items('assigned', 1, 10, 'modified_at', 'desc')
+  ),
+  '1',
+  'admin queue RPC returns the assigned review set'
+);
+
+select is(
+  (
+    select coalesce(jsonb_agg(value order by value)::text, '[]')
+    from jsonb_array_elements(
+      (
+        select comment_state_codes
+        from public.qry_review_get_admin_queue_items('assigned', 1, 10, 'modified_at', 'desc')
+        limit 1
+      )
+    ) as value
+  ),
+  '[0, 1]',
+  'admin queue RPC includes aggregated reviewer state codes for progress rendering'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_comment_items('55000000-0000-0000-0000-000000000001', 'all')
+  ),
+  '2',
+  'admin comment query RPC can read every comment row for the review'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '55000000-0000-0000-0000-000000000001'
+  ),
+  '2',
+  'review owner can read all comments for their own review'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_items(
+      array['55000000-0000-0000-0000-000000000001'::uuid],
+      null,
+      null,
+      null
+    )
+  ),
+  '1',
+  'generic review item RPC returns a directly addressed review for its owner'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_items(
+      null,
+      '65000000-0000-0000-0000-000000000004'::uuid,
+      '01.00.000',
+      null
+    )
+  ),
+  '1',
+  'generic review item RPC can resolve review history by data id and version for logs/detail views'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_comment_items('55000000-0000-0000-0000-000000000001', 'all')
+  ),
+  '2',
+  'owner comment query RPC can read every comment row for the review'
+);
+
+reset role;
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '15000000-0000-0000-0000-000000000006', true);
+
+select is(
+  (
+    select count(*)::text
+    from public.comments
+    where review_id = '55000000-0000-0000-0000-000000000001'
+  ),
+  '0',
+  'outsider cannot read review comments'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.qry_review_get_items(
+      array['55000000-0000-0000-0000-000000000001'::uuid],
+      null,
+      null,
+      null
+    )
+  ),
+  '0',
+  'generic review item RPC returns nothing for an unauthorized actor'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes #6

## Summary
- tighten review read-side RLS for `reviews` and `comments`
- add explicit review query RPCs for admin queue, member queue, detail/history, and comment reads
- add pgTAP regression coverage for allowed/denied read paths

## Key Decisions
- remove the old `reviews.state_code in (2, -1)` open-read fallback and replace it with explicit `review-admin / owner / review-member` semantics
- keep historical access for review participants through existing comment participation instead of only the current `reviewer_id` assignment list
- narrow `review-member` comment visibility to the actor's own comment rows; only review owner and system `review-admin` can read all comments for a review

## Validation
- `supabase db reset`
- `supabase test db supabase/tests/20260415_review_read_query_boundaries.sql`
- `supabase test db supabase/tests/20260409_comments_select_rls.sql`

## Follow-up
- `linancn/tiangong-lca-next#341` still needs to switch the review pages from direct table reads to the new RPCs before the full read-path cutover is complete.
