### PR TITLE
fix: tune latest flow open data query budget

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "5f11d88cd363a895bb5da2be488a662631a26dc5"
+lastReviewedCommit: "a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
+lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
+lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
+lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260521124500_tune_latest_flow_open_data_timeout.sql
+++ b/supabase/migrations/20260521124500_tune_latest_flow_open_data_timeout.sql
@@ -1,0 +1,13 @@
+CREATE INDEX IF NOT EXISTS "flows_public_latest_keys_cover_idx"
+ON "public"."flows" USING "btree" ("id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id")
+WHERE "state_code" = 100;
+
+ALTER FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text)
+  SET "statement_timeout" TO '60s';

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(25);
+select plan(29);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -353,6 +353,44 @@ select is(
   strpos(pg_get_functiondef('public.pgroonga_search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'user_id::text = this_user_id'),
   0,
   'lifecyclemodel latest search does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  to_regclass('public.flows_public_latest_keys_cover_idx') is not null,
+  'flow open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.get_latest_flow_versions(bigint,bigint,text,text,uuid,integer,jsonb,text,text)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'flow latest list has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.get_latest_process_versions(bigint,bigint,text,text,uuid,integer,text,text,text)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'process latest list has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.get_latest_lifecyclemodel_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'lifecyclemodel latest list has a function-level timeout budget'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes #46

## Summary
- Add a partial covering index for published Flow rows used by the latest-version open-data key scan.
- Set a 60s function-level `statement_timeout` budget for the core latest list RPCs, matching the existing hybrid-search RPC budget.
- Extend the core latest-version SQL assertions to check the Flow open-data index and RPC timeout settings.

## Context
`get_latest_flow_versions` can still hit PostgreSQL statement timeout for open data (`data_source = 'tg'`) after the latest-version dedupe rollout. PR #48 reduced the default Flow list path to a key-first scan, but the published Flow dataset is still large enough that the default PostgREST statement budget can be exceeded.

## Validation
- `git diff --check`
- `$HOME/.cargo/bin/docpact validate-config --root . --strict`
- `$HOME/.cargo/bin/docpact lint --root . --worktree`
- Attempted `/Users/foreveryoung/tiangong/workspace/tiangong-lca-next/node_modules/.bin/supabase db reset`, but local Docker daemon is not running: `Cannot connect to the Docker daemon at unix:///Users/foreveryoung/.docker/run/docker.sock`.

## Risk / Follow-up
- This keeps the RPC response shape unchanged.
- Supabase Preview should verify the migration and SQL assertions in a real database environment.
- If production-size Flow open-data calls still exceed 60s after this, the next step should be a cached latest-version relation/materialized maintenance path rather than continuing to expand request-time work.
