### PR TITLE
ci: use compatible supabase cli release

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-18"
-lastReviewedCommit: "181511dbc6a2e084ad01016df64708453b6b10f5"
+lastReviewedCommit: "9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.99.0
+          version: 2.98.0
 
       - name: Link Supabase dev branch
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -21,7 +21,7 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- Pin the Supabase Dev workflow to CLI 2.98.0, whose release assets match supabase/setup-cli@v2's expected download URL.
- Keep setup-cli@v2 from PR #40 and update only the CLI version.

## Key Decisions
- setup-cli@v2 still failed with CLI 2.99.0 because that release publishes version-prefixed Linux tarballs, while setup-cli@v2 downloads supabase_linux_amd64.tar.gz for >=1.28.0.
- CLI 2.98.0 publishes supabase_linux_amd64.tar.gz and is compatible with setup-cli@v2's current download logic.

## Validation
- gh run view 26027604606 --repo tiangong-lca/database-engine --log-failed: confirmed setup-cli@v2 + 2.99.0 still failed at download with HTTP 404.
- gh release view v2.98.0 --repo supabase/cli: confirmed supabase_linux_amd64.tar.gz is present.
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-dev.yml")'
- scripts/docpact-gate.sh --base origin/dev

## Risks / Rollback
- This changes only the CLI version used by the dev deployment workflow; migration behavior remains supabase link followed by supabase db push.

## Follow-ups
- After merge, confirm the Supabase Dev workflow on dev succeeds before database-engine dev -> main promotion.

## Workspace Integration
- Root workspace integration remains blocked until database-engine changes are promoted to main.