### PR TITLE
Promote docpact 0.1.4 upgrade to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "9cbf95369a7786d2b15e2787b46462ebbee42cc1"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - docs/agents/**
   - .github/workflows/**
   - .env.supabase*.example
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,8 +23,8 @@ checkPaths:
   - supabase/workspace/**
   - scripts/**
   - .github/workflows/supabase-dev.yml
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/**
   - .github/workflows/supabase-dev.yml
   - .github/workflows/ai-doc-lint.yml
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #24

## Summary
- Promotes the docpact 0.1.4 governance upgrade from dev to main.
- Includes the already-merged dev change from PR #23 at f05cdcc2ff7181046692baf8f08ace36d6daeda7.

## Decisions
- This is an M2 promote PR: base is main, head is a branch pinned to current dev, with no additional working-branch edits.

## Validation
- Dev already passed the repo-level PR checks for the docpact 0.1.4 upgrade.
- This promote PR should rely on GitHub PR checks before merge.

## Risk / rollback
- Low-risk documentation-governance/tooling promote.
- Rollback is reverting the promote merge from main if needed.

## Workspace integration
- After this PR merges, root workspace main may pin the promoted main commit for workspace integration under tiangong-lca/workspace#77.
