### PR TITLE
feat: add latest-version RPCs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-20"
-lastReviewedCommit: "b6011f4ae0ed130ca99981ddbc57559b4325bbe5"
+lastReviewedCommit: "9fe01549b988d87f9707dc914de9fd1d0b55b55a"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-20"
-lastReviewedCommit: "b2d5990da6d7e490296647871cf47e15efd8c547"
+lastReviewedCommit: "b6011f4ae0ed130ca99981ddbc57559b4325bbe5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
+lastReviewedCommit: 9fe01549b988d87f9707dc914de9fd1d0b55b55a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
+lastReviewedCommit: 9fe01549b988d87f9707dc914de9fd1d0b55b55a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
+lastReviewedCommit: 9fe01549b988d87f9707dc914de9fd1d0b55b55a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260520170000_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520170000_unitgroups_latest_version_query_rpcs.sql
@@ -1,0 +1,295 @@
+CREATE INDEX IF NOT EXISTS "unitgroups_state_code_id_version_modified_at_idx"
+ON "public"."unitgroups" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "unitgroups_user_id_state_code_id_version_modified_at_idx"
+ON "public"."unitgroups" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "unitgroups_team_id_state_code_id_version_modified_at_idx"
+ON "public"."unitgroups" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.unitgroups f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.unitgroups f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";

--- a/supabase/migrations/20260520174500_flowproperties_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520174500_flowproperties_latest_version_query_rpcs.sql
@@ -1,0 +1,295 @@
+CREATE INDEX IF NOT EXISTS "flowproperties_state_code_id_version_modified_at_idx"
+ON "public"."flowproperties" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "flowproperties_user_id_state_code_id_version_modified_at_idx"
+ON "public"."flowproperties" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "flowproperties_team_id_state_code_id_version_modified_at_idx"
+ON "public"."flowproperties" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.flowproperties f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flowproperties f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";

