### PR TITLE
[codex] Scope embedding derivative triggers

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: "2026-05-14"
+lastReviewedCommit: "5c0152c65b2e9afaf433817d6794d0da705f435d"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,8 +20,8 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -118,6 +118,30 @@ Repository configuration expected by `.github/workflows/supabase-dev.yml`:
 - variable `SUPABASE_DEV_PROJECT_ID`
 - secret `SUPABASE_ACCESS_TOKEN`
 - secret `SUPABASE_DEV_DB_PASSWORD`
+
+## PR to Supabase migration path
+
+Committed migration files do not affect any remote database until one of the
+deployment paths below runs.
+
+Normal PR path:
+
+1. A feature branch includes new files under `supabase/migrations/`.
+2. The PR targets Git `dev`.
+3. Supabase GitHub integration creates or updates the PR preview branch from
+   the checked-in `supabase/` directory.
+4. The preview branch is PR-scoped proof only; it is not the persistent
+   Supabase `dev` branch.
+5. After the PR merges, the resulting push to Git `dev` triggers
+   `.github/workflows/supabase-dev.yml`.
+6. The workflow links to `SUPABASE_DEV_PROJECT_ID` and runs `supabase db push`.
+7. Pending checked-in migrations are then applied to the persistent Supabase
+   `dev` branch.
+
+This repository currently has no checked-in manual `workflow_dispatch` deploy
+for Supabase. An operator can still run `supabase link` and `supabase db push`
+locally, but that is a deliberate manual deployment path and must be recorded
+as such in validation or incident notes.
 
 ## Vault secret contract
 

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -118,6 +118,23 @@ related:
 - variable `SUPABASE_DEV_PROJECT_ID`
 - secret `SUPABASE_ACCESS_TOKEN`
 - secret `SUPABASE_DEV_DB_PASSWORD`
+
+## PR 到 Supabase migration 路径
+
+已提交的 migration 文件不会因为文件存在就影响远端数据库，只有下面这些部署路径运行后才会生效。
+
+常规 PR 路径：
+
+1. feature 分支包含新的 `supabase/migrations/` 文件。
+2. PR 目标分支是 Git `dev`。
+3. Supabase GitHub integration 根据已提交的 `supabase/` 目录创建或更新该 PR 的 preview branch。
+4. preview branch 只用于 PR 级别验证；它不是持久化 Supabase `dev` 分支。
+5. PR 合并后，对 Git `dev` 的 push 会触发 `.github/workflows/supabase-dev.yml`。
+6. 该 workflow 会连接 `SUPABASE_DEV_PROJECT_ID` 并执行 `supabase db push`。
+7. 尚未应用的已提交 migrations 随后才会应用到持久化 Supabase `dev` 分支。
+
+本仓目前没有 checked-in 的手动 `workflow_dispatch` Supabase 部署流程。运维人员仍可在本地执行
+`supabase link` 和 `supabase db push`，但这是明确的人工部署路径，必须在验证记录或事故记录中说明。
 
 ## Vault secret 契约
 

--- a/supabase/migrations/20260514093000_scope_embedding_derivative_update_triggers.sql
+++ b/supabase/migrations/20260514093000_scope_embedding_derivative_update_triggers.sql
@@ -1,0 +1,70 @@
+drop trigger if exists flows_json_sync_trigger on public.flows;
+drop trigger if exists flows_set_modified_at_trigger on public.flows;
+drop trigger if exists lifecyclemodels_json_sync_trigger on public.lifecyclemodels;
+drop trigger if exists lifecyclemodels_set_modified_at_trigger on public.lifecyclemodels;
+drop trigger if exists processes_json_sync_trigger on public.processes;
+drop trigger if exists processes_set_modified_at_trigger on public.processes;
+
+create trigger flows_json_sync_trigger
+before insert or update of json_ordered on public.flows
+for each row
+execute function public.flows_sync_jsonb_version();
+
+create trigger flows_set_modified_at_trigger
+before update of
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  version,
+  team_id,
+  review_id,
+  rule_verification,
+  reviews,
+  embedding_flag
+on public.flows
+for each row
+execute function public.update_modified_at();
+
+create trigger lifecyclemodels_json_sync_trigger
+before insert or update of json_ordered on public.lifecyclemodels
+for each row
+execute function public.lifecyclemodels_sync_jsonb_version();
+
+create trigger lifecyclemodels_set_modified_at_trigger
+before update of
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  version,
+  json_tg,
+  team_id,
+  rule_verification,
+  reviews,
+  embedding_flag
+on public.lifecyclemodels
+for each row
+execute function public.update_modified_at();
+
+create trigger processes_json_sync_trigger
+before insert or update of json_ordered on public.processes
+for each row
+execute function public.processes_sync_jsonb_version();
+
+create trigger processes_set_modified_at_trigger
+before update of
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  version,
+  team_id,
+  review_id,
+  rule_verification,
+  reviews,
+  embedding_flag,
+  model_id
+on public.processes
+for each row
+execute function public.update_modified_at();

