### PR TITLE
fix: allow process volume provider rule

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-14"
-lastReviewedCommit: "5c0152c65b2e9afaf433817d6794d0da705f435d"
+lastReviewedAt: "2026-05-18"
+lastReviewedCommit: "06251bd92cd72f16c5809217421805a48577a3b2"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 3dc752e9d8a8a322a3bd823308dae50e3cc4b657
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 06251bd92cd72f16c5809217421805a48577a3b2
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 06251bd92cd72f16c5809217421805a48577a3b2
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260518180641_lca_network_snapshots_allow_process_volume_provider_rule.sql
+++ b/supabase/migrations/20260518180641_lca_network_snapshots_allow_process_volume_provider_rule.sql
@@ -1,0 +1,19 @@
+ALTER TABLE public.lca_network_snapshots
+    DROP CONSTRAINT IF EXISTS lca_network_snapshots_provider_rule_chk;
+
+ALTER TABLE public.lca_network_snapshots
+    ADD CONSTRAINT lca_network_snapshots_provider_rule_chk
+    CHECK (
+        provider_matching_rule = ANY (
+            ARRAY[
+                'strict_unique_provider'::text,
+                'best_provider_strict'::text,
+                'split_by_evidence'::text,
+                'split_by_evidence_hybrid'::text,
+                'split_equal'::text,
+                'equal_split_multi_provider'::text,
+                'custom_weighted_provider'::text,
+                'split_by_process_volume'::text
+            ]
+        )
+    );


### PR DESCRIPTION
Closes #38

## Summary
- Add a Supabase migration that recreates lca_network_snapshots_provider_rule_chk with split_by_process_volume included.
- Record the required docpact review evidence for the migration governance docs.

## Key Decisions
- Keep the existing allowed provider_matching_rule values unchanged and only add split_by_process_volume.
- Use DROP CONSTRAINT IF EXISTS before re-adding the check constraint so the migration can apply cleanly even after the temporary remote hotfix.

## Validation
- scripts/docpact-gate.sh --base origin/dev
- psql "" ... -c BEGIN -f supabase/migrations/20260518180641_lca_network_snapshots_allow_process_volume_provider_rule.sql -c "SELECT pg_get_constraintdef(...)" -c ROLLBACK: verified the constraint definition includes split_by_process_volume.
- psql "" ... -c BEGIN -f supabase/migrations/20260518180641_lca_network_snapshots_allow_process_volume_provider_rule.sql -c "INSERT INTO public.lca_network_snapshots (provider_matching_rule, status) VALUES ('split_by_process_volume', 'draft') RETURNING provider_matching_rule, status" -c ROLLBACK: verified the new value is accepted.
- supabase db reset was attempted but could not run locally because the Docker daemon at /Users/biao/.orbstack/run/docker.sock is not running.

## Risks / Rollback
- The migration briefly drops and re-adds a table check constraint; it preserves the prior value set and adds one new allowed value.

## Follow-ups
- After merge into dev, validate the persistent Supabase dev branch deployment from the repo workflow.

## Workspace Integration
- After database-engine is promoted according to branch policy, root lca-workspace should bump the database-engine submodule pointer.