--- a/supabase/migrations/20260520203000_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520203000_core_datasets_latest_version_query_rpcs.sql
@@ -1,0 +1,1274 @@
+CREATE INDEX IF NOT EXISTS "flows_state_code_id_version_modified_at_idx"
+ON "public"."flows" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "flows_user_id_state_code_id_version_modified_at_idx"
+ON "public"."flows" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "flows_team_id_state_code_id_version_modified_at_idx"
+ON "public"."flows" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "processes_state_code_id_version_modified_at_idx"
+ON "public"."processes" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "processes_user_id_state_code_id_version_modified_at_idx"
+ON "public"."processes" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "processes_team_id_state_code_id_version_modified_at_idx"
+ON "public"."processes" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_state_code_id_version_modified_at_idx"
+ON "public"."lifecyclemodels" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_user_id_state_code_id_version_modified_at_idx"
+ON "public"."lifecyclemodels" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_team_id_state_code_id_version_modified_at_idx"
+ON "public"."lifecyclemodels" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_flow_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.flows f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT DISTINCT visible_rows.id
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_process_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT p.*
+      FROM public.processes p
+      WHERE
+        (
+          (data_source = 'tg' AND p.state_code = 100)
+          OR (data_source = 'co' AND p.state_code = 200)
+          OR (data_source = 'my' AND p.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND p.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR p.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR p.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT DISTINCT visible_rows.id
+      FROM visible_rows
+      WHERE
+        coalesce(type_of_data_set_filter, 'all') = 'all'
+        OR visible_rows.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        visible_rows.model_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.model_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_lifecyclemodel_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE
+        (
+          (data_source = 'tg' AND l.state_code = 100)
+          OR (data_source = 'co' AND l.state_code = 200)
+          OR (data_source = 'my' AND l.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND l.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR l.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR l.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flows_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_processes_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE
+        (
+          (data_source = 'tg' AND p.state_code = 100)
+          OR (data_source = 'co' AND p.state_code = 200)
+          OR (data_source = 'my' AND p.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND p.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR p.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR p.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          coalesce(type_of_data_set_filter, 'all') = 'all'
+          OR visible_rows.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+        )
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        visible_rows.model_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.model_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE
+        (
+          (data_source = 'tg' AND l.state_code = 100)
+          OR (data_source = 'co' AND l.state_code = 200)
+          OR (data_source = 'my' AND l.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND l.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR l.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR l.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_flows"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_flows_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_flows_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_flows_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT f.*
+      FROM public.flows f
+      JOIN fused ON fused.id = f.id
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = f.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_processes"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "model_id" uuid,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_processes_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_processes_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_processes_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT p.*
+      FROM public.processes p
+      JOIN fused ON fused.id = p.id
+      WHERE
+        (
+          (data_source = 'tg' AND p.state_code = 100)
+          OR (data_source = 'co' AND p.state_code = 200)
+          OR (data_source = 'my' AND p.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = p.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.model_id,
+        visible_rows.team_id,
+        version_counts.version_count,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.model_id,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_lifecyclemodels"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_lifecyclemodels_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_lifecyclemodels_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_lifecyclemodels_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      JOIN fused ON fused.id = l.id
+      WHERE
+        (
+          (data_source = 'tg' AND l.state_code = 100)
+          OR (data_source = 'co' AND l.state_code = 200)
+          OR (data_source = 'my' AND l.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = l.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -1,0 +1,300 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(15);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '16000000-0000-0000-0000-000000000047',
+    'authenticated',
+    'authenticated',
+    'latest-core-datasets-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"16000000-0000-0000-0000-000000000047","email":"latest-core-datasets-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('26000000-0000-0000-0000-000000000048', '{"name":"Latest Core Dataset Team"}'::jsonb, 1, false);
+
+create temporary table latest_zero_embedding (value text) on commit drop;
+insert into latest_zero_embedding (value)
+select '[' || string_agg('0', ',') || ']'
+from generate_series(1, 1024);
+
+alter table public.flows disable trigger "flows_json_sync_trigger";
+alter table public.processes disable trigger "processes_json_sync_trigger";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_trigger";
+
+insert into public.flows (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '47000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-old","#text":"Old class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"legacy-flow-token"}'::jsonb,
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-old","#text":"Old class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"legacy-flow-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '47000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-new","#text":"New class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"latest-flow-token"}'::jsonb,
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-new","#text":"New class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"latest-flow-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '47000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-single","#text":"Single class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"single-flow-token"}'::jsonb,
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-single","#text":"Single class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"single-flow-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  );
+
+insert into public.processes (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '48000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-old","#text":"Old class"}]}}},"time":{"common:referenceYear":"2020"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"legacy-process-token"}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-old","#text":"Old class"}]}}},"time":{"common:referenceYear":"2020"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"legacy-process-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '48000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-new","#text":"New class"}]}}},"time":{"common:referenceYear":"2021"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"latest-process-token"}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-new","#text":"New class"}]}}},"time":{"common:referenceYear":"2021"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"latest-process-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '48000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-single","#text":"Single class"}]}}},"time":{"common:referenceYear":"2022"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"single-process-token"}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-single","#text":"Single class"}]}}},"time":{"common:referenceYear":"2022"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"single-process-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  );
+
+insert into public.lifecyclemodels (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '49000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-old","#text":"Old class"}]}}}}},"search":"legacy-lifecycle-token"}'::jsonb,
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-old","#text":"Old class"}]}}}}},"search":"legacy-lifecycle-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '49000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-new","#text":"New class"}]}}}}},"search":"latest-lifecycle-token"}'::jsonb,
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-new","#text":"New class"}]}}}}},"search":"latest-lifecycle-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '49000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-single","#text":"Single class"}]}}}}},"search":"single-lifecycle-token"}'::jsonb,
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-single","#text":"Single class"}]}}}}},"search":"single-lifecycle-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '16000000-0000-0000-0000-000000000047', true);
+
+select is(
+  (select version::text from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'flow list returns the highest visible version for a UUID'
+);
+
+select is(
+  (select version_count from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
+  2::bigint,
+  'flow list reports version_count for the visible UUID group'
+);
+
+select is(
+  (select max(total_count) from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
+  2::bigint,
+  'flow list total_count counts unique UUIDs'
+);
+
+select is(
+  (select version::text from public.pgroonga_search_flows_latest('legacy-flow-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'flow PGroonga search can match an older version while returning the highest visible version'
+);
+
+select is(
+  (select version::text from public.hybrid_search_flows('legacy-flow-token', (select value from latest_zero_embedding), '{}', 0.1, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) where id = '47000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'flow hybrid search returns the highest visible version for a matching UUID'
+);
+
+select is(
+  (select version::text from public.get_latest_process_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '48000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'process list returns the highest visible version for a UUID'
+);
+
+select is(
+  (select version_count from public.get_latest_process_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '48000000-0000-0000-0000-000000000001'),
+  2::bigint,
+  'process list reports version_count for the visible UUID group'
+);
+
+select is(
+  (select max(total_count) from public.get_latest_process_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
+  2::bigint,
+  'process list total_count counts unique UUIDs'
+);
+
+select is(
+  (select version::text from public.pgroonga_search_processes_latest('legacy-process-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '48000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'process PGroonga search can match an older version while returning the highest visible version'
+);
+
+select is(
+  (select version::text from public.hybrid_search_processes('legacy-process-token', (select value from latest_zero_embedding), '{}', 0.1, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) where id = '48000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'process hybrid search returns the highest visible version for a matching UUID'
+);
+
+select is(
+  (select version::text from public.get_latest_lifecyclemodel_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'lifecyclemodel list returns the highest visible version for a UUID'
+);
+
+select is(
+  (select version_count from public.get_latest_lifecyclemodel_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
+  2::bigint,
+  'lifecyclemodel list reports version_count for the visible UUID group'
+);
+
+select is(
+  (select max(total_count) from public.get_latest_lifecyclemodel_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
+  2::bigint,
+  'lifecyclemodel list total_count counts unique UUIDs'
+);
+
+select is(
+  (select version::text from public.pgroonga_search_lifecyclemodels_latest('legacy-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'lifecyclemodel PGroonga search can match an older version while returning the highest visible version'
+);
+
+select is(
+  (select version::text from public.hybrid_search_lifecyclemodels('legacy-lifecycle-token', (select value from latest_zero_embedding), '{}', 0.1, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) where id = '49000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'lifecyclemodel hybrid search returns the highest visible version for a matching UUID'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
@@ -1,0 +1,249 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '16000000-0000-0000-0000-000000000046',
+    'authenticated',
+    'authenticated',
+    'latest-flowproperty-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"16000000-0000-0000-0000-000000000046","email":"latest-flowproperty-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('26000000-0000-0000-0000-000000000046', '{"name":"Latest Flowproperty Team A"}'::jsonb, 1, false),
+  ('26000000-0000-0000-0000-000000000047', '{"name":"Latest Flowproperty Team B"}'::jsonb, 2, false);
+
+alter table public.flowproperties disable trigger "flowproperties_json_sync_trigger";
+
+insert into public.flowproperties (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '46000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Legacy matched flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"legacy unique"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Legacy matched flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"legacy unique"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Latest flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"current text"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Latest flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"current text"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Single open flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u2"}},"units":{"unit":[{"@dataSetInternalID":"u2","name":"MJ"}]}},"search":"single"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Single open flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u2"}},"units":{"unit":[{"@dataSetInternalID":"u2","name":"MJ"}]}},"search":"single"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000003',
+    '01.00.001',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Other team flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u3"}},"units":{"unit":[{"@dataSetInternalID":"u3","name":"m"}]}},"search":"other team"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Other team flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u3"}},"units":{"unit":[{"@dataSetInternalID":"u3","name":"m"}]}},"search":"other team"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000047',
+    true,
+    now() - interval '3 days',
+    now() - interval '3 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner draft flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"draft"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner draft flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"draft"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    0,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '4 days',
+    now() - interval '4 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000004',
+    '01.00.001',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner review flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"review"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner review flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"review"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    200,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '1 hour',
+    now() - interval '1 hour'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '16000000-0000-0000-0000-000000000046', true);
+
+select is(
+  (
+    select version::text
+    from public.get_latest_flowproperty_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'open flow property list returns the highest visible version for a UUID'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_flowproperty_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  2::bigint,
+  'open flow property list reports version_count for the visible UUID group'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.get_latest_flowproperty_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+  ),
+  3::bigint,
+  'open flow property list total_count counts unique UUIDs, not version rows'
+);
+
+select is(
+  (
+    select count(*)
+    from public.get_latest_flowproperty_versions(
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046',
+      '26000000-0000-0000-0000-000000000046'
+    )
+  ),
+  2::bigint,
+  'team filter limits open flow property latest-version rows before pagination'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_flowproperty_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000046'
+    )
+    where id = '46000000-0000-0000-0000-000000000004'
+  ),
+  2::bigint,
+  'my data without a state filter counts all owner-visible versions'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_flowproperty_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000046',
+      null,
+      200
+    )
+    where id = '46000000-0000-0000-0000-000000000004'
+  ),
+  1::bigint,
+  'my data state filter is applied before version_count is calculated'
+);
+
+select is(
+  (
+    select version::text
+    from public.pgroonga_search_flowproperties_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046'
+    )
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'search can match an older version while returning the highest visible version for that UUID'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.pgroonga_search_flowproperties_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046'
+    )
+  ),
+  1::bigint,
+  'search total_count counts matching UUIDs after grouping'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
@@ -44,6 +44,8 @@ values
   ('26000000-0000-0000-0000-000000000046', '{"name":"Latest Unitgroup Team A"}'::jsonb, 1, false),
   ('26000000-0000-0000-0000-000000000047', '{"name":"Latest Unitgroup Team B"}'::jsonb, 2, false);
 
+alter table public.unitgroups disable trigger "unitgroups_json_sync_trigger";
+
 insert into public.unitgroups (
   id,
   version,

--- a/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
@@ -1,0 +1,247 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '16000000-0000-0000-0000-000000000046',
+    'authenticated',
+    'authenticated',
+    'latest-unitgroup-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"16000000-0000-0000-0000-000000000046","email":"latest-unitgroup-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('26000000-0000-0000-0000-000000000046', '{"name":"Latest Unitgroup Team A"}'::jsonb, 1, false),
+  ('26000000-0000-0000-0000-000000000047', '{"name":"Latest Unitgroup Team B"}'::jsonb, 2, false);
+
+insert into public.unitgroups (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '46000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Legacy matched unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"legacy unique"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Legacy matched unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"legacy unique"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Latest unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"current text"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Latest unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"current text"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Single open unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u2"}},"units":{"unit":[{"@dataSetInternalID":"u2","name":"MJ"}]}},"search":"single"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Single open unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u2"}},"units":{"unit":[{"@dataSetInternalID":"u2","name":"MJ"}]}},"search":"single"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000003',
+    '01.00.001',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Other team unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u3"}},"units":{"unit":[{"@dataSetInternalID":"u3","name":"m"}]}},"search":"other team"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Other team unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u3"}},"units":{"unit":[{"@dataSetInternalID":"u3","name":"m"}]}},"search":"other team"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000047',
+    true,
+    now() - interval '3 days',
+    now() - interval '3 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner draft unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"draft"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner draft unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"draft"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    0,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '4 days',
+    now() - interval '4 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000004',
+    '01.00.001',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner review unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"review"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner review unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"review"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    200,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '1 hour',
+    now() - interval '1 hour'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '16000000-0000-0000-0000-000000000046', true);
+
+select is(
+  (
+    select version::text
+    from public.get_latest_unitgroup_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'open unit group list returns the highest visible version for a UUID'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_unitgroup_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  2::bigint,
+  'open unit group list reports version_count for the visible UUID group'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.get_latest_unitgroup_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+  ),
+  3::bigint,
+  'open unit group list total_count counts unique UUIDs, not version rows'
+);
+
+select is(
+  (
+    select count(*)
+    from public.get_latest_unitgroup_versions(
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046',
+      '26000000-0000-0000-0000-000000000046'
+    )
+  ),
+  2::bigint,
+  'team filter limits open unit group latest-version rows before pagination'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_unitgroup_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000046'
+    )
+    where id = '46000000-0000-0000-0000-000000000004'
+  ),
+  2::bigint,
+  'my data without a state filter counts all owner-visible versions'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_unitgroup_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000046',
+      null,
+      200
+    )
+    where id = '46000000-0000-0000-0000-000000000004'
+  ),
+  1::bigint,
+  'my data state filter is applied before version_count is calculated'
+);
+
+select is(
+  (
+    select version::text
+    from public.pgroonga_search_unitgroups_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046'
+    )
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'search can match an older version while returning the highest visible version for that UUID'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.pgroonga_search_unitgroups_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046'
+    )
+  ),
+  1::bigint,
+  'search total_count counts matching UUIDs after grouping'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#46

## Summary
- Add latest-version list/search RPCs for Unitgroups and Flowproperties.
- Add latest-version list/search RPCs for Flows, Processes, and LifeCycleModels in the same PR so the remaining database side of the UUID de-dup方案 is consolidated here.
- Override `hybrid_search_flows`, `hybrid_search_processes`, and `hybrid_search_lifecyclemodels` so hybrid search can match any visible version while returning only the latest visible version for each UUID.
- Return `version_count` and `total_count` from latest list/search functions so frontend pagination and All Versions UI can use server-side UUID totals.
- Add pgtap SQL assertions covering highest version selection, `version_count`, unique UUID total, team/state filters, and old-version search matches.
- Harden handcrafted version fixtures by disabling json sync triggers where needed so test versions are not overwritten by fixture JSON shape.

## Scope Direction
- This PR now covers Unitgroups, Flowproperties, Flows, Processes, and LifeCycleModels for latest-version list/search behavior.
- Historical DB slices that are already merged or separately recorded remain linked as their own records: #44 for Sources and #45 for Contacts.

## Key Decisions
- Follow the Sources/Contacts latest-version RPC shape so frontend rows receive `version_count` and no `latestVersion` field.
- Keep existing non-latest query/search functions intact where frontend still references them, while adding latest-version RPCs for migration-safe frontend adoption.
- Match can occur on any visible version during PGroonga and hybrid search, while the returned row is the latest visible version for that UUID.
- For hybrid search, keep the existing RPC names used by Edge Functions and change the returned row grain to unique UUID + latest visible version.

## Validation
- `./scripts/docpact-gate.sh`
- `git diff --check`
- `/Users/foreveryoung/tiangong/workspace/tiangong-lca-next/node_modules/.bin/supabase db reset` attempted locally, but Docker Desktop is unable to start on this machine: `failed to inspect service: Error response from daemon: Docker Desktop is unable to start`.
- Earlier validation retained from this PR:
  - `git diff --cached --check` before the Flowproperties commit.
  - `$HOME/.cargo/bin/docpact validate-config --root . --strict`
  - `$HOME/.cargo/bin/docpact lint --root . --staged --format json --output /tmp/database-engine-docpact-47-flowproperties.json` before the Flowproperties commit.
  - After merging `origin/dev` to resolve PR conflicts at `e629181`:
    - `$HOME/.cargo/bin/docpact validate-config --root . --strict`
    - `$HOME/.cargo/bin/docpact lint --root . --merge-base origin/dev`
    - `git diff --check origin/dev...HEAD`
- Not run locally: successful `supabase db reset` / SQL assertions because Docker Desktop is currently unable to start. Supabase Preview/remote checks remain the expected SQL proof path for this PR.

## Risks / Rollback
- Moderate: read-only RPCs/search functions and supporting indexes, including same-name hybrid search functions consumed by Edge Functions.
- Rollback path: frontend can stay on earlier non-latest functions for affected slices, and this migration can be reverted before database deployment if remote Supabase preview exposes SQL issues.

## Follow-ups
- Wire tiangong-lca-next remaining selection drawers to the same All Versions semantics under linancn/tiangong-lca-next#421 / PR linancn/tiangong-lca-next#422.
- After merge into database-engine `dev`, verify Supabase persistent `dev` deployment and then proceed with workspace integration according to lca-workspace policy.

## Workspace Integration
- After merge into database-engine dev, workspace integration remains pending according to lca-workspace policy.