--- a/supabase/tests/20260514_embedding_derivative_trigger_scope.sql
+++ b/supabase/tests/20260514_embedding_derivative_trigger_scope.sql
@@ -1,0 +1,128 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(15);
+
+create or replace function pg_temp.trigger_update_columns(
+  p_table regclass,
+  p_trigger_name text
+) returns text
+language sql
+stable
+as $$
+  select coalesce(
+    string_agg(att.attname, ', ' order by att.attnum),
+    '<all update columns>'
+  )
+  from pg_trigger trg
+  left join lateral unnest(trg.tgattr::smallint[]) a(attnum) on true
+  left join pg_attribute att
+    on att.attrelid = trg.tgrelid
+   and att.attnum = a.attnum
+  where trg.tgrelid = p_table
+    and trg.tgname = p_trigger_name
+    and not trg.tgisinternal
+  group by trg.oid;
+$$;
+
+select is(
+  pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_json_sync_trigger'),
+  'json_ordered',
+  'flows json sync only runs when json_ordered is updated'
+);
+
+select is(
+  pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_json_sync_trigger'),
+  'json_ordered',
+  'lifecyclemodels json sync only runs when json_ordered is updated'
+);
+
+select is(
+  pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_json_sync_trigger'),
+  'json_ordered',
+  'processes json sync only runs when json_ordered is updated'
+);
+
+select isnt(
+  pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger'),
+  '<all update columns>',
+  'flows modified_at trigger is column-scoped'
+);
+
+select isnt(
+  pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger'),
+  '<all update columns>',
+  'lifecyclemodels modified_at trigger is column-scoped'
+);
+
+select isnt(
+  pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger'),
+  '<all update columns>',
+  'processes modified_at trigger is column-scoped'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') like '%json%'
+  and pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') like '%state_code%',
+  'flows modified_at still covers business fields'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') like '%json%'
+  and pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') like '%state_code%',
+  'lifecyclemodels modified_at still covers business fields'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') like '%json%'
+  and pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') like '%state_code%',
+  'processes modified_at still covers business fields'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') not like '%embedding_ft%'
+  and pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') not like '%embedding_at%'
+  and pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') not like '%extracted_text%'
+  and pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') not like '%extracted_md%',
+  'flows modified_at skips derived embedding and extraction columns'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') not like '%embedding_ft%'
+  and pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') not like '%embedding_at%'
+  and pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') not like '%extracted_text%'
+  and pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') not like '%extracted_md%',
+  'lifecyclemodels modified_at skips derived embedding and extraction columns'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') not like '%embedding_ft%'
+  and pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') not like '%embedding_at%'
+  and pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') not like '%extracted_text%'
+  and pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') not like '%extracted_md%',
+  'processes modified_at skips derived embedding and extraction columns'
+);
+
+select is(
+  (select (tgtype & 4) <> 0 from pg_trigger where tgrelid = 'public.flows'::regclass and tgname = 'flows_json_sync_trigger'),
+  true,
+  'flows json sync still runs on insert'
+);
+
+select is(
+  (select (tgtype & 4) <> 0 from pg_trigger where tgrelid = 'public.lifecyclemodels'::regclass and tgname = 'lifecyclemodels_json_sync_trigger'),
+  true,
+  'lifecyclemodels json sync still runs on insert'
+);
+
+select is(
+  (select (tgtype & 4) <> 0 from pg_trigger where tgrelid = 'public.processes'::regclass and tgname = 'processes_json_sync_trigger'),
+  true,
+  'processes json sync still runs on insert'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary
- Scope `flows`, `lifecyclemodels`, and `processes` JSON sync triggers so they only run on `json_ordered` updates.
- Scope `modified_at` triggers to business fields and exclude derived embedding/extraction columns.
- Add pgTAP coverage for trigger update-column behavior.
- Document the PR -> Supabase preview -> Git `dev` -> persistent Supabase `dev` migration path.

## Root cause
Embedding worker writes to `embedding_ft` were still firing broad `BEFORE UPDATE` triggers. On large rows this could force unnecessary JSON/TOAST comparison and `modified_at` churn while HNSW/vector index maintenance was also happening, making single-row embedding updates stall and causing PGMQ retries.

## Validation
- Remote transaction dry run: applied the migration and ran `supabase/tests/20260514_embedding_derivative_trigger_scope.sql`; all 15 assertions passed, then rolled back.
- `docpact validate-config --root . --strict`
- `docpact lint --root . --files AGENTS.md,.docpact/config.yaml,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,docs/agents/supabase-branching.md,docs/agents/supabase-branching_CN.md,supabase/migrations/20260514093000_scope_embedding_derivative_update_triggers.sql,supabase/tests/20260514_embedding_derivative_trigger_scope.sql --mode enforce --format json`
- `git diff --check`

## Notes
- No GitHub Issue is linked yet; this was prepared from the active embedding incident investigation.
- Local `supabase db reset` was not run because the local Docker/OrbStack daemon was unavailable.
- Applying this PR to persistent Supabase `dev` happens only after merge to Git `dev`, via `.github/workflows/supabase-dev.yml` running `supabase db push`.
