### PR TITLE
[promote] Merge dev into main for embedding trigger fix

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-24"
-lastReviewedCommit: "9cbf95369a7786d2b15e2787b46462ebbee42cc1"
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.
@@ -49,8 +49,19 @@ ownership:
           - supabase/workspace/**
       ownerRepo: database-engine
 
+    - id: local-docpact-push-gate
+      paths:
+        include:
+          - .githooks/**
+          - scripts/docpact-gate.sh
+          - scripts/install-git-hooks.sh
+      ownerRepo: database-engine
+
 coverage:
   include:
+    - .githooks/**
+    - scripts/docpact-gate.sh
+    - scripts/install-git-hooks.sh
     - AGENTS.md
     - README.md
     - README.zh-CN.md
@@ -85,6 +96,11 @@ freshness:
 
 routing:
   intents:
+    local-docpact-gate:
+      paths:
+        - .githooks/pre-push
+        - scripts/docpact-gate.sh
+        - scripts/install-git-hooks.sh
     migration-and-rpc:
       paths:
         - supabase/migrations/**
@@ -294,3 +310,19 @@ rules:
       - path: docs/agents/repo-validation.md
         mode: review_or_update
     reason: Repo-local documentation maintenance automation must stay aligned with the repo contract and governed-doc rules.
+  - id: database-engine-local-docpact-push-gate
+    scope: repo
+    repo: database-engine
+    triggers:
+      - path: .githooks/pre-push
+        kind: local-git-hook
+      - path: scripts/docpact-gate.sh
+        kind: local-automation
+      - path: scripts/install-git-hooks.sh
+        kind: local-automation
+    requiredDocs:
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+    reason: Local push documentation governance gates must stay aligned with repo validation guidance and docpact configuration.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: "2026-05-14"
+lastReviewedCommit: "5c0152c65b2e9afaf433817d6794d0da705f435d"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+exec "$repo_root/scripts/docpact-gate.sh" "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,11 @@ checkPaths:
   - docs/agents/**
   - .github/workflows/**
   - .env.supabase*.example
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
+  - .githooks/**
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -179,3 +182,13 @@ If the change must ship through the workspace:
 3. update the `lca-workspace` submodule pointer deliberately
 
 For normal root `main` integration, `lca-workspace/main` should point only at commits already promoted onto `database-engine/main`.
+
+## Local Docpact Push Gate
+
+Install the versioned local hook once per checkout:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/dev` for routine branches and `origin/main` for promote or hotfix branches. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -23,8 +23,11 @@ checkPaths:
   - supabase/workspace/**
   - scripts/**
   - .github/workflows/supabase-dev.yml
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -115,3 +118,7 @@ If a task changes both schema and app behavior, the SQL truth still starts here.
 - generated workspace files are not the durable schema source of truth
 - GitHub default branch does not define the daily trunk
 - a merged child PR does not finish workspace delivery
+
+## Local Docpact Push Gate
+
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,11 @@ checkPaths:
   - scripts/**
   - .github/workflows/supabase-dev.yml
   - .github/workflows/ai-doc-lint.yml
-lastReviewedAt: 2026-05-06
-lastReviewedCommit: f05cdcc2ff7181046692baf8f08ace36d6daeda7
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -116,3 +119,13 @@ Every PR note for this repo should state:
 1. exact commands run
 2. exact SQL assertion files or migration paths exercised
 3. whether any proof is deferred to preview branch, persistent `dev`, or root integration
+
+## Local Docpact Push Gate
+
+Install the versioned local hook once per checkout:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/dev` for routine branches and `origin/main` for promote or hotfix branches. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,8 +20,8 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -118,6 +118,30 @@ Repository configuration expected by `.github/workflows/supabase-dev.yml`:
 - variable `SUPABASE_DEV_PROJECT_ID`
 - secret `SUPABASE_ACCESS_TOKEN`
 - secret `SUPABASE_DEV_DB_PASSWORD`
+
+## PR to Supabase migration path
+
+Committed migration files do not affect any remote database until one of the
+deployment paths below runs.
+
+Normal PR path:
+
+1. A feature branch includes new files under `supabase/migrations/`.
+2. The PR targets Git `dev`.
+3. Supabase GitHub integration creates or updates the PR preview branch from
+   the checked-in `supabase/` directory.
+4. The preview branch is PR-scoped proof only; it is not the persistent
+   Supabase `dev` branch.
+5. After the PR merges, the resulting push to Git `dev` triggers
+   `.github/workflows/supabase-dev.yml`.
+6. The workflow links to `SUPABASE_DEV_PROJECT_ID` and runs `supabase db push`.
+7. Pending checked-in migrations are then applied to the persistent Supabase
+   `dev` branch.
+
+This repository currently has no checked-in manual `workflow_dispatch` deploy
+for Supabase. An operator can still run `supabase link` and `supabase db push`
+locally, but that is a deliberate manual deployment path and must be recorded
+as such in validation or incident notes.
 
 ## Vault secret contract
 

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+lastReviewedAt: 2026-05-14
+lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -118,6 +118,23 @@ related:
 - variable `SUPABASE_DEV_PROJECT_ID`
 - secret `SUPABASE_ACCESS_TOKEN`
 - secret `SUPABASE_DEV_DB_PASSWORD`
+
+## PR 到 Supabase migration 路径
+
+已提交的 migration 文件不会因为文件存在就影响远端数据库，只有下面这些部署路径运行后才会生效。
+
+常规 PR 路径：
+
+1. feature 分支包含新的 `supabase/migrations/` 文件。
+2. PR 目标分支是 Git `dev`。
+3. Supabase GitHub integration 根据已提交的 `supabase/` 目录创建或更新该 PR 的 preview branch。
+4. preview branch 只用于 PR 级别验证；它不是持久化 Supabase `dev` 分支。
+5. PR 合并后，对 Git `dev` 的 push 会触发 `.github/workflows/supabase-dev.yml`。
+6. 该 workflow 会连接 `SUPABASE_DEV_PROJECT_ID` 并执行 `supabase db push`。
+7. 尚未应用的已提交 migrations 随后才会应用到持久化 Supabase `dev` 分支。
+
+本仓目前没有 checked-in 的手动 `workflow_dispatch` Supabase 部署流程。运维人员仍可在本地执行
+`supabase link` 和 `supabase db push`，但这是明确的人工部署路径，必须在验证记录或事故记录中说明。
 
 ## Vault secret 契约
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,8 +16,11 @@ checkPaths:
   - scripts/**
   - supabase/workspace/**
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -144,3 +147,7 @@ Not currently supported:
 Internal shared module used by the scripts above.
 
 It is not intended to be the primary entry point for routine command-line use.
+
+## Local Docpact Push Gate
+
+The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. It is documentation-governance tooling and does not change database schema workspace behavior.

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -16,8 +16,11 @@ checkPaths:
   - scripts/**
   - supabase/workspace/**
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -144,3 +147,7 @@ python scripts/new_migration.py --name "update policy roles update" --source-pat
 这是上面几个脚本共用的内部模块。
 
 通常不作为日常命令行入口直接使用。
+
+## Local Docpact Push Gate
+
+The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. It is documentation-governance tooling and does not change database schema workspace behavior.

--- a/scripts/docpact-gate.sh
+++ b/scripts/docpact-gate.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+find_docpact() {
+  if [ -n "${DOCPACT_BIN:-}" ] && "$DOCPACT_BIN" --version >/dev/null 2>&1; then
+    printf '%s\n' "$DOCPACT_BIN"
+    return 0
+  fi
+
+  if [ -x "$HOME/.cargo/bin/docpact" ] && "$HOME/.cargo/bin/docpact" --version >/dev/null 2>&1; then
+    printf '%s\n' "$HOME/.cargo/bin/docpact"
+    return 0
+  fi
+
+  if command -v docpact >/dev/null 2>&1; then
+    command -v docpact
+    return 0
+  fi
+
+  echo "docpact was not found. Install it with: cargo install docpact --version 0.1.4 --force" >&2
+  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
+  return 127
+}
+
+docpact_bin="$(find_docpact)"
+current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+head_ref="${DOCPACT_HEAD_REF:-HEAD}"
+base_ref="${DOCPACT_BASE_REF:-origin/dev}"
+
+case "$current_branch" in
+  main | master | promote/* | hotfix/* | release/*)
+    if [ -z "${DOCPACT_BASE_REF:-}" ]; then
+      base_ref="origin/main"
+    fi
+    ;;
+esac
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base)
+      base_ref="$2"
+      shift 2
+      ;;
+    --head)
+      head_ref="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if ! base_sha="$(git merge-base "$head_ref" "$base_ref" 2>/dev/null)"; then
+  echo "Could not resolve merge-base for $head_ref and $base_ref." >&2
+  echo "Fetch the base ref or rerun with DOCPACT_BASE_REF=<ref>." >&2
+  exit 2
+fi
+
+head_sha="$(git rev-parse "$head_ref")"
+report_path="${TMPDIR:-/tmp}/docpact-gate-$$.json"
+trap 'rm -f "$report_path"' EXIT HUP INT TERM
+
+echo "Running docpact config validation."
+"$docpact_bin" validate-config --root . --strict
+
+echo "Running docpact lint: base=$base_sha head=$head_sha."
+"$docpact_bin" lint --root . --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-push scripts/docpact-gate.sh
+
+echo "Configured git hooks: core.hooksPath=.githooks"

--- a/supabase/migrations/20260514093000_scope_embedding_derivative_update_triggers.sql
+++ b/supabase/migrations/20260514093000_scope_embedding_derivative_update_triggers.sql
@@ -1,0 +1,70 @@
+drop trigger if exists flows_json_sync_trigger on public.flows;
+drop trigger if exists flows_set_modified_at_trigger on public.flows;
+drop trigger if exists lifecyclemodels_json_sync_trigger on public.lifecyclemodels;
+drop trigger if exists lifecyclemodels_set_modified_at_trigger on public.lifecyclemodels;
+drop trigger if exists processes_json_sync_trigger on public.processes;
+drop trigger if exists processes_set_modified_at_trigger on public.processes;
+
+create trigger flows_json_sync_trigger
+before insert or update of json_ordered on public.flows
+for each row
+execute function public.flows_sync_jsonb_version();
+
+create trigger flows_set_modified_at_trigger
+before update of
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  version,
+  team_id,
+  review_id,
+  rule_verification,
+  reviews,
+  embedding_flag
+on public.flows
+for each row
+execute function public.update_modified_at();
+
+create trigger lifecyclemodels_json_sync_trigger
+before insert or update of json_ordered on public.lifecyclemodels
+for each row
+execute function public.lifecyclemodels_sync_jsonb_version();
+
+create trigger lifecyclemodels_set_modified_at_trigger
+before update of
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  version,
+  json_tg,
+  team_id,
+  rule_verification,
+  reviews,
+  embedding_flag
+on public.lifecyclemodels
+for each row
+execute function public.update_modified_at();
+
+create trigger processes_json_sync_trigger
+before insert or update of json_ordered on public.processes
+for each row
+execute function public.processes_sync_jsonb_version();
+
+create trigger processes_set_modified_at_trigger
+before update of
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  version,
+  team_id,
+  review_id,
+  rule_verification,
+  reviews,
+  embedding_flag,
+  model_id
+on public.processes
+for each row
+execute function public.update_modified_at();

--- a/supabase/tests/20260514_embedding_derivative_trigger_scope.sql
+++ b/supabase/tests/20260514_embedding_derivative_trigger_scope.sql
@@ -1,0 +1,128 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(15);
+
+create or replace function pg_temp.trigger_update_columns(
+  p_table regclass,
+  p_trigger_name text
+) returns text
+language sql
+stable
+as $$
+  select coalesce(
+    string_agg(att.attname, ', ' order by att.attnum),
+    '<all update columns>'
+  )
+  from pg_trigger trg
+  left join lateral unnest(trg.tgattr::smallint[]) a(attnum) on true
+  left join pg_attribute att
+    on att.attrelid = trg.tgrelid
+   and att.attnum = a.attnum
+  where trg.tgrelid = p_table
+    and trg.tgname = p_trigger_name
+    and not trg.tgisinternal
+  group by trg.oid;
+$$;
+
+select is(
+  pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_json_sync_trigger'),
+  'json_ordered',
+  'flows json sync only runs when json_ordered is updated'
+);
+
+select is(
+  pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_json_sync_trigger'),
+  'json_ordered',
+  'lifecyclemodels json sync only runs when json_ordered is updated'
+);
+
+select is(
+  pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_json_sync_trigger'),
+  'json_ordered',
+  'processes json sync only runs when json_ordered is updated'
+);
+
+select isnt(
+  pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger'),
+  '<all update columns>',
+  'flows modified_at trigger is column-scoped'
+);
+
+select isnt(
+  pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger'),
+  '<all update columns>',
+  'lifecyclemodels modified_at trigger is column-scoped'
+);
+
+select isnt(
+  pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger'),
+  '<all update columns>',
+  'processes modified_at trigger is column-scoped'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') like '%json%'
+  and pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') like '%state_code%',
+  'flows modified_at still covers business fields'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') like '%json%'
+  and pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') like '%state_code%',
+  'lifecyclemodels modified_at still covers business fields'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') like '%json%'
+  and pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') like '%state_code%',
+  'processes modified_at still covers business fields'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') not like '%embedding_ft%'
+  and pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') not like '%embedding_at%'
+  and pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') not like '%extracted_text%'
+  and pg_temp.trigger_update_columns('public.flows'::regclass, 'flows_set_modified_at_trigger') not like '%extracted_md%',
+  'flows modified_at skips derived embedding and extraction columns'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') not like '%embedding_ft%'
+  and pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') not like '%embedding_at%'
+  and pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') not like '%extracted_text%'
+  and pg_temp.trigger_update_columns('public.lifecyclemodels'::regclass, 'lifecyclemodels_set_modified_at_trigger') not like '%extracted_md%',
+  'lifecyclemodels modified_at skips derived embedding and extraction columns'
+);
+
+select ok(
+  pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') not like '%embedding_ft%'
+  and pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') not like '%embedding_at%'
+  and pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') not like '%extracted_text%'
+  and pg_temp.trigger_update_columns('public.processes'::regclass, 'processes_set_modified_at_trigger') not like '%extracted_md%',
+  'processes modified_at skips derived embedding and extraction columns'
+);
+
+select is(
+  (select (tgtype & 4) <> 0 from pg_trigger where tgrelid = 'public.flows'::regclass and tgname = 'flows_json_sync_trigger'),
+  true,
+  'flows json sync still runs on insert'
+);
+
+select is(
+  (select (tgtype & 4) <> 0 from pg_trigger where tgrelid = 'public.lifecyclemodels'::regclass and tgname = 'lifecyclemodels_json_sync_trigger'),
+  true,
+  'lifecyclemodels json sync still runs on insert'
+);
+
+select is(
+  (select (tgtype & 4) <> 0 from pg_trigger where tgrelid = 'public.processes'::regclass and tgname = 'processes_json_sync_trigger'),
+  true,
+  'processes json sync still runs on insert'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -17,8 +17,11 @@ checkPaths:
   - supabase/workspace/**
   - scripts/**
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -77,3 +80,7 @@ Each refresh performs these operations inside `supabase/workspace`:
 ```bash
 python scripts/build_schema_workspace.py --environment dev
 ```
+
+## Local Docpact Push Gate
+
+The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. It is documentation-governance tooling and does not change database schema workspace behavior.

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -17,8 +17,11 @@ checkPaths:
   - supabase/workspace/**
   - scripts/**
   - docs/agents/repo-architecture.md
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4495c2c5771c03789c0ec26de5852f6a33001fec
+  - .githooks/pre-push
+  - scripts/docpact-gate.sh
+  - scripts/install-git-hooks.sh
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -77,3 +80,7 @@ related:
 ```bash
 python scripts/build_schema_workspace.py --environment dev
 ```
+
+## Local Docpact Push Gate
+
+The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. It is documentation-governance tooling and does not change database schema workspace behavior.


### PR DESCRIPTION
## Summary
- Promote current Git `dev` to Git `main`.
- Includes the merged embedding trigger scope fix from #35.
- Also carries the existing `dev` commit `5c0152c chore: add local docpact pre-push gate`, which is already part of the current `dev` promotion range.

## Migration impact
- The new migration scopes embedding derivative update triggers for `flows`, `lifecyclemodels`, and `processes`.
- Applying to `main` follows the repository promotion path after `dev` validation.

## Validation carried from #35
- Remote transaction dry run: migration plus `supabase/tests/20260514_embedding_derivative_trigger_scope.sql`; all 15 assertions passed, then rolled back.
- `docpact validate-config --root . --strict`
- `docpact lint ... --mode enforce`
- `git diff --check`

## Notes
- This is a `dev -> main` promotion PR, not a feature branch PR.
