### PR TITLE
feat: add latest contact version RPCs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-20"
-lastReviewedCommit: "b2d5990da6d7e490296647871cf47e15efd8c547"
+lastReviewedCommit: "b6011f4ae0ed130ca99981ddbc57559b4325bbe5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260520143000_contacts_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520143000_contacts_latest_version_query_rpcs.sql
@@ -1,0 +1,295 @@
+CREATE INDEX IF NOT EXISTS "contacts_state_code_id_version_modified_at_idx"
+ON "public"."contacts" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "contacts_user_id_state_code_id_version_modified_at_idx"
+ON "public"."contacts" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "contacts_team_id_state_code_id_version_modified_at_idx"
+ON "public"."contacts" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.contacts f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.contacts f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";

--- a/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
@@ -1,0 +1,247 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '17000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'latest-contact-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"17000000-0000-0000-0000-000000000001","email":"latest-contact-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('27000000-0000-0000-0000-000000000001', '{"name":"Latest Contact Team A"}'::jsonb, 1, false),
+  ('27000000-0000-0000-0000-000000000002', '{"name":"Latest Contact Team B"}'::jsonb, 2, false);
+
+insert into public.contacts (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '37000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Legacy matched contact"}],"common:name":[{"@xml:lang":"en","#text":"Legacy matched contact"}],"email":"legacy@example.com"}}},"search":"legacy unique"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Legacy matched contact"}],"common:name":[{"@xml:lang":"en","#text":"Legacy matched contact"}],"email":"legacy@example.com"}}},"search":"legacy unique"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    100,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Latest contact"}],"common:name":[{"@xml:lang":"en","#text":"Latest contact"}],"email":"latest@example.com"}}},"search":"current text"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Latest contact"}],"common:name":[{"@xml:lang":"en","#text":"Latest contact"}],"email":"latest@example.com"}}},"search":"current text"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    100,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Single open contact"}],"common:name":[{"@xml:lang":"en","#text":"Single open contact"}],"email":"single@example.com"}}},"search":"single"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Single open contact"}],"common:name":[{"@xml:lang":"en","#text":"Single open contact"}],"email":"single@example.com"}}},"search":"single"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    100,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000003',
+    '01.00.001',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Other team contact"}],"common:name":[{"@xml:lang":"en","#text":"Other team contact"}],"email":"other-team@example.com"}}},"search":"other team"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Other team contact"}],"common:name":[{"@xml:lang":"en","#text":"Other team contact"}],"email":"other-team@example.com"}}},"search":"other team"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    100,
+    '27000000-0000-0000-0000-000000000002',
+    true,
+    now() - interval '3 days',
+    now() - interval '3 days'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner draft contact"}],"common:name":[{"@xml:lang":"en","#text":"Owner draft contact"}],"email":"draft@example.com"}}},"search":"draft"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner draft contact"}],"common:name":[{"@xml:lang":"en","#text":"Owner draft contact"}],"email":"draft@example.com"}}},"search":"draft"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    0,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '4 days',
+    now() - interval '4 days'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000004',
+    '01.00.001',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner review contact"}],"common:name":[{"@xml:lang":"en","#text":"Owner review contact"}],"email":"review@example.com"}}},"search":"review"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner review contact"}],"common:name":[{"@xml:lang":"en","#text":"Owner review contact"}],"email":"review@example.com"}}},"search":"review"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    20,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '1 hour',
+    now() - interval '1 hour'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '17000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select version::text
+    from public.get_latest_contact_versions(10, 1, 'tg', '17000000-0000-0000-0000-000000000001')
+    where id = '37000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'open contact list returns the highest visible version for a UUID'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_contact_versions(10, 1, 'tg', '17000000-0000-0000-0000-000000000001')
+    where id = '37000000-0000-0000-0000-000000000001'
+  ),
+  2::bigint,
+  'open contact list reports version_count for the visible UUID group'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.get_latest_contact_versions(10, 1, 'tg', '17000000-0000-0000-0000-000000000001')
+  ),
+  3::bigint,
+  'open contact list total_count counts unique UUIDs, not version rows'
+);
+
+select is(
+  (
+    select count(*)
+    from public.get_latest_contact_versions(
+      10,
+      1,
+      'tg',
+      '17000000-0000-0000-0000-000000000001',
+      '27000000-0000-0000-0000-000000000001'
+    )
+  ),
+  2::bigint,
+  'team filter limits open contact latest-version rows before pagination'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_contact_versions(
+      10,
+      1,
+      'my',
+      '17000000-0000-0000-0000-000000000001'
+    )
+    where id = '37000000-0000-0000-0000-000000000004'
+  ),
+  2::bigint,
+  'my data without a state filter counts all owner-visible versions'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_contact_versions(
+      10,
+      1,
+      'my',
+      '17000000-0000-0000-0000-000000000001',
+      null,
+      20
+    )
+    where id = '37000000-0000-0000-0000-000000000004'
+  ),
+  1::bigint,
+  'my data state filter is applied before version_count is calculated'
+);
+
+select is(
+  (
+    select version::text
+    from public.pgroonga_search_contacts_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '17000000-0000-0000-0000-000000000001'
+    )
+    where id = '37000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'search can match an older version while returning the highest visible version for that UUID'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.pgroonga_search_contacts_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '17000000-0000-0000-0000-000000000001'
+    )
+  ),
+  1::bigint,
+  'search total_count counts matching UUIDs after grouping'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary
- Add `get_latest_contact_versions` for Contacts main lists to page and count by unique UUID before returning the highest visible version.
- Add `pgroonga_search_contacts_latest` so search may match any visible version while returning the highest visible version for each matching UUID.
- Add PGTAP assertions covering latest-version selection, `version_count`, unique UUID `total_count`, team/state filters, and search grouping.

Part of #43 and supports linancn/tiangong-lca-next#421.

## Validation
- `~/.cargo/bin/docpact lint --root . --files "supabase/migrations/20260520143000_contacts_latest_version_query_rpcs.sql,supabase/tests/20260520_contacts_latest_version_query_rpcs.sql,.docpact/config.yaml,AGENTS.md,docs/agents/repo-architecture.md,docs/agents/repo-validation.md" --format json --output .docpact/runs/latest.json`
- `git diff --check`

## Deferred proof
- `supabase db reset` and `supabase/tests/20260520_contacts_latest_version_query_rpcs.sql` were not run locally because this machine does not have the `supabase` CLI available (`supabase --version` exits with `command not found`).
- Preview branch checks should run the migration and SQL assertions for database-side proof.
