### PR TITLE
Upgrade docpact CI pin to 0.1.4

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "9cbf95369a7786d2b15e2787b46462ebbee42cc1"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - docs/agents/**
   - .github/workflows/**
   - .env.supabase*.example
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,8 +23,8 @@ checkPaths:
   - supabase/workspace/**
   - scripts/**
   - .github/workflows/supabase-dev.yml
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/**
   - .github/workflows/supabase-dev.yml
   - .github/workflows/ai-doc-lint.yml
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #22

## Summary
- Upgrade .github/workflows/ai-doc-lint.yml from docpact 0.1.2 to 0.1.4.
- Preserve the existing ai-doc-lint workflow/check name and command shape.
- Refresh governed doc review metadata required by the repo-local docpact rules for workflow changes.

## Key Decisions
- Do not change runtime code, package versions, release automation, or root workspace submodule pointers.

## Validation
- docpact validate-config --root . --strict with docpact 0.1.4.
- docpact lint --root . --worktree --mode enforce with docpact 0.1.4.
- docpact lint --root . --base origin/dev --head HEAD --mode enforce with docpact 0.1.4.

## Risks / Rollback
- Root workspace integration remains pending until this child PR merges and the submodule pointer is deliberately bumped.

## Workspace Integration
- Part of tiangong-lca/workspace#77; child issue keeps Workspace Integration Pending.