### PR TITLE
fix: harden review reject rollback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-24"
-lastReviewedCommit: "9cbf95369a7786d2b15e2787b46462ebbee42cc1"
+lastReviewedAt: "2026-05-07"
+lastReviewedCommit: "76656f62ad96b10fe8bc6676344c5c8320ea2f31"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - docs/agents/**
   - .github/workflows/**
   - .env.supabase*.example
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: eb53e4b204470d8b69ae0da6e4cdd39a2ceaee1b
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,8 +23,8 @@ checkPaths:
   - supabase/workspace/**
   - scripts/**
   - .github/workflows/supabase-dev.yml
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 76656f62ad96b10fe8bc6676344c5c8320ea2f31
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/**
   - .github/workflows/supabase-dev.yml
   - .github/workflows/ai-doc-lint.yml
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
+lastReviewedAt: 2026-05-07
+lastReviewedCommit: 76656f62ad96b10fe8bc6676344c5c8320ea2f31
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260507110000_harden_review_reject_root_rollback.sql
+++ b/supabase/migrations/20260507110000_harden_review_reject_root_rollback.sql
@@ -1,0 +1,378 @@
+create or replace function public.cmd_review_reject(
+  p_table text,
+  p_review_id uuid,
+  p_reason text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_root_table text;
+  v_root_targets jsonb;
+  v_comment_ref_roots jsonb := '[]'::jsonb;
+  v_target record;
+  v_comment_ref record;
+  v_review_json jsonb;
+  v_affected_datasets jsonb := '[]'::jsonb;
+  v_collected_targets_count integer := 0;
+  v_rollback_targets_count integer := 0;
+  v_rows_updated integer := 0;
+  v_root_state_code integer;
+  v_root_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ADMIN_REQUIRED',
+      'status', 403,
+      'message', 'Only review admins can reject reviews'
+    );
+  end if;
+
+  v_root_table := lower(coalesce(p_table, ''));
+  if v_root_table not in ('processes', 'lifecyclemodels') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_TABLE',
+      'status', 400,
+      'message', 'table must be processes or lifecyclemodels'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code not in (-1, 0, 1) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Only pending, assigned, or rejected reviews can be rejected',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  v_root_targets := jsonb_build_array(
+    jsonb_build_object(
+      'table', v_root_table,
+      'id', v_review.data_id,
+      'version', v_review.data_version,
+      'is_root', true
+    )
+  );
+
+  create temporary table if not exists cmd_review_reject_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    dataset_row jsonb not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  truncate table cmd_review_reject_targets;
+
+  insert into cmd_review_reject_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_root_targets, true);
+
+  select t.state_code
+    into v_root_state_code
+  from cmd_review_reject_targets as t
+  where t.table_name = v_root_table
+    and t.dataset_id = v_review.data_id
+    and t.dataset_version = v_review.data_version
+    and t.is_root = true;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ROOT_TARGET_NOT_FOUND',
+      'status', 409,
+      'message', 'Review root dataset was not collected for reject',
+      'details', jsonb_build_object(
+        'table', v_root_table,
+        'id', v_review.data_id,
+        'version', v_review.data_version
+      )
+    );
+  end if;
+
+  if v_review.state_code in (0, 1)
+     and not (v_root_state_code >= 20 and v_root_state_code < 100) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ROOT_STATE_MISMATCH',
+      'status', 409,
+      'message', 'Review root dataset is not under review',
+      'details', jsonb_build_object(
+        'table', v_root_table,
+        'id', v_review.data_id,
+        'version', v_review.data_version,
+        'state_code', v_root_state_code
+      )
+    );
+  end if;
+
+  for v_comment_ref in
+    select distinct
+      ref.ref_type,
+      ref.ref_object_id,
+      ref.ref_version
+    from public.comments as c
+    cross join lateral public.cmd_review_extract_refs(coalesce(to_jsonb(c.json), '{}'::jsonb)) as ref
+    where c.review_id = p_review_id
+      and c.state_code <> -2
+  loop
+    v_comment_ref_roots := v_comment_ref_roots || jsonb_build_array(
+      jsonb_build_object(
+        'table', public.cmd_review_ref_type_to_table(v_comment_ref.ref_type),
+        'id', v_comment_ref.ref_object_id,
+        'version', v_comment_ref.ref_version,
+        'is_root', false
+      )
+    );
+  end loop;
+
+  insert into cmd_review_reject_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_comment_ref_roots, true)
+  on conflict (table_name, dataset_id, dataset_version) do nothing;
+
+  select count(*)
+    into v_collected_targets_count
+  from cmd_review_reject_targets;
+
+  select count(*)
+    into v_rollback_targets_count
+  from cmd_review_reject_targets
+  where state_code >= 20
+    and state_code < 100;
+
+  for v_target in
+    select *
+    from cmd_review_reject_targets
+    where state_code >= 20
+      and state_code < 100
+    order by table_name, dataset_id, dataset_version
+  loop
+    execute format(
+      'update public.%I
+          set state_code = 0,
+              modified_at = now()
+        where id = $1
+          and version = $2',
+      v_target.table_name
+    )
+      using v_target.dataset_id, v_target.dataset_version;
+
+    get diagnostics v_rows_updated = row_count;
+
+    if v_rows_updated <> 1 then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'REVIEW_TARGET_UPDATE_FAILED',
+        'status', 409,
+        'message', 'Failed to reset review target state',
+        'details', jsonb_build_object(
+          'table', v_target.table_name,
+          'id', v_target.dataset_id,
+          'version', v_target.dataset_version,
+          'rows_updated', v_rows_updated
+        )
+      );
+    end if;
+  end loop;
+
+  v_root_row := public.cmd_review_get_dataset_row(
+    v_root_table,
+    v_review.data_id,
+    v_review.data_version,
+    false
+  );
+
+  if v_root_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ROOT_TARGET_NOT_FOUND',
+      'status', 409,
+      'message', 'Review root dataset was not found after rollback',
+      'details', jsonb_build_object(
+        'table', v_root_table,
+        'id', v_review.data_id,
+        'version', v_review.data_version
+      )
+    );
+  end if;
+
+  v_root_state_code := coalesce((v_root_row->>'state_code')::integer, 0);
+
+  if v_root_state_code <> 0 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ROOT_ROLLBACK_FAILED',
+      'status', 409,
+      'message', 'Review root dataset was not reset to draft state',
+      'details', jsonb_build_object(
+        'table', v_root_table,
+        'id', v_review.data_id,
+        'version', v_review.data_version,
+        'state_code', v_root_state_code
+      )
+    );
+  end if;
+
+  update public.comments
+    set state_code = -1,
+        modified_at = now()
+  where review_id = p_review_id
+    and state_code <> -2;
+
+  v_review_json := coalesce(v_review.json, '{}'::jsonb);
+  v_review_json := jsonb_set(
+    v_review_json,
+    '{comment}',
+    coalesce(v_review_json->'comment', '{}'::jsonb) || jsonb_build_object(
+      'message', coalesce(p_reason, '')
+    ),
+    true
+  );
+  v_review_json := public.cmd_review_append_log(
+    v_review_json,
+    'rejected',
+    v_actor,
+    jsonb_build_object(
+      'reason', coalesce(p_reason, '')
+    )
+  );
+
+  update public.reviews
+    set state_code = -1,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'table', table_name,
+        'id', dataset_id,
+        'version', dataset_version,
+        'state_code', 0
+      )
+      order by table_name, dataset_id, dataset_version
+    ),
+    '[]'::jsonb
+  )
+    into v_affected_datasets
+  from cmd_review_reject_targets
+  where state_code >= 20
+    and state_code < 100;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_reject',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'root_table', v_root_table,
+      'root_target', jsonb_build_object(
+        'table', v_root_table,
+        'id', v_review.data_id,
+        'version', v_review.data_version,
+        'state_code', v_root_state_code
+      ),
+      'collected_targets_count', v_collected_targets_count,
+      'rollback_targets_count', v_rollback_targets_count,
+      'reason', coalesce(p_reason, ''),
+      'affected_datasets', v_affected_datasets
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'affected_datasets', v_affected_datasets,
+      'target_counts', jsonb_build_object(
+        'collected', v_collected_targets_count,
+        'rollback', v_rollback_targets_count
+      )
+    )
+  );
+end;
+$$;
+
+revoke all on function public.cmd_review_reject(text, uuid, text, jsonb) from public;
+grant execute on function public.cmd_review_reject(text, uuid, text, jsonb) to anon;
+grant execute on function public.cmd_review_reject(text, uuid, text, jsonb) to authenticated;
+grant execute on function public.cmd_review_reject(text, uuid, text, jsonb) to service_role;

--- a/supabase/tests/20260405_review_workflow_rpcs.sql
+++ b/supabase/tests/20260405_review_workflow_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(44);
+select plan(51);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -508,6 +508,50 @@ values
     '[{"key":0,"id":"53000000-0000-0000-0000-000000000205"}]'::jsonb
   ),
   (
+    '32000000-0000-0000-0000-000000000207',
+    '01.00.000',
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Draft Reject Mismatch Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::jsonb,
+    '{
+      "processDataSet": {
+        "processInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                { "@xml:lang": "en", "#text": "Draft Reject Mismatch Process" }
+              ]
+            }
+          }
+        },
+        "modellingAndValidation": {
+          "validation": { "review": [] },
+          "complianceDeclarations": { "compliance": [] }
+        }
+      }
+    }'::json,
+    '12000000-0000-0000-0000-000000000001',
+    0,
+    '22000000-0000-0000-0000-000000000001',
+    '42000000-0000-0000-0000-000000000207',
+    true,
+    '[{"key":0,"id":"53000000-0000-0000-0000-000000000207"}]'::jsonb
+  ),
+  (
     '32000000-0000-0000-0000-000000000301',
     '01.00.000',
     '{
@@ -907,6 +951,34 @@ values
     '["12000000-0000-0000-0000-000000000011"]'::jsonb,
     '{
       "data": { "id": "32000000-0000-0000-0000-000000000205", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000206',
+    '32000000-0000-0000-0000-000000000206',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000206", "version": "01.00.000" },
+      "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
+      "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
+      "comment": { "message": "" },
+      "logs": []
+    }'::jsonb
+  ),
+  (
+    '53000000-0000-0000-0000-000000000207',
+    '32000000-0000-0000-0000-000000000207',
+    '01.00.000',
+    1,
+    '["12000000-0000-0000-0000-000000000011"]'::jsonb,
+    '{
+      "data": { "id": "32000000-0000-0000-0000-000000000207", "version": "01.00.000" },
       "team": { "id": "22000000-0000-0000-0000-000000000001", "name": "Review Team" },
       "user": { "id": "12000000-0000-0000-0000-000000000001", "name": "Review Owner", "email": "review-owner@example.com" },
       "comment": { "message": "" },
@@ -1382,6 +1454,46 @@ select is(
 select is(
   public.cmd_review_reject(
     'processes',
+    '53000000-0000-0000-0000-000000000206',
+    'Missing root dataset',
+    '{"command":"review_reject"}'::jsonb
+  )->>'code',
+  'REVIEW_ROOT_TARGET_NOT_FOUND',
+  'review reject fails when the root dataset is not collected'
+);
+
+select is(
+  (select state_code::text from public.reviews where id = '53000000-0000-0000-0000-000000000206'),
+  '1',
+  'failed reject for a missing root dataset leaves the review state unchanged'
+);
+
+select is(
+  public.cmd_review_reject(
+    'processes',
+    '53000000-0000-0000-0000-000000000207',
+    'Root is already draft',
+    '{"command":"review_reject"}'::jsonb
+  )->>'code',
+  'REVIEW_ROOT_STATE_MISMATCH',
+  'review reject fails when an active review root dataset is not under review'
+);
+
+select is(
+  (select state_code::text from public.processes where id = '32000000-0000-0000-0000-000000000207' and version = '01.00.000'),
+  '0',
+  'failed reject for a draft root dataset leaves the root dataset state unchanged'
+);
+
+select is(
+  (select state_code::text from public.reviews where id = '53000000-0000-0000-0000-000000000207'),
+  '1',
+  'failed reject for a draft root dataset leaves the review state unchanged'
+);
+
+select is(
+  public.cmd_review_reject(
+    'processes',
     '53000000-0000-0000-0000-000000000204',
     'Needs more evidence',
     '{"command":"review_reject"}'::jsonb
@@ -1400,6 +1512,32 @@ select is(
   (select state_code::text from public.reviews where id = '53000000-0000-0000-0000-000000000204'),
   '-1',
   'rejecting a review marks the review row as rejected'
+);
+
+select is(
+  (
+    select payload->>'collected_targets_count'
+    from public.command_audit_log
+    where command = 'cmd_review_reject'
+      and target_id = '53000000-0000-0000-0000-000000000204'
+    order by created_at desc
+    limit 1
+  ),
+  '1',
+  'successful review reject audit records the collected target count'
+);
+
+select is(
+  (
+    select payload->>'rollback_targets_count'
+    from public.command_audit_log
+    where command = 'cmd_review_reject'
+      and target_id = '53000000-0000-0000-0000-000000000204'
+    order by created_at desc
+    limit 1
+  ),
+  '1',
+  'successful review reject audit records the rollback target count'
 );
 
 select is(


### PR DESCRIPTION
Closes #30

## Summary
- Harden cmd_review_reject so active review rejection cannot succeed when the root dataset is missing from collected targets or is not under review.
- Add target collection and rollback counts to successful reject audit payloads.
- Extend review workflow SQL assertions for missing-root, draft-root, successful rollback, and audit count behavior.

## Key Decisions
- Keep the fix in database-engine because frontend table selection is considered correct; the database command now enforces the rejection invariant itself.
- Allow already-rejected reviews to be re-rejected only when the root dataset still exists and post-checks as draft, preserving existing idempotent-ish behavior without allowing active reviews to drift.

## Validation
- git diff --check
- rg count confirmed 51 select is(...) assertions for select plan(51) in supabase/tests/20260405_review_workflow_rpcs.sql
- Loaded supabase/migrations/20260507110000_harden_review_reject_root_rollback.sql into a temporary postgres:17 container with minimal schema/function stubs; the migration parsed and created the function successfully.
- supabase db reset not run because the local supabase CLI is not installed; npx -y supabase@latest --version exited 1 without output.

## Risks / Rollback
- Medium: this changes rejection failure behavior from silent partial success to structured 409 errors for inconsistent root target/state cases.
- Rollback by reverting the migration/PR if preview branch validation shows incompatible legacy rejection flows.

## Follow-ups
- Run full Supabase preview-branch validation and the review workflow SQL assertion file in CI or an environment with the Supabase CLI available.

## Workspace Integration
- Requires later lca-workspace submodule pointer integration after merge and database-engine dev-to-main promotion per M2 policy.