### PR TITLE
fix: tune latest PGroonga search budget

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4"
+lastReviewedCommit: "6a5b8d6974f9b0e56345a7b70953b722e1dccaf1"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
+lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
+lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
+lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260521131500_tune_core_latest_search_timeout.sql
+++ b/supabase/migrations/20260521131500_tune_core_latest_search_timeout.sql
@@ -1,0 +1,18 @@
+CREATE INDEX IF NOT EXISTS "processes_public_latest_keys_cover_idx"
+ON "public"."processes" USING "btree" ("id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id", "model_id")
+WHERE "state_code" = 100;
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_public_latest_keys_cover_idx"
+ON "public"."lifecyclemodels" USING "btree" ("id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id")
+WHERE "state_code" = 100;
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer)
+  SET "statement_timeout" TO '60s';

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(29);
+select plan(34);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -361,6 +361,16 @@ select ok(
 );
 
 select ok(
+  to_regclass('public.processes_public_latest_keys_cover_idx') is not null,
+  'process open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
+  to_regclass('public.lifecyclemodels_public_latest_keys_cover_idx') is not null,
+  'lifecyclemodel open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
   exists (
     select 1
     from pg_proc p
@@ -391,6 +401,39 @@ select ok(
       and cfg = 'statement_timeout=60s'
   ),
   'lifecyclemodel latest list has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'flow latest PGroonga search has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'process latest PGroonga search has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'lifecyclemodel latest PGroonga search has a function-level timeout budget'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes #46

## Summary
- Set a 60s function-level `statement_timeout` budget for the core latest PGroonga search RPCs.
- Add open-data partial covering indexes for Process and LifecycleModel latest-version key scans, matching the Flow index added in #49.
- Extend SQL assertions to lock the search timeout settings and open-data index coverage.

## Context
Open-data requests to `pgroonga_search_flows_latest` and `pgroonga_search_processes_latest` can still hit PostgreSQL statement timeout after the latest-version dedupe rollout. The ordinary latest list RPCs were given the same timeout budget in #49, but the PGroonga latest search RPCs still used the default PostgREST statement budget.

## Validation
- `git diff --check`
- `$HOME/.cargo/bin/docpact validate-config --root . --strict`
- `$HOME/.cargo/bin/docpact lint --root . --worktree`
- Attempted `/Users/foreveryoung/tiangong/workspace/tiangong-lca-next/node_modules/.bin/supabase db reset`, but local Docker daemon is not running: `Cannot connect to the Docker daemon at unix:///Users/foreveryoung/.docker/run/docker.sock`.

## Risk / Follow-up
- This keeps the RPC response shape unchanged.
- Supabase Preview should verify the migration and SQL assertions in a real database environment.
- If production-size open-data search still exceeds 60s, the next fix should change the search implementation to a cached/latest-key relation instead of extending request-time work further.
