### PR TITLE
ci: pin supabase cli setup

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-18"
-lastReviewedCommit: "06251bd92cd72f16c5809217421805a48577a3b2"
+lastReviewedCommit: "181511dbc6a2e084ad01016df64708453b6b10f5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
-          version: latest
+          version: 2.99.0
 
       - name: Link Supabase dev branch
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 3dc752e9d8a8a322a3bd823308dae50e3cc4b657
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 06251bd92cd72f16c5809217421805a48577a3b2
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 06251bd92cd72f16c5809217421805a48577a3b2
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,8 +20,8 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- Update the Supabase Dev workflow from supabase/setup-cli@v1 with version latest to supabase/setup-cli@v2 with a pinned Supabase CLI 2.99.0.
- Record required docpact review evidence for the workflow and branch-operation docs.

## Key Decisions
- The #39 merge failed before migration execution because setup-cli@v1 could not resolve latest and returned HTTP 404.
- Pinning the CLI removes the unstable latest lookup while retaining the same single persistent-dev deployment path.

## Validation
- gh run view 26027274716 --repo tiangong-lca/database-engine --log-failed: failure occurs in Setup Supabase CLI with Unexpected HTTP response: 404.
- gh release view v2.99.0 --repo supabase/cli: confirmed the pinned CLI release exists.
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-dev.yml")': workflow YAML parses.
- scripts/docpact-gate.sh --base origin/dev

## Risks / Rollback
- This changes CI/deploy setup only; the dev deployment still runs supabase link followed by supabase db push.

## Follow-ups
- After merge, rerun or observe Supabase Dev on dev for c44bdf5/this workflow fix and confirm the persistent dev branch deploys.

## Workspace Integration
- Root workspace integration still waits until database-engine changes are promoted to main.