### PR TITLE
chore: promote provider rule constraint to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-14"
-lastReviewedCommit: "5c0152c65b2e9afaf433817d6794d0da705f435d"
+lastReviewedAt: "2026-05-18"
+lastReviewedCommit: "06251bd92cd72f16c5809217421805a48577a3b2"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-18"
-lastReviewedCommit: "181511dbc6a2e084ad01016df64708453b6b10f5"
+lastReviewedCommit: "9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-18"
-lastReviewedCommit: "06251bd92cd72f16c5809217421805a48577a3b2"
+lastReviewedCommit: "181511dbc6a2e084ad01016df64708453b6b10f5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.99.0
+          version: 2.98.0
 
       - name: Link Supabase dev branch
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
-          version: latest
+          version: 2.99.0
 
       - name: Link Supabase dev branch
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 3dc752e9d8a8a322a3bd823308dae50e3cc4b657
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 3dc752e9d8a8a322a3bd823308dae50e3cc4b657
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 06251bd92cd72f16c5809217421805a48577a3b2
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 06251bd92cd72f16c5809217421805a48577a3b2
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 06251bd92cd72f16c5809217421805a48577a3b2
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 06251bd92cd72f16c5809217421805a48577a3b2
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -21,7 +21,7 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,8 +20,8 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-05-18
-lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
+lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-05-14
-lastReviewedCommit: 5c0152c65b2e9afaf433817d6794d0da705f435d
+lastReviewedAt: 2026-05-18
+lastReviewedCommit: 181511dbc6a2e084ad01016df64708453b6b10f5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260518180641_lca_network_snapshots_allow_process_volume_provider_rule.sql
+++ b/supabase/migrations/20260518180641_lca_network_snapshots_allow_process_volume_provider_rule.sql
@@ -1,0 +1,19 @@
+ALTER TABLE public.lca_network_snapshots
+    DROP CONSTRAINT IF EXISTS lca_network_snapshots_provider_rule_chk;
+
+ALTER TABLE public.lca_network_snapshots
+    ADD CONSTRAINT lca_network_snapshots_provider_rule_chk
+    CHECK (
+        provider_matching_rule = ANY (
+            ARRAY[
+                'strict_unique_provider'::text,
+                'best_provider_strict'::text,
+                'split_by_evidence'::text,
+                'split_by_evidence_hybrid'::text,
+                'split_equal'::text,
+                'equal_split_multi_provider'::text,
+                'custom_weighted_provider'::text,
+                'split_by_process_volume'::text
+            ]
+        )
+    );


### PR DESCRIPTION
## Summary
- Promote database-engine dev through PR #39, #40, and #41 into main.
- Includes the lca_network_snapshots provider rule constraint migration for split_by_process_volume.
- Includes Supabase Dev workflow fixes that restored the persistent dev deployment.

## Key Decisions
- Use the normal database-engine dev -> main promotion path before root workspace integration.

## Validation
- Supabase Dev on dev commit b2d5990 succeeded: https://github.com/tiangong-lca/database-engine/actions/runs/26027967990
- scripts/docpact-gate.sh --base origin/main

## Risks / Rollback
- This promotes already-merged dev commits to the production baseline; root workspace main will still wait for this PR to merge before bumping database-engine.

## Follow-ups
- After merge, update lca-workspace main to point database-engine at the promoted main commit.

## Workspace Integration
- Required before root lca-workspace/main can integrate the database-engine change for tiangong-lca/workspace#109 and tiangong-lca/database-engine#38.