### PR TITLE
docs: add AI-facing repo contract layer for database-engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,146 @@
+---
+title: database-engine AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: database-engine
+language: en
+whenToUse:
+  - when a task may change database schema, migrations, seeds, Supabase branch config, or database-side SQL tests
+  - when routing work from the workspace root into the database-engine repo
+  - when deciding whether a change belongs here, in tiangong-lca-next, in tiangong-lca-edge-functions, or in lca-workspace
+whenToUpdate:
+  - when repo ownership or source-of-truth paths change
+  - when branch policy or workspace integration rules change
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - supabase/config.toml
+  - supabase/migrations/**
+  - supabase/tests/**
+  - supabase/seed.sql
+  - supabase/seeds/**
+  - supabase/workspace/**
+  - scripts/**
+  - docs/agents/**
+  - .github/workflows/**
+  - .env.supabase*.example
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 0ffe436a3bc80671d68c3f2ff37b248146bc6af2
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - docs/agents/supabase-branching.md
+---
+
+# AGENTS.md — database-engine AI Working Guide
+
+`database-engine` owns the checked-in Supabase database contract for the TianGong LCA workspace. Start here when the task may change schema truth, migration history, database-side tests, branch bindings, or the automation that deploys the persistent Supabase `dev` branch.
+
+## AI Load Order
+
+Load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md` for change verification
+5. `ai/architecture.md` for schema-workspace or hotspot context
+6. `docs/agents/supabase-branching.md` for deeper branch-operation rules
+7. `supabase/workspace/README.md` and `scripts/README.md` only when working with generated schema workspace helpers
+
+Do not start with the generated schema workspace, long migration files, or GitHub UI branch defaults.
+
+## Repo Ownership
+
+This repo owns:
+
+- `supabase/config.toml`
+- `supabase/migrations/**`
+- `supabase/seed.sql`
+- `supabase/seeds/**`
+- `supabase/tests/**`
+- `scripts/**` for schema export, workspace refresh, change copying, and migration generation
+- `.github/workflows/supabase-dev.yml`
+- `.env.supabase.dev.local.example`
+- `.env.supabase.main.local.example`
+- branching and database-operations docs under `docs/agents/**`
+
+This repo does not own:
+
+- frontend runtime env selection or app-side Supabase clients
+- Edge Function runtime code
+- workspace submodule pointer bumps or delivery completion
+
+Route those tasks to:
+
+- `tiangong-lca-next` for frontend envs and app-side Supabase integration
+- `tiangong-lca-edge-functions` for Edge Function runtime behavior
+- `lca-workspace` for root integration after merge
+
+## Branch Facts
+
+- GitHub default branch: `main`
+- True daily trunk: `dev`
+- Routine branch base: `dev`
+- Routine PR base: `dev`
+- Promote path: `dev -> main`
+- Hotfix path: branch from `main`, merge back into `main`, then back-merge `main -> dev`
+
+Do not infer the working trunk from GitHub default-branch UI.
+
+## Stable Vs Generated Paths
+
+Treat these as stable manual-edit locations:
+
+- `supabase/migrations/**`
+- `supabase/seed.sql`
+- `supabase/seeds/**`
+- `supabase/tests/**`
+- `supabase/workspace/changes/**`
+- `scripts/**`
+- docs and workflow files
+
+Treat these as generated inspection views, not hand-maintained truth:
+
+- `supabase/workspace/remote_schema.sql`
+- `supabase/workspace/global/**`
+- `supabase/workspace/schemas/**`
+
+If you need to author a migration from generated workspace content, copy the target object into `supabase/workspace/changes/**` first and then generate the migration.
+
+## Quick Routes
+
+| If the task is about... | Load next |
+| --- | --- |
+| adding or editing a migration, policy, RPC, trigger, or seed | `ai/task-router.md`, then `ai/validation.md` |
+| changing branch config, auth redirect settings, or the persistent dev workflow | `ai/repo.yaml`, then `docs/agents/supabase-branching.md` |
+| investigating preview-branch failure or migration drift | `ai/validation.md`, then `docs/agents/supabase-branching.md` |
+| browsing remote schema snapshots or generating a migration from workspace files | `ai/architecture.md`, then `supabase/workspace/README.md` and `scripts/README.md` |
+| deciding whether the change belongs in frontend or edge runtime code instead | `ai/task-router.md` |
+| deciding whether root workspace integration is still pending after merge | root `AGENTS.md` and `_docs/workspace-branch-policy-contract.md` in `lca-workspace` |
+
+## Hard Boundaries
+
+- Do not treat `supabase/workspace/global/**` or `supabase/workspace/schemas/**` as stable edit locations.
+- Do not create a second workflow that pushes to the persistent Supabase `dev` branch without updating the repo contract docs in the same change.
+- Do not move frontend `.env` or app-side client logic into this repo.
+- Do not treat a merged PR here as delivery-complete when the workspace still needs a submodule bump.
+
+## Workspace Integration
+
+A merged PR in `database-engine` is repo-complete, not delivery-complete.
+
+If the change must ship through the workspace:
+
+1. merge the child PR into `database-engine`
+2. make sure the intended SHA is eligible for root integration
+3. update the `lca-workspace` submodule pointer deliberately
+
+For normal root `main` integration, `lca-workspace/main` should point only at commits already promoted onto `database-engine/main`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 `database-engine` is the Supabase database governance repository for the TianGong LCA workspace.
 
+## AI Entry Docs
+
+For AI-facing routing and current repo facts, start here:
+
+- `AGENTS.md`
+- `ai/repo.yaml`
+- `ai/task-router.md`
+- `ai/validation.md`
+- `ai/architecture.md`
+
 It owns the checked-in database source of truth:
 
 - `supabase/config.toml`
@@ -57,5 +67,10 @@ Frontend runtime env files stay in `tiangong-lca-next`.
 
 ## Docs
 
+- AI entrypoint: `AGENTS.md`
+- Repo facts: `ai/repo.yaml`
+- Task router: `ai/task-router.md`
+- Validation guide: `ai/validation.md`
+- Architecture notes: `ai/architecture.md`
 - English: `docs/agents/supabase-branching.md`
 - Chinese: `docs/agents/supabase-branching_CN.md`

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,120 @@
+---
+title: database-engine Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: database-engine
+language: en
+whenToUse:
+  - when you need a compact mental model of the repo before editing SQL, config, or schema-workspace tooling
+  - when deciding whether a path is stable source of truth or generated inspection output
+  - when the task mentions workspace-based migration authoring, remote schema export, or branch-specific database behavior
+whenToUpdate:
+  - when major repo paths or authoring workflows change
+  - when the generated schema workspace contract changes
+  - when new hotspot areas make the current map misleading
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - supabase/config.toml
+  - supabase/migrations/**
+  - supabase/tests/**
+  - supabase/workspace/**
+  - scripts/**
+  - .github/workflows/supabase-dev.yml
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 0ffe436a3bc80671d68c3f2ff37b248146bc6af2
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../supabase/workspace/README.md
+  - ../scripts/README.md
+---
+
+# database-engine Architecture Notes
+
+## Repo Shape
+
+This repo is organized around one checked-in Supabase project plus a generated schema-inspection workspace.
+
+## Stable Path Map
+
+| Path group | Stability | Why it matters |
+| --- | --- | --- |
+| `supabase/config.toml` | stable | shared local baseline plus branch-specific remote bindings |
+| `supabase/migrations/**` | stable | authoritative migration history and durable schema changes |
+| `supabase/seed.sql` | stable | shared seed data |
+| `supabase/seeds/dev.sql` | stable | persistent dev-only seed overlay |
+| `supabase/tests/**` | stable | PGTAP-style regression and access-control assertions |
+| `scripts/**` | stable | export, refresh, change-copy, and migration-generation helpers |
+| `.github/workflows/supabase-dev.yml` | stable | only checked-in automation for pushing committed migrations to the persistent remote `dev` branch |
+| `supabase/workspace/changes/**` | stable | manual overlay area used when generating migrations from workspace files |
+| `supabase/workspace/remote_schema.sql` | generated | full raw dump from the remote database |
+| `supabase/workspace/global/**` | generated | split-out global objects rebuilt on workspace refresh |
+| `supabase/workspace/schemas/**` | generated | human-browsable split schema objects rebuilt on workspace refresh |
+
+## Branch Model In Practice
+
+`database-engine` is an M2 repo:
+
+- Git `dev` is the daily integration trunk
+- Git `main` is the promoted release line
+- PR branches map to Supabase preview branches
+- `.github/workflows/supabase-dev.yml` pushes committed migrations to the persistent remote `dev` branch on Git `dev`
+
+This means branch behavior is part of the repo architecture, not just delivery process.
+
+## Current Hotspot Themes
+
+The current migration and test history clusters around these themes:
+
+1. access control and policy hardening
+2. review workflow command/query RPCs
+3. dataset lifecycle and publish/delete flows
+4. notification and membership query boundaries
+5. lifecycle bundle cleanup and embedding-related compatibility
+6. remote schema reconciliation and preview-branch validation
+
+If the task touches one of those areas, expect both schema truth and regression assertions to matter.
+
+## Generated Workspace Workflow
+
+The generated schema workspace exists to inspect and transform remote schema objects without hand-maintaining the generated tree.
+
+Use it like this:
+
+1. refresh the generated workspace from the target remote database
+2. inspect `remote_schema.sql`, `global/**`, or `schemas/**`
+3. copy the object you want to modify into `supabase/workspace/changes/**`
+4. generate a migration from the stable overlay file or write the migration directly
+
+Do not leave durable manual edits only inside generated paths.
+
+## Script Responsibilities
+
+| Script | Job |
+| --- | --- |
+| `scripts/export_remote_schema.py` | export the target remote schema into `supabase/workspace/remote_schema.sql` |
+| `scripts/build_schema_workspace.py` | rebuild the generated workspace tree from the exported schema |
+| `scripts/copy_workspace_file_to_changes.py` | copy generated workspace files into the stable `changes/**` overlay |
+| `scripts/new_migration.py` | generate a migration file from a supported overlay object path |
+| `scripts/_db_workflow.py` | shared internal module for the helpers above |
+
+## Cross-Repo Boundaries
+
+This repo owns database truth, but not every runtime consequence:
+
+- `tiangong-lca-next` owns frontend env selection and app-side Supabase clients
+- `tiangong-lca-edge-functions` owns Edge Function runtime code
+- `lca-workspace` owns root delivery completion after a child PR merges
+
+If a task changes both schema and app behavior, the SQL truth still starts here.
+
+## Common Misreads
+
+- generated workspace files are not the durable schema source of truth
+- GitHub default branch does not define the daily trunk
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,181 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "0ffe436a3bc80671d68c3f2ff37b248146bc6af2",
+  "rules": [
+    {
+      "id": "database-engine-bootstrap-contract",
+      "scope": "repo",
+      "repo": "database-engine",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "docs/agents/**",
+          "kind": "doc-ops"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and routing guidance must stay aligned."
+    },
+    {
+      "id": "database-engine-branch-config-and-automation",
+      "scope": "repo",
+      "repo": "database-engine",
+      "triggers": [
+        {
+          "path": "supabase/config.toml",
+          "kind": "db-config"
+        },
+        {
+          "path": ".github/workflows/supabase-dev.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".env.supabase.dev.local.example",
+          "kind": "operator-template"
+        },
+        {
+          "path": ".env.supabase.main.local.example",
+          "kind": "operator-template"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Branch bindings and persistent dev automation change how the repo should be routed and validated."
+    },
+    {
+      "id": "database-engine-migration-seed-contract",
+      "scope": "repo",
+      "repo": "database-engine",
+      "triggers": [
+        {
+          "path": "supabase/migrations/**",
+          "kind": "db-schema"
+        },
+        {
+          "path": "supabase/seed.sql",
+          "kind": "db-seed"
+        },
+        {
+          "path": "supabase/seeds/**",
+          "kind": "db-seed"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Schema and seed changes affect source-of-truth boundaries, authoring routes, and validation expectations."
+    },
+    {
+      "id": "database-engine-sql-tests-contract",
+      "scope": "repo",
+      "repo": "database-engine",
+      "triggers": [
+        {
+          "path": "supabase/tests/**",
+          "kind": "db-test"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Regression and access-control test changes can change the minimum verification story for future work."
+    },
+    {
+      "id": "database-engine-schema-workspace-tooling",
+      "scope": "repo",
+      "repo": "database-engine",
+      "triggers": [
+        {
+          "path": "scripts/**",
+          "kind": "tooling"
+        },
+        {
+          "path": "supabase/workspace/**",
+          "kind": "generated-workspace"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Schema-workspace scripts and generated inspection trees need explicit documentation because some paths are stable and others are disposable."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,149 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "0ffe436a3bc80671d68c3f2ff37b248146bc6af2",
+  "repo": {
+    "id": "database-engine",
+    "path": "database-engine",
+    "canonicalRepo": "tiangong-lca/database-engine",
+    "purpose": "Supabase database governance repository for TianGong LCA.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "branchingDeepDiveDoc": "docs/agents/supabase-branching.md",
+    "branchingDeepDiveDocZh": "docs/agents/supabase-branching_CN.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "dev",
+    "routinePrBase": "dev",
+    "branchModel": "M2",
+    "promotePath": "dev -> main",
+    "hotfixPath": "main -> main, then back-merge main -> dev",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main should normally bump only commits already promoted onto database-engine/main.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/tiangong-lca/database-engine/issues/10"
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "supabase/config.toml",
+          "role": "shared Supabase CLI baseline plus branch-specific remote bindings"
+        },
+        {
+          "path": "supabase/migrations/**",
+          "role": "committed migration history and schema change truth"
+        },
+        {
+          "path": "supabase/seed.sql",
+          "role": "shared seed data loaded on local reset"
+        },
+        {
+          "path": "supabase/seeds/dev.sql",
+          "role": "persistent dev-only seed overlay"
+        },
+        {
+          "path": "supabase/tests/**",
+          "role": "PGTAP-style database assertions and regression checks"
+        },
+        {
+          "path": "scripts/**",
+          "role": "schema export, workspace refresh, change-copying, and migration-generation helpers"
+        },
+        {
+          "path": "supabase/workspace/README.md",
+          "role": "contract for the generated remote schema workspace"
+        },
+        {
+          "path": "supabase/workspace/changes/**",
+          "role": "stable manual overlay area when generating migrations from workspace files"
+        },
+        {
+          "path": ".github/workflows/supabase-dev.yml",
+          "role": "only checked-in automation that pushes committed migrations to the persistent remote dev branch"
+        },
+        {
+          "path": ".env.supabase.dev.local.example",
+          "role": "operator dev branch binding template"
+        },
+        {
+          "path": ".env.supabase.main.local.example",
+          "role": "operator main branch binding template"
+        }
+      ],
+      "generatedInspectionPaths": [
+        "supabase/workspace/remote_schema.sql",
+        "supabase/workspace/global/**",
+        "supabase/workspace/schemas/**"
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "tiangong-lca-next",
+          "doesNotOwn": [
+            "frontend runtime env files",
+            "app-side Supabase clients",
+            "frontend validation flows"
+          ]
+        },
+        {
+          "repo": "tiangong-lca-edge-functions",
+          "doesNotOwn": [
+            "Edge Function runtime code",
+            "non-SQL API orchestration logic"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "submodule pointer updates",
+            "workspace delivery completion",
+            "root integration branch decisions"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "access control, review workflow, and query/command RPC boundaries",
+        "paths": [
+          "supabase/migrations/**",
+          "supabase/tests/**",
+          "supabase/workspace/schemas/public/functions/**",
+          "supabase/workspace/schemas/public/tables/**/policies/**",
+          "supabase/workspace/schemas/public/tables/**/triggers/**"
+        ]
+      },
+      {
+        "topic": "preview branch and persistent dev branch operations",
+        "paths": [
+          "supabase/config.toml",
+          ".github/workflows/supabase-dev.yml",
+          "docs/agents/supabase-branching.md"
+        ]
+      },
+      {
+        "topic": "generated remote schema browsing and migration generation",
+        "paths": [
+          "supabase/workspace/**",
+          "scripts/build_schema_workspace.py",
+          "scripts/copy_workspace_file_to_changes.py",
+          "scripts/new_migration.py"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "supabase start",
+        "supabase db reset",
+        "supabase migration list"
+      ],
+      "sqlTests": {
+        "path": "supabase/tests/**",
+        "style": "PGTAP SQL files",
+        "wrapperStatus": "no single checked-in runner",
+        "note": "Record the exact local invocation used for relevant SQL test files in the PR."
+      }
+    }
+  }
+}

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,118 @@
+---
+title: database-engine Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: database-engine
+language: en
+whenToUse:
+  - when you already know the task belongs in database-engine but need the correct next file or next validation doc
+  - when deciding whether a change belongs in migrations, config, tests, generated workspace files, or another repo
+  - when investigating preview-branch, persistent-dev, or root-integration follow-up questions
+whenToUpdate:
+  - when new high-frequency task categories appear
+  - when source-of-truth paths or generated-workspace workflows change
+  - when cross-repo boundaries change
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - supabase/config.toml
+  - supabase/migrations/**
+  - supabase/tests/**
+  - supabase/workspace/**
+  - scripts/**
+  - .github/workflows/supabase-dev.yml
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 0ffe436a3bc80671d68c3f2ff37b248146bc6af2
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../docs/agents/supabase-branching.md
+  - ../supabase/workspace/README.md
+  - ../scripts/README.md
+---
+
+# database-engine Task Router
+
+## Repo Load Order
+
+When working inside `database-engine`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. `docs/agents/supabase-branching.md` for deeper branch operations
+6. `supabase/workspace/README.md` or `scripts/README.md` only for schema-workspace tooling
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Add or edit a migration, policy, trigger, or RPC | `supabase/migrations/**` | `ai/validation.md`, `ai/architecture.md` | Migration history is the checked-in schema truth. |
+| Change shared or dev-only seed data | `supabase/seed.sql`, `supabase/seeds/dev.sql` | `ai/validation.md` | Keep shared and dev-only seed responsibilities separate. |
+| Update branch bindings, redirects, or local Supabase behavior | `supabase/config.toml` | `ai/repo.yaml`, `docs/agents/supabase-branching.md` | Config changes often affect preview and persistent branch behavior together. |
+| Change the persistent remote dev deployment path | `.github/workflows/supabase-dev.yml` | `ai/validation.md`, `docs/agents/supabase-branching.md` | This repo should keep only one checked-in push path for the persistent Supabase `dev` branch. |
+| Investigate preview branch failure, drift, or `MIGRATIONS_FAILED` | failing file under `supabase/migrations/**` plus relevant config | `ai/validation.md`, `docs/agents/supabase-branching.md` | Prefer fixing the Git truth and recreating the branch over hand-editing remote state. |
+| Browse remote schema or generate a migration from workspace files | `supabase/workspace/**`, `scripts/build_schema_workspace.py`, `scripts/new_migration.py` | `ai/architecture.md`, `supabase/workspace/README.md`, `scripts/README.md` | `supabase/workspace/global/**` and `schemas/**` are generated inspection views. |
+| Change the stable manual overlay used for workspace-based migration authoring | `supabase/workspace/changes/**` | `ai/architecture.md`, `scripts/README.md` | Keep the relative structure aligned with `supabase/workspace/schemas/**`. |
+| Update operator branch-binding templates | `.env.supabase.dev.local.example`, `.env.supabase.main.local.example` | `ai/repo.yaml`, `docs/agents/supabase-branching.md` | These are operator templates, not app runtime env files. |
+| Decide whether a task belongs in frontend envs or app-side Supabase clients | `tiangong-lca-next` instead of this repo | root `ai/task-router.md` | This repo does not own frontend runtime env selection. |
+| Decide whether a task belongs in Edge Function runtime code | `tiangong-lca-edge-functions` instead of this repo | root `ai/task-router.md` | Database-side SQL may call Edge Functions, but runtime code still belongs in the edge repo. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Editing generated schema workspace files as durable truth
+
+Do not hand-maintain:
+
+- `supabase/workspace/remote_schema.sql`
+- `supabase/workspace/global/**`
+- `supabase/workspace/schemas/**`
+
+Use them for inspection. If you want to preserve edits, copy into `supabase/workspace/changes/**` first or write the migration directly under `supabase/migrations/**`.
+
+### Treating GitHub default branch as the daily trunk
+
+`database-engine` is an M2 repo:
+
+- GitHub default branch: `main`
+- true daily trunk: `dev`
+- routine PR base: `dev`
+
+### Moving app code into the database repo
+
+Do not implement these here:
+
+- app-side Supabase client code
+- frontend runtime env selection
+- Edge Function runtime logic
+
+## Cross-Repo Handoffs
+
+Use these handoffs when the work crosses boundaries:
+
+1. database schema or SQL contract change plus frontend impact
+   - start here
+   - then notify `tiangong-lca-next`
+2. database-triggered webhook or RPC change plus edge runtime impact
+   - start here for SQL and Vault contract
+   - then notify `tiangong-lca-edge-functions`
+3. merged repo PR that still must ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there
+
+## If You Still Need More Context
+
+Load:
+
+1. `ai/architecture.md` for stable versus generated path rules
+2. `ai/validation.md` for minimum checks
+3. `docs/agents/supabase-branching.md` for branch-operation edge cases

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,116 @@
+---
+title: database-engine Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: database-engine
+language: en
+whenToUse:
+  - when a database-engine change is ready for local validation
+  - when deciding the minimum proof required for migration, config, workflow, script, or docs changes
+  - when writing PR validation notes for database-engine work
+whenToUpdate:
+  - when the repo gains a new canonical validation command or wrapper
+  - when change categories require different minimum checks
+  - when schema-workspace tooling or branch operations change
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - supabase/config.toml
+  - supabase/migrations/**
+  - supabase/tests/**
+  - supabase/seed.sql
+  - supabase/seeds/**
+  - scripts/**
+  - .github/workflows/supabase-dev.yml
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 0ffe436a3bc80671d68c3f2ff37b248146bc6af2
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../docs/agents/supabase-branching.md
+  - ../scripts/README.md
+---
+
+# database-engine Validation Guide
+
+## Default Baseline
+
+Unless the change is doc-only, the baseline local commands are:
+
+```bash
+supabase start
+supabase db reset
+supabase migration list
+```
+
+These commands confirm that the local stack starts, the migration history can be replayed, and the local migration state is inspectable.
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| `supabase/migrations/**` | `supabase db reset` succeeds | run the relevant SQL assertions under `supabase/tests/**`; inspect affected workspace objects if the migration was authored from workspace files | Record which migration and which test files were exercised. |
+| `supabase/tests/**` only | run the relevant SQL assertion files against a reset local DB | add a nearby migration or policy smoke check if the new assertions expose a gap | This repo stores PGTAP-style SQL assertions, not a single canonical runner wrapper. |
+| `supabase/seed.sql` or `supabase/seeds/dev.sql` | `supabase db reset` succeeds with expected seed behavior | rerun targeted SQL assertions that depend on the seeded rows | Keep shared seed and dev-only seed expectations separate. |
+| `supabase/config.toml` | `supabase start` and `supabase db reset` still work locally | verify the changed branch-binding or auth assumption against `docs/agents/supabase-branching.md` | Config changes can affect preview, persistent dev, and local behavior together. |
+| `.github/workflows/supabase-dev.yml` | inspect YAML changes and confirm referenced secrets/vars still exist in docs | verify the intended deploy path in a PR note because the real push occurs only on Git `dev` | Local dry-run for GitHub-hosted execution is limited; document the expected remote proof. |
+| `scripts/**` | run the touched script with `--help` when possible, or execute the narrowest safe non-destructive path | if a script changes generated workspace behavior, refresh the workspace in a safe environment and inspect git diff | Avoid remote-destructive script runs unless the task explicitly requires them. |
+| `supabase/workspace/**` | prove whether the touched file is generated or stable | if stable manual overlay files changed, explain how they feed migration generation | Generated files alone are not sufficient evidence of a durable schema change. |
+| AI docs only | run the root `ai-doc-lint` warning flow against touched files | perform scenario-based routing checks from root into this repo | Refresh review metadata even when prose stays unchanged. |
+
+## SQL Assertion Notes
+
+The repo currently stores SQL assertions under `supabase/tests/**`.
+
+Facts that matter:
+
+- they use PGTAP-style SQL assertions
+- no single checked-in wrapper defines the only valid invocation
+- PR validation notes should therefore record the exact command or SQL runner used
+
+If you add or change assertions:
+
+1. reset the local DB first
+2. run the relevant assertion files against that reset state
+3. record the exact invocation in the PR
+
+## Schema Workspace Tooling Checks
+
+If the task touches `scripts/**` or `supabase/workspace/**`, first decide whether you changed:
+
+- stable documentation or overlay paths
+- generated inspection output
+- helper scripts that transform one into the other
+
+Useful low-risk checks:
+
+```bash
+python scripts/build_schema_workspace.py --help
+python scripts/copy_workspace_file_to_changes.py --help
+python scripts/new_migration.py --help
+python scripts/export_remote_schema.py --help
+```
+
+If you actually refresh the workspace, make the validation note explicit about which generated paths changed and whether the change is intended to be committed.
+
+## Preview, Persistent Dev, and Root Integration
+
+For branch-oriented changes:
+
+- preview-branch proof usually happens on the repo PR
+- persistent remote `dev` proof happens after merge into Git `dev`
+- root workspace proof happens later in `lca-workspace`
+
+Do not collapse those three phases into one validation note.
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. which local commands ran
+2. which SQL assertion files or migration paths were exercised
+3. whether any proof is deferred to preview branch, persistent `dev`, or root integration


### PR DESCRIPTION
Closes tiangong-lca/database-engine#10

## Summary
- Add a repo-level AI bootstrap layer with `AGENTS.md`, `ai/repo.yaml`, `ai/task-router.md`, `ai/validation.md`, `ai/architecture.md`, and `ai/doc-impact.yaml`.
- Route schema, branch-config, generated-workspace, and root-integration questions with explicit ownership and next-hop guidance.
- Keep existing branching docs as deeper operational context while lowering first-hop token cost for agents.

## Key Decisions
- Use `AGENTS.md` plus `ai/` as the checked-in contract layer and keep `docs/agents/supabase-branching.md` as a deeper operational doc instead of duplicating it.
- Document `supabase/workspace/remote_schema.sql`, `global/**`, and `schemas/**` as generated inspection paths, with `changes/**` as the stable manual overlay.
- Reuse the root warning-only `ai-doc-lint` flow by adding repo-local `ai/doc-impact.yaml` rather than introducing a repo-specific CI path in this PR.

## Validation
- node .github/scripts/ai-doc-lint.mjs --mode warn --files "database-engine/AGENTS.md,database-engine/README.md,database-engine/ai/repo.yaml,database-engine/ai/doc-impact.yaml,database-engine/ai/task-router.md,database-engine/ai/validation.md,database-engine/ai/architecture.md,ai/workspace.yaml,.agents/skills/lca-workspace-delivery-workflow/references/github-project.md"
- python database-engine/scripts/build_schema_workspace.py --help
- python database-engine/scripts/copy_workspace_file_to_changes.py --help
- python database-engine/scripts/new_migration.py --help
- python database-engine/scripts/export_remote_schema.py --help
- git -C database-engine diff --check

## Risks / Rollback
- Low risk: docs-only change. The main failure mode is stale routing if branch or source-of-truth rules change later without refreshing review metadata.

## Follow-ups
- After merge, `lca-workspace` still needs the database-engine submodule pointer bump tracked under `tiangong-lca/workspace#73`.
- The parent workspace rollout remains open for the remaining repos.