### PR TITLE
chore: promote README metadata cleanup to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -198,11 +198,9 @@ rules:
         kind: repo-landing
     requiredDocs:
       - path: AGENTS.md
-        mode: review_or_update
-      - path: README.md
-        mode: review_or_update
-      - path: README.zh-CN.md
-        mode: review_or_update
+        mode: must_exist
+      - path: .docpact/config.yaml
+        mode: must_exist
     reason: Repo landing docs should stay aligned with the current repo contract and AI entry surface.
   - id: database-engine-branch-config-and-automation
     scope: repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - docs/agents/**
   - .github/workflows/**
   - .env.supabase*.example
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -1,31 +1,3 @@
----
-title: database-engine
-docType: overview
-scope: repo
-status: active
-authoritative: false
-owner: database-engine
-language: en
-whenToUse:
-  - when you need the shortest high-level description of what this repo owns
-  - when landing in the repo without needing the full AI contract surface yet
-whenToUpdate:
-  - when repo purpose, branch model, or owned surfaces change
-  - when the AI entry surface listed here changes
-checkPaths:
-  - README.md
-  - AGENTS.md
-  - .docpact/config.yaml
-  - docs/agents/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
-related:
-  - AGENTS.md
-  - .docpact/config.yaml
-  - docs/agents/repo-validation.md
-  - docs/agents/repo-architecture.md
----
-
 # database-engine
 
 `database-engine` is the Supabase database governance repository for the TianGong LCA workspace.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,8 +23,8 @@ checkPaths:
   - supabase/workspace/**
   - scripts/**
   - .github/workflows/supabase-dev.yml
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/**
   - .github/workflows/supabase-dev.yml
   - .github/workflows/ai-doc-lint.yml
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 9cbf95369a7786d2b15e2787b46462ebbee42cc1
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #28

## Summary
- Promote the README metadata cleanup delta from dev to main.
- This enables root workspace main to integrate the submodule pointer after merge.

## Key Decisions
- origin/main..origin/dev contains only the README metadata cleanup delta for this promote.

## Validation
- docpact validate-config --strict
- docpact lint --base origin/main --head origin/dev --mode enforce

## Risks / Rollback
- Low-risk docs/governance promote; rollback is reverting the promote merge on main if needed.

## Workspace Integration
- After merge, update the lca-workspace root main submodule pointer.