### PR TITLE
promote: dev to main for latest-version data lists

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-20"
-lastReviewedCommit: "c39bd3b32212cc37280bbcd5ec979c400c33346e"
+lastReviewedAt: "2026-05-21"
+lastReviewedCommit: "6971941e7174d663e376aaef194b50c088619483"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-20"
-lastReviewedCommit: "b6011f4ae0ed130ca99981ddbc57559b4325bbe5"
+lastReviewedCommit: "9fe01549b988d87f9707dc914de9fd1d0b55b55a"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "6971941e7174d663e376aaef194b50c088619483"
+lastReviewedCommit: "5f11d88cd363a895bb5da2be488a662631a26dc5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "6a5b8d6974f9b0e56345a7b70953b722e1dccaf1"
+lastReviewedCommit: "fdbbeb50aaae531528905e115780781e815aae75"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "5f11d88cd363a895bb5da2be488a662631a26dc5"
+lastReviewedCommit: "a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-18"
-lastReviewedCommit: "9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32"
+lastReviewedAt: "2026-05-20"
+lastReviewedCommit: "b2d5990da6d7e490296647871cf47e15efd8c547"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4"
+lastReviewedCommit: "6a5b8d6974f9b0e56345a7b70953b722e1dccaf1"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -53,6 +53,7 @@ ownership:
       paths:
         include:
           - .githooks/**
+          - scripts/docpact
           - scripts/docpact-gate.sh
           - scripts/install-git-hooks.sh
       ownerRepo: database-engine
@@ -60,6 +61,7 @@ ownership:
 coverage:
   include:
     - .githooks/**
+    - scripts/docpact
     - scripts/docpact-gate.sh
     - scripts/install-git-hooks.sh
     - AGENTS.md
@@ -99,6 +101,7 @@ routing:
     local-docpact-gate:
       paths:
         - .githooks/pre-push
+        - scripts/docpact
         - scripts/docpact-gate.sh
         - scripts/install-git-hooks.sh
     migration-and-rpc:
@@ -316,6 +319,8 @@ rules:
     triggers:
       - path: .githooks/pre-push
         kind: local-git-hook
+      - path: scripts/docpact
+        kind: local-automation
       - path: scripts/docpact-gate.sh
         kind: local-automation
       - path: scripts/install-git-hooks.sh

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-20"
-lastReviewedCommit: "b2d5990da6d7e490296647871cf47e15efd8c547"
+lastReviewedCommit: "b6011f4ae0ed130ca99981ddbc57559b4325bbe5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "fdbbeb50aaae531528905e115780781e815aae75"
+lastReviewedCommit: "f7c400dbbdf4f834286520d405687199a0c451f1"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,14 +20,14 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.4 --force
+        run: cargo install docpact --version 0.1.9 --force
 
       - name: Validate docpact config
-        run: docpact validate-config --root . --strict
+        run: scripts/docpact validate-config --root . --strict
 
       - name: Run docpact lint
         run: >
-          docpact lint
+          scripts/docpact lint
           --root .
           --base "${{ github.event.pull_request.base.sha }}"
           --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: c39bd3b32212cc37280bbcd5ec979c400c33346e
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 6971941e7174d663e376aaef194b50c088619483
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
+lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
+lastReviewedCommit: fdbbeb50aaae531528905e115780781e815aae75
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: fdbbeb50aaae531528905e115780781e815aae75
+lastReviewedCommit: f7c400dbbdf4f834286520d405687199a0c451f1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
+lastReviewedCommit: 9fe01549b988d87f9707dc914de9fd1d0b55b55a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-18
-lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
+lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ checkPaths:
   - .github/workflows/**
   - .env.supabase*.example
   - .githooks/**
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
@@ -191,4 +192,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/dev` for routine branches and `origin/main` for promote or hotfix branches. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/dev` for routine branches and `origin/main` for promote or hotfix branches. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 6971941e7174d663e376aaef194b50c088619483
+lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
+lastReviewedCommit: fdbbeb50aaae531528905e115780781e815aae75
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: fdbbeb50aaae531528905e115780781e815aae75
+lastReviewedCommit: f7c400dbbdf4f834286520d405687199a0c451f1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-18
-lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,8 +26,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: c39bd3b32212cc37280bbcd5ec979c400c33346e
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 6971941e7174d663e376aaef194b50c088619483
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
+lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,6 +24,7 @@ checkPaths:
   - scripts/**
   - .github/workflows/supabase-dev.yml
   - .githooks/pre-push
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
@@ -121,4 +122,4 @@ If a task changes both schema and app behavior, the SQL truth still starts here.
 
 ## Local Docpact Push Gate
 
-This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 6971941e7174d663e376aaef194b50c088619483
+lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
+lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,7 +27,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
+lastReviewedCommit: 9fe01549b988d87f9707dc914de9fd1d0b55b55a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: fdbbeb50aaae531528905e115780781e815aae75
+lastReviewedCommit: f7c400dbbdf4f834286520d405687199a0c451f1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-18
-lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
+lastReviewedAt: 2026-05-20
+lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,6 +26,7 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .github/workflows/ai-doc-lint.yml
   - .githooks/pre-push
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
@@ -65,7 +66,7 @@ supabase migration list
 | `.github/workflows/supabase-dev.yml` | inspect YAML changes and confirm referenced secrets and vars still exist in docs | verify the intended deploy path in a PR note because the real push occurs only on Git `dev` | Local dry-run for GitHub-hosted execution is limited; document the expected remote proof. |
 | `scripts/**` | run the touched script with `--help` when possible, or execute the narrowest safe non-destructive path | if a script changes generated workspace behavior, refresh the workspace in a safe environment and inspect git diff | Avoid remote-destructive script runs unless the task explicitly requires them. |
 | `supabase/workspace/**` | prove whether the touched file is generated or stable | if stable manual overlay files changed, explain how they feed migration generation | Generated files alone are not sufficient evidence of a durable schema change. |
-| repo docs only | `docpact lint --root . --files "<csv>" --mode enforce` | `docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | Refresh review metadata even when prose stays unchanged. |
+| repo docs only | `scripts/docpact lint --root . --files "<csv>" --mode enforce` | `scripts/docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | Refresh review metadata even when prose stays unchanged. |
 
 ## SQL Assertion Notes
 
@@ -128,4 +129,4 @@ Install the versioned local hook once per checkout:
 ./scripts/install-git-hooks.sh
 ```
 
-The `pre-push` hook runs `scripts/docpact-gate.sh`, which performs strict config validation and `docpact lint --mode enforce` before the push leaves the machine. The default comparison base is `origin/dev` for routine branches and `origin/main` for promote or hotfix branches. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/dev` for routine branches and `origin/main` for promote or hotfix branches. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -28,8 +28,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-20
-lastReviewedCommit: c39bd3b32212cc37280bbcd5ec979c400c33346e
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 6971941e7174d663e376aaef194b50c088619483
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b2d5990da6d7e490296647871cf47e15efd8c547
+lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-20
-lastReviewedCommit: b6011f4ae0ed130ca99981ddbc57559b4325bbe5
+lastReviewedCommit: 9fe01549b988d87f9707dc914de9fd1d0b55b55a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
+lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
+lastReviewedCommit: a8b3b7fac73c1e8e2394387d41ba2e231f96a5b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 6a5b8d6974f9b0e56345a7b70953b722e1dccaf1
+lastReviewedCommit: fdbbeb50aaae531528905e115780781e815aae75
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-21
-lastReviewedCommit: 6971941e7174d663e376aaef194b50c088619483
+lastReviewedCommit: 5f11d88cd363a895bb5da2be488a662631a26dc5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,6 +17,7 @@ checkPaths:
   - supabase/workspace/**
   - docs/agents/repo-architecture.md
   - .githooks/pre-push
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-08
@@ -150,4 +151,4 @@ It is not intended to be the primary entry point for routine command-line use.
 
 ## Local Docpact Push Gate
 
-The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. It is documentation-governance tooling and does not change database schema workspace behavior.
+The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`. It is documentation-governance tooling and does not change database schema workspace behavior.

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -17,6 +17,7 @@ checkPaths:
   - supabase/workspace/**
   - docs/agents/repo-architecture.md
   - .githooks/pre-push
+  - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-08
@@ -150,4 +151,4 @@ python scripts/new_migration.py --name "update policy roles update" --source-pat
 
 ## Local Docpact Push Gate
 
-The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. It is documentation-governance tooling and does not change database schema workspace behavior.
+The repository now includes a local pre-push docpact gate in `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`. It is documentation-governance tooling and does not change database schema workspace behavior.

--- a/scripts/docpact
+++ b/scripts/docpact
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+docpact_version="${DOCPACT_VERSION:-0.1.9}"
+
+use_candidate() {
+  candidate="$1"
+  if [ -n "$candidate" ] && [ -x "$candidate" ] && "$candidate" --version >/dev/null 2>&1; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+  return 1
+}
+
+find_docpact() {
+  if [ -n "${DOCPACT_BIN:-}" ]; then
+    if use_candidate "$DOCPACT_BIN"; then
+      return 0
+    fi
+    echo "DOCPACT_BIN is set but is not an executable docpact binary: $DOCPACT_BIN" >&2
+    return 127
+  fi
+
+  if [ -n "${CARGO_HOME:-}" ] && use_candidate "$CARGO_HOME/bin/docpact"; then
+    return 0
+  fi
+
+  if [ -n "${HOME:-}" ] && use_candidate "$HOME/.cargo/bin/docpact"; then
+    return 0
+  fi
+
+  if use_candidate "/opt/homebrew/bin/docpact"; then
+    return 0
+  fi
+
+  if use_candidate "/usr/local/bin/docpact"; then
+    return 0
+  fi
+
+  if command -v docpact >/dev/null 2>&1; then
+    candidate="$(command -v docpact)"
+    case "$candidate" in
+      */scripts/docpact | scripts/docpact | ./scripts/docpact)
+        ;;
+      *)
+        if use_candidate "$candidate"; then
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  echo "docpact was not found." >&2
+  echo "Install it with: cargo install docpact --version $docpact_version --force" >&2
+  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
+  return 127
+}
+
+if [ "${1:-}" = "--print-bin" ]; then
+  find_docpact
+  exit 0
+fi
+
+docpact_bin="$(find_docpact)"
+exec "$docpact_bin" "$@"

--- a/scripts/docpact-gate.sh
+++ b/scripts/docpact-gate.sh
@@ -4,28 +4,7 @@ set -eu
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-find_docpact() {
-  if [ -n "${DOCPACT_BIN:-}" ] && "$DOCPACT_BIN" --version >/dev/null 2>&1; then
-    printf '%s\n' "$DOCPACT_BIN"
-    return 0
-  fi
-
-  if [ -x "$HOME/.cargo/bin/docpact" ] && "$HOME/.cargo/bin/docpact" --version >/dev/null 2>&1; then
-    printf '%s\n' "$HOME/.cargo/bin/docpact"
-    return 0
-  fi
-
-  if command -v docpact >/dev/null 2>&1; then
-    command -v docpact
-    return 0
-  fi
-
-  echo "docpact was not found. Install it with: cargo install docpact --version 0.1.4 --force" >&2
-  echo "Or set DOCPACT_BIN to an executable docpact binary." >&2
-  return 127
-}
-
-docpact_bin="$(find_docpact)"
+docpact_cmd="$repo_root/scripts/docpact"
 current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
 head_ref="${DOCPACT_HEAD_REF:-HEAD}"
 base_ref="${DOCPACT_BASE_REF:-origin/dev}"
@@ -65,7 +44,7 @@ report_path="${TMPDIR:-/tmp}/docpact-gate-$$.json"
 trap 'rm -f "$report_path"' EXIT HUP INT TERM
 
 echo "Running docpact config validation."
-"$docpact_bin" validate-config --root . --strict
+"$docpact_cmd" validate-config --root "$repo_root" --strict
 
 echo "Running docpact lint: base=$base_sha head=$head_sha."
-"$docpact_bin" lint --root . --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"
+"$docpact_cmd" lint --root "$repo_root" --base "$base_sha" --head "$head_sha" --mode enforce --output "$report_path"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -5,6 +5,6 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
 git config core.hooksPath .githooks
-chmod +x .githooks/pre-push scripts/docpact-gate.sh
+chmod +x .githooks/pre-push scripts/docpact scripts/docpact-gate.sh
 
 echo "Configured git hooks: core.hooksPath=.githooks"

--- a/supabase/migrations/20260520090000_sources_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520090000_sources_latest_version_query_rpcs.sql
@@ -1,0 +1,295 @@
+CREATE INDEX IF NOT EXISTS "sources_state_code_id_version_modified_at_idx"
+ON "public"."sources" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "sources_user_id_state_code_id_version_modified_at_idx"
+ON "public"."sources" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "sources_team_id_state_code_id_version_modified_at_idx"
+ON "public"."sources" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.sources f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.sources f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";

--- a/supabase/migrations/20260520143000_contacts_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520143000_contacts_latest_version_query_rpcs.sql
@@ -1,0 +1,295 @@
+CREATE INDEX IF NOT EXISTS "contacts_state_code_id_version_modified_at_idx"
+ON "public"."contacts" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "contacts_user_id_state_code_id_version_modified_at_idx"
+ON "public"."contacts" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "contacts_team_id_state_code_id_version_modified_at_idx"
+ON "public"."contacts" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.contacts f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.contacts f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";

--- a/supabase/migrations/20260520170000_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520170000_unitgroups_latest_version_query_rpcs.sql
@@ -1,0 +1,295 @@
+CREATE INDEX IF NOT EXISTS "unitgroups_state_code_id_version_modified_at_idx"
+ON "public"."unitgroups" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "unitgroups_user_id_state_code_id_version_modified_at_idx"
+ON "public"."unitgroups" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "unitgroups_team_id_state_code_id_version_modified_at_idx"
+ON "public"."unitgroups" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.unitgroups f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.unitgroups f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";

--- a/supabase/migrations/20260520174500_flowproperties_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520174500_flowproperties_latest_version_query_rpcs.sql
@@ -1,0 +1,295 @@
+CREATE INDEX IF NOT EXISTS "flowproperties_state_code_id_version_modified_at_idx"
+ON "public"."flowproperties" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "flowproperties_user_id_state_code_id_version_modified_at_idx"
+ON "public"."flowproperties" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "flowproperties_team_id_state_code_id_version_modified_at_idx"
+ON "public"."flowproperties" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.flowproperties f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flowproperties f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";

--- a/supabase/migrations/20260520203000_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/migrations/20260520203000_core_datasets_latest_version_query_rpcs.sql
@@ -1,0 +1,1274 @@
+CREATE INDEX IF NOT EXISTS "flows_state_code_id_version_modified_at_idx"
+ON "public"."flows" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "flows_user_id_state_code_id_version_modified_at_idx"
+ON "public"."flows" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "flows_team_id_state_code_id_version_modified_at_idx"
+ON "public"."flows" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "processes_state_code_id_version_modified_at_idx"
+ON "public"."processes" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "processes_user_id_state_code_id_version_modified_at_idx"
+ON "public"."processes" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "processes_team_id_state_code_id_version_modified_at_idx"
+ON "public"."processes" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_state_code_id_version_modified_at_idx"
+ON "public"."lifecyclemodels" USING "btree" ("state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_user_id_state_code_id_version_modified_at_idx"
+ON "public"."lifecyclemodels" USING "btree" ("user_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_team_id_state_code_id_version_modified_at_idx"
+ON "public"."lifecyclemodels" USING "btree" ("team_id", "state_code", "id", "version" DESC, "modified_at" DESC);
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_flow_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.flows f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT DISTINCT visible_rows.id
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_process_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT p.*
+      FROM public.processes p
+      WHERE
+        (
+          (data_source = 'tg' AND p.state_code = 100)
+          OR (data_source = 'co' AND p.state_code = 200)
+          OR (data_source = 'my' AND p.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND p.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR p.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR p.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT DISTINCT visible_rows.id
+      FROM visible_rows
+      WHERE
+        coalesce(type_of_data_set_filter, 'all') = 'all'
+        OR visible_rows.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        visible_rows.model_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.model_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_lifecyclemodel_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE
+        (
+          (data_source = 'tg' AND l.state_code = 100)
+          OR (data_source = 'co' AND l.state_code = 200)
+          OR (data_source = 'my' AND l.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND l.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR l.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR l.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flows_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_processes_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE
+        (
+          (data_source = 'tg' AND p.state_code = 100)
+          OR (data_source = 'co' AND p.state_code = 200)
+          OR (data_source = 'my' AND p.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND p.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR p.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR p.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          coalesce(type_of_data_set_filter, 'all') = 'all'
+          OR visible_rows.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+        )
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        visible_rows.model_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.model_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE
+        (
+          (data_source = 'tg' AND l.state_code = 100)
+          OR (data_source = 'co' AND l.state_code = 200)
+          OR (data_source = 'my' AND l.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND l.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR l.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR l.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_flows"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_flows_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_flows_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_flows_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT f.*
+      FROM public.flows f
+      JOIN fused ON fused.id = f.id
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = f.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_processes"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "model_id" uuid,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_processes_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_processes_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_processes_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT p.*
+      FROM public.processes p
+      JOIN fused ON fused.id = p.id
+      WHERE
+        (
+          (data_source = 'tg' AND p.state_code = 100)
+          OR (data_source = 'co' AND p.state_code = 200)
+          OR (data_source = 'my' AND p.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = p.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.model_id,
+        visible_rows.team_id,
+        version_counts.version_count,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.model_id,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_lifecyclemodels"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_lifecyclemodels_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_lifecyclemodels_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_lifecyclemodels_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      JOIN fused ON fused.id = l.id
+      WHERE
+        (
+          (data_source = 'tg' AND l.state_code = 100)
+          OR (data_source = 'co' AND l.state_code = 200)
+          OR (data_source = 'my' AND l.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = l.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";

--- a/supabase/migrations/20260521113000_fix_core_latest_my_user_filters.sql
+++ b/supabase/migrations/20260521113000_fix_core_latest_my_user_filters.sql
@@ -65,6 +65,119 @@ BEGIN
   END IF;
   filter_condition_jsonb := filter_condition_jsonb - 'classification';
 
+  IF filter_condition_jsonb = '{}'::jsonb
+    AND flow_type IS NULL
+    AND as_input IS NULL
+    AND jsonb_array_length(classification_filter) = 0
+  THEN
+    RETURN QUERY
+      WITH visible_keys AS (
+        SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+        FROM public.flows f
+        WHERE data_source = 'tg'
+          AND f.state_code = 100
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+        UNION ALL
+        SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+        FROM public.flows f
+        WHERE data_source = 'co'
+          AND f.state_code = 200
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+        UNION ALL
+        SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+        FROM public.flows f
+        WHERE data_source = 'my'
+          AND normalized_this_user_id IS NOT NULL
+          AND f.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+        UNION ALL
+        SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+        FROM public.flows f
+        WHERE data_source = 'te'
+          AND team_id_filter IS NOT NULL
+          AND f.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      ),
+      latest_keys AS (
+        SELECT DISTINCT ON (visible_keys.id)
+          visible_keys.id,
+          visible_keys.version,
+          visible_keys.created_at,
+          visible_keys.modified_at,
+          visible_keys.team_id
+        FROM visible_keys
+        ORDER BY visible_keys.id, visible_keys.version DESC, visible_keys.modified_at DESC
+      ),
+      counted_keys AS (
+        SELECT latest_keys.*, count(*) OVER()::bigint AS total_count
+        FROM latest_keys
+      ),
+      paged_keys AS (
+        SELECT counted_keys.*
+        FROM counted_keys
+        ORDER BY
+          CASE
+            WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_keys.version
+          END ASC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_keys.version
+          END DESC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_keys.created_at
+          END ASC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.created_at
+          END DESC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_keys.modified_at
+          END ASC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.modified_at
+          END DESC NULLS LAST,
+          counted_keys.id
+        LIMIT normalized_page_size
+        OFFSET (normalized_page_current - 1) * normalized_page_size
+      )
+      SELECT
+        payload.id,
+        payload.json,
+        payload.version,
+        payload.modified_at,
+        payload.team_id,
+        page_version_counts.version_count,
+        paged_keys.total_count
+      FROM paged_keys
+      JOIN public.flows payload
+        ON payload.id = paged_keys.id
+       AND payload.version = paged_keys.version
+      JOIN LATERAL (
+        SELECT count(*)::bigint AS version_count
+        FROM visible_keys
+        WHERE visible_keys.id = paged_keys.id
+      ) page_version_counts ON true
+      ORDER BY
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN paged_keys.version
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN paged_keys.version
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN paged_keys.created_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.created_at
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN paged_keys.modified_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.modified_at
+        END DESC NULLS LAST,
+        paged_keys.id;
+    RETURN;
+  END IF;
+
   RETURN QUERY
     WITH visible_rows AS (
       SELECT f.*

--- a/supabase/migrations/20260521113000_fix_core_latest_my_user_filters.sql
+++ b/supabase/migrations/20260521113000_fix_core_latest_my_user_filters.sql
@@ -1,0 +1,930 @@
+CREATE OR REPLACE FUNCTION "public"."get_latest_flow_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.flows f
+      WHERE data_source = 'tg'
+        AND f.state_code = 100
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*
+      FROM public.flows f
+      WHERE data_source = 'co'
+        AND f.state_code = 200
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*
+      FROM public.flows f
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND f.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      UNION ALL
+      SELECT f.*
+      FROM public.flows f
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND f.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT DISTINCT visible_rows.id
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_process_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT p.*
+      FROM public.processes p
+      WHERE data_source = 'tg'
+        AND p.state_code = 100
+        AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+      UNION ALL
+      SELECT p.*
+      FROM public.processes p
+      WHERE data_source = 'co'
+        AND p.state_code = 200
+        AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+      UNION ALL
+      SELECT p.*
+      FROM public.processes p
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND p.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+      UNION ALL
+      SELECT p.*
+      FROM public.processes p
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND p.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT DISTINCT visible_rows.id
+      FROM visible_rows
+      WHERE
+        coalesce(type_of_data_set_filter, 'all') = 'all'
+        OR visible_rows.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        visible_rows.model_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.model_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_lifecyclemodel_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'tg'
+        AND l.state_code = 100
+        AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+      UNION ALL
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'co'
+        AND l.state_code = 200
+        AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+      UNION ALL
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND l.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+      UNION ALL
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND l.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count
+      FROM visible_rows
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.version_count,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flows_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'tg'
+        AND f.state_code = 100
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'co'
+        AND f.state_code = 200
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND f.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      UNION ALL
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND f.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_processes_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE data_source = 'tg'
+        AND p.state_code = 100
+        AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+      UNION ALL
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE data_source = 'co'
+        AND p.state_code = 200
+        AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+      UNION ALL
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND p.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+      UNION ALL
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND p.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          coalesce(type_of_data_set_filter, 'all') = 'all'
+          OR visible_rows.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+        )
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        visible_rows.model_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.model_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "version_count" bigint,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'tg'
+        AND l.state_code = 100
+        AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+      UNION ALL
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'co'
+        AND l.state_code = 200
+        AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+      UNION ALL
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND l.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+      UNION ALL
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND l.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    version_counts AS (
+      SELECT visible_rows.id, count(*)::bigint AS version_count
+      FROM visible_rows
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        version_counts.version_count,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      JOIN version_counts ON version_counts.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.version_count,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";

--- a/supabase/migrations/20260521124500_tune_latest_flow_open_data_timeout.sql
+++ b/supabase/migrations/20260521124500_tune_latest_flow_open_data_timeout.sql
@@ -1,0 +1,13 @@
+CREATE INDEX IF NOT EXISTS "flows_public_latest_keys_cover_idx"
+ON "public"."flows" USING "btree" ("id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id")
+WHERE "state_code" = 100;
+
+ALTER FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text)
+  SET "statement_timeout" TO '60s';

--- a/supabase/migrations/20260521131500_tune_core_latest_search_timeout.sql
+++ b/supabase/migrations/20260521131500_tune_core_latest_search_timeout.sql
@@ -1,0 +1,18 @@
+CREATE INDEX IF NOT EXISTS "processes_public_latest_keys_cover_idx"
+ON "public"."processes" USING "btree" ("id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id", "model_id")
+WHERE "state_code" = 100;
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_public_latest_keys_cover_idx"
+ON "public"."lifecyclemodels" USING "btree" ("id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id")
+WHERE "state_code" = 100;
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer)
+  SET "statement_timeout" TO '60s';

--- a/supabase/migrations/20260521143000_remove_latest_version_count.sql
+++ b/supabase/migrations/20260521143000_remove_latest_version_count.sql
@@ -1,0 +1,2510 @@
+-- Remove realtime version totals from latest-version list/search RPC contracts.
+-- The frontend now opens all versions by UUID directly, so list/search calls do not need this aggregate.
+
+DROP FUNCTION IF EXISTS "public"."get_latest_source_versions"(bigint, bigint, text, text, uuid, integer, text, text);
+CREATE OR REPLACE FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.sources f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id
+      FROM visible_rows
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."pgroonga_search_sources_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer);
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.sources f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."get_latest_contact_versions"(bigint, bigint, text, text, uuid, integer, text, text);
+CREATE OR REPLACE FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.contacts f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id
+      FROM visible_rows
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."pgroonga_search_contacts_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer);
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.contacts f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."get_latest_unitgroup_versions"(bigint, bigint, text, text, uuid, integer, text, text);
+CREATE OR REPLACE FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.unitgroups f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id
+      FROM visible_rows
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."pgroonga_search_unitgroups_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer);
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.unitgroups f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."get_latest_flowproperty_versions"(bigint, bigint, text, text, uuid, integer, text, text);
+CREATE OR REPLACE FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.flowproperties f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id
+      FROM visible_rows
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."pgroonga_search_flowproperties_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer);
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flowproperties f
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id::text = this_user_id)
+          OR (data_source = 'te' AND team_id_filter IS NOT NULL AND f.team_id = team_id_filter)
+        )
+        AND (team_id_filter IS NULL OR data_source NOT IN ('tg', 'co') OR f.team_id = team_id_filter)
+        AND (state_code_filter IS NULL OR data_source NOT IN ('my', 'te') OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> coalesce(filter_condition, '{}'::jsonb)
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb,
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer
+) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text);
+CREATE OR REPLACE FUNCTION "public"."get_latest_flow_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  IF filter_condition_jsonb = '{}'::jsonb
+    AND flow_type IS NULL
+    AND as_input IS NULL
+    AND jsonb_array_length(classification_filter) = 0
+  THEN
+    RETURN QUERY
+      WITH visible_keys AS (
+        SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+        FROM public.flows f
+        WHERE data_source = 'tg'
+          AND f.state_code = 100
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+        UNION ALL
+        SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+        FROM public.flows f
+        WHERE data_source = 'co'
+          AND f.state_code = 200
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+        UNION ALL
+        SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+        FROM public.flows f
+        WHERE data_source = 'my'
+          AND normalized_this_user_id IS NOT NULL
+          AND f.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+        UNION ALL
+        SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+        FROM public.flows f
+        WHERE data_source = 'te'
+          AND team_id_filter IS NOT NULL
+          AND f.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      ),
+      latest_keys AS (
+        SELECT DISTINCT ON (visible_keys.id)
+          visible_keys.id,
+          visible_keys.version,
+          visible_keys.created_at,
+          visible_keys.modified_at,
+          visible_keys.team_id
+        FROM visible_keys
+        ORDER BY visible_keys.id, visible_keys.version DESC, visible_keys.modified_at DESC
+      ),
+      counted_keys AS (
+        SELECT latest_keys.*, count(*) OVER()::bigint AS total_count
+        FROM latest_keys
+      ),
+      paged_keys AS (
+        SELECT counted_keys.*
+        FROM counted_keys
+        ORDER BY
+          CASE
+            WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_keys.version
+          END ASC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_keys.version
+          END DESC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_keys.created_at
+          END ASC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.created_at
+          END DESC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_keys.modified_at
+          END ASC NULLS LAST,
+          CASE
+            WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.modified_at
+          END DESC NULLS LAST,
+          counted_keys.id
+        LIMIT normalized_page_size
+        OFFSET (normalized_page_current - 1) * normalized_page_size
+      )
+      SELECT
+        payload.id,
+        payload.json,
+        payload.version,
+        payload.modified_at,
+        payload.team_id,
+        paged_keys.total_count
+      FROM paged_keys
+      JOIN public.flows payload
+        ON payload.id = paged_keys.id
+       AND payload.version = paged_keys.version
+      ORDER BY
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN paged_keys.version
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN paged_keys.version
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN paged_keys.created_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.created_at
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN paged_keys.modified_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.modified_at
+        END DESC NULLS LAST,
+        paged_keys.id;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*
+      FROM public.flows f
+      WHERE data_source = 'tg'
+        AND f.state_code = 100
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*
+      FROM public.flows f
+      WHERE data_source = 'co'
+        AND f.state_code = 200
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*
+      FROM public.flows f
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND f.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      UNION ALL
+      SELECT f.*
+      FROM public.flows f
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND f.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT DISTINCT visible_rows.id
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text);
+CREATE OR REPLACE FUNCTION "public"."get_latest_process_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT p.*
+      FROM public.processes p
+      WHERE data_source = 'tg'
+        AND p.state_code = 100
+        AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+      UNION ALL
+      SELECT p.*
+      FROM public.processes p
+      WHERE data_source = 'co'
+        AND p.state_code = 200
+        AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+      UNION ALL
+      SELECT p.*
+      FROM public.processes p
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND p.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+      UNION ALL
+      SELECT p.*
+      FROM public.processes p
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND p.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT DISTINCT visible_rows.id
+      FROM visible_rows
+      WHERE
+        coalesce(type_of_data_set_filter, 'all') = 'all'
+        OR visible_rows.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        visible_rows.model_id
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.model_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text);
+CREATE OR REPLACE FUNCTION "public"."get_latest_lifecyclemodel_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'tg'
+        AND l.state_code = 100
+        AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+      UNION ALL
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'co'
+        AND l.state_code = 200
+        AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+      UNION ALL
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND l.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+      UNION ALL
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND l.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.created_at,
+        visible_rows.modified_at,
+        visible_rows.team_id
+      FROM visible_rows
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_rows.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_rows.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_rows.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_rows.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_rows.modified_at
+      END DESC NULLS LAST,
+      counted_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer);
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flows_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'tg'
+        AND f.state_code = 100
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'co'
+        AND f.state_code = 200
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND f.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      UNION ALL
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND f.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text);
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_processes_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE data_source = 'tg'
+        AND p.state_code = 100
+        AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+      UNION ALL
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE data_source = 'co'
+        AND p.state_code = 200
+        AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+      UNION ALL
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND p.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+      UNION ALL
+      SELECT p.*, p.tableoid AS source_tableoid, p.ctid AS source_ctid
+      FROM public.processes p
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND p.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          coalesce(type_of_data_set_filter, 'all') = 'all'
+          OR visible_rows.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+        )
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        visible_rows.model_id,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.model_id,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer);
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'tg'
+        AND l.state_code = 100
+        AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+      UNION ALL
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'co'
+        AND l.state_code = 200
+        AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+      UNION ALL
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND l.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+      UNION ALL
+      SELECT l.*, l.tableoid AS source_tableoid, l.ctid AS source_ctid
+      FROM public.lifecyclemodels l
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND l.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_flows"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_flows_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_flows_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_flows_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT f.*
+      FROM public.flows f
+      JOIN fused ON fused.id = f.id
+      WHERE
+        (
+          (data_source = 'tg' AND f.state_code = 100)
+          OR (data_source = 'co' AND f.state_code = 200)
+          OR (data_source = 'my' AND f.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = f.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_processes"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "model_id" uuid,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_processes_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_processes_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_processes_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT p.*
+      FROM public.processes p
+      JOIN fused ON fused.id = p.id
+      WHERE
+        (
+          (data_source = 'tg' AND p.state_code = 100)
+          OR (data_source = 'co' AND p.state_code = 200)
+          OR (data_source = 'my' AND p.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = p.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.model_id,
+        visible_rows.team_id,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.model_id,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";
+
+DROP FUNCTION IF EXISTS "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+CREATE OR REPLACE FUNCTION "public"."hybrid_search_lifecyclemodels"(
+  "query_text" text,
+  "query_embedding" text,
+  "filter_condition" text DEFAULT ''::text,
+  "match_threshold" double precision DEFAULT 0.5,
+  "match_count" integer DEFAULT 20,
+  "full_text_weight" double precision DEFAULT 0.3,
+  "extracted_text_weight" double precision DEFAULT 0.2,
+  "semantic_weight" double precision DEFAULT 0.5,
+  "rrf_k" integer DEFAULT 10,
+  "data_source" text DEFAULT 'tg'::text,
+  "page_size" integer DEFAULT 10,
+  "page_current" integer DEFAULT 1
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "statement_timeout" TO '60s'
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  candidate_limit integer;
+BEGIN
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+
+  RETURN QUERY
+    WITH full_text AS (
+      SELECT ps.rank AS ps_rank, ps.id AS ps_id
+      FROM public.pgroonga_search_lifecyclemodels_v1(
+        query_text,
+        filter_condition,
+        '',
+        candidate_limit,
+        1,
+        data_source
+      ) ps
+    ),
+    ex_text AS (
+      SELECT ex.rank AS ex_rank, ex.id AS ex_id
+      FROM public.pgroonga_search_lifecyclemodels_text_v1(
+        query_text,
+        candidate_limit,
+        1,
+        data_source
+      ) ex
+    ),
+    semantic AS (
+      SELECT ss.rank AS ss_rank, ss.id AS ss_id
+      FROM public.semantic_search_lifecyclemodels_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw AS (
+      SELECT
+        coalesce(full_text.ps_id, semantic.ss_id, ex_text.ex_id) AS id,
+        coalesce(1.0 / (rrf_k + full_text.ps_rank), 0.0) * full_text_weight
+          + coalesce(1.0 / (rrf_k + ex_text.ex_rank), 0.0) * extracted_text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight AS score
+      FROM full_text
+      FULL OUTER JOIN semantic ON full_text.ps_id = semantic.ss_id
+      FULL OUTER JOIN ex_text ON ex_text.ex_id = coalesce(full_text.ps_id, semantic.ss_id)
+    ),
+    fused AS (
+      SELECT fused_raw.id, sum(fused_raw.score) AS score
+      FROM fused_raw
+      WHERE fused_raw.id IS NOT NULL
+      GROUP BY fused_raw.id
+    ),
+    visible_rows AS (
+      SELECT l.*
+      FROM public.lifecyclemodels l
+      JOIN fused ON fused.id = l.id
+      WHERE
+        (
+          (data_source = 'tg' AND l.state_code = 100)
+          OR (data_source = 'co' AND l.state_code = 200)
+          OR (data_source = 'my' AND l.user_id = auth.uid())
+          OR (
+            data_source = 'te'
+            AND EXISTS (
+              SELECT 1
+              FROM public.roles r
+              WHERE r.user_id = auth.uid()
+                AND r.team_id = l.team_id
+                AND r.role::text IN ('admin', 'member', 'owner')
+            )
+          )
+        )
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        fused.score
+      FROM visible_rows
+      JOIN fused ON fused.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    )
+    SELECT
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    FROM counted_rows
+    ORDER BY counted_rows.score DESC, counted_rows.modified_at DESC, counted_rows.id
+    LIMIT greatest(coalesce(page_size, 10), 1)
+    OFFSET (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+END;
+$$;
+
+ALTER FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) TO "service_role";
+
+ALTER FUNCTION "public"."get_latest_flow_versions"(bigint, bigint, text, text, uuid, integer, jsonb, text, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."get_latest_process_versions"(bigint, bigint, text, text, uuid, integer, text, text, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."get_latest_lifecyclemodel_versions"(bigint, bigint, text, text, uuid, integer, text, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."hybrid_search_flows"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."hybrid_search_processes"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer)
+  SET "statement_timeout" TO '60s';
+
+ALTER FUNCTION "public"."hybrid_search_lifecyclemodels"(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer)
+  SET "statement_timeout" TO '60s';

--- a/supabase/migrations/20260521153500_tune_flow_latest_pgroonga_open_data.sql
+++ b/supabase/migrations/20260521153500_tune_flow_latest_pgroonga_open_data.sql
@@ -1,0 +1,295 @@
+CREATE INDEX IF NOT EXISTS "flows_public_json_pgroonga_idx"
+ON "public"."flows" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 100;
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flows_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  IF data_source = 'tg' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT
+          f.id,
+          max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flows f
+        WHERE f.state_code = 100
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+          AND (
+            flow_type IS NULL
+            OR (f.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+          )
+          AND (
+            as_input IS NULL
+            OR as_input = false
+            OR NOT (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+          AND (
+            jsonb_array_length(classification_filter) = 0
+            OR EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+              WHERE
+                (
+                  selected_class.item->>'scope' = 'elementary'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS category(item)
+                    WHERE category.item->>'@catId' = selected_class.item->>'code'
+                  )
+                )
+                OR (
+                  selected_class.item->>'scope' = 'classification'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS class_item(item)
+                    WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                  )
+                )
+            )
+          )
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT
+          matched_ids.id,
+          latest_row.json,
+          latest_row.version,
+          latest_row.modified_at,
+          latest_row.team_id,
+          matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT
+            f2.json,
+            f2.version,
+            f2.modified_at,
+            f2.team_id
+          FROM public.flows f2
+          WHERE f2.state_code = 100
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT
+          rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+          counted_rows.*
+        FROM counted_rows
+      )
+      SELECT
+        ranked_rows.rank,
+        ranked_rows.id,
+        ranked_rows.json,
+        ranked_rows.version,
+        ranked_rows.modified_at,
+        ranked_rows.team_id,
+        ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+    WITH visible_rows AS (
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'co'
+        AND f.state_code = 200
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND f.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      UNION ALL
+      SELECT f.*, f.tableoid AS source_tableoid, f.ctid AS source_ctid
+      FROM public.flows f
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND f.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+    ),
+    matched_ids AS (
+      SELECT
+        visible_rows.id,
+        max(pgroonga_score(visible_rows.source_tableoid, visible_rows.source_ctid)) AS search_score
+      FROM visible_rows
+      WHERE visible_rows.json @> filter_condition_jsonb
+        AND visible_rows.json &@~ query_text
+        AND (
+          flow_type IS NULL
+          OR (visible_rows.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+        )
+        AND (
+          as_input IS NULL
+          OR as_input = false
+          OR NOT (
+            visible_rows.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        AND (
+          jsonb_array_length(classification_filter) = 0
+          OR EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+            WHERE
+              (
+                selected_class.item->>'scope' = 'elementary'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS category(item)
+                  WHERE category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              OR (
+                selected_class.item->>'scope' = 'classification'
+                AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements(
+                    CASE jsonb_typeof(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      WHEN 'array' THEN visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      WHEN 'object' THEN jsonb_build_array(visible_rows.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      ELSE '[]'::jsonb
+                    END
+                  ) AS class_item(item)
+                  WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+      GROUP BY visible_rows.id
+    ),
+    latest_rows AS (
+      SELECT DISTINCT ON (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        matched_ids.search_score
+      FROM visible_rows
+      JOIN matched_ids ON matched_ids.id = visible_rows.id
+      ORDER BY visible_rows.id, visible_rows.version DESC, visible_rows.modified_at DESC
+    ),
+    counted_rows AS (
+      SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+      FROM latest_rows
+    ),
+    ranked_rows AS (
+      SELECT
+        rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+        counted_rows.*
+      FROM counted_rows
+    )
+    SELECT
+      ranked_rows.rank,
+      ranked_rows.id,
+      ranked_rows.json,
+      ranked_rows.version,
+      ranked_rows.modified_at,
+      ranked_rows.team_id,
+      ranked_rows.total_count
+    FROM ranked_rows
+    ORDER BY ranked_rows.rank, ranked_rows.id
+    LIMIT normalized_page_size
+    OFFSET (normalized_page_current - 1) * normalized_page_size;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";

--- a/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
@@ -1,0 +1,247 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '17000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'latest-contact-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"17000000-0000-0000-0000-000000000001","email":"latest-contact-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('27000000-0000-0000-0000-000000000001', '{"name":"Latest Contact Team A"}'::jsonb, 1, false),
+  ('27000000-0000-0000-0000-000000000002', '{"name":"Latest Contact Team B"}'::jsonb, 2, false);
+
+insert into public.contacts (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '37000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Legacy matched contact"}],"common:name":[{"@xml:lang":"en","#text":"Legacy matched contact"}],"email":"legacy@example.com"}}},"search":"legacy unique"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Legacy matched contact"}],"common:name":[{"@xml:lang":"en","#text":"Legacy matched contact"}],"email":"legacy@example.com"}}},"search":"legacy unique"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    100,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Latest contact"}],"common:name":[{"@xml:lang":"en","#text":"Latest contact"}],"email":"latest@example.com"}}},"search":"current text"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Latest contact"}],"common:name":[{"@xml:lang":"en","#text":"Latest contact"}],"email":"latest@example.com"}}},"search":"current text"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    100,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Single open contact"}],"common:name":[{"@xml:lang":"en","#text":"Single open contact"}],"email":"single@example.com"}}},"search":"single"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Single open contact"}],"common:name":[{"@xml:lang":"en","#text":"Single open contact"}],"email":"single@example.com"}}},"search":"single"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    100,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000003',
+    '01.00.001',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Other team contact"}],"common:name":[{"@xml:lang":"en","#text":"Other team contact"}],"email":"other-team@example.com"}}},"search":"other team"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Other team contact"}],"common:name":[{"@xml:lang":"en","#text":"Other team contact"}],"email":"other-team@example.com"}}},"search":"other team"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    100,
+    '27000000-0000-0000-0000-000000000002',
+    true,
+    now() - interval '3 days',
+    now() - interval '3 days'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner draft contact"}],"common:name":[{"@xml:lang":"en","#text":"Owner draft contact"}],"email":"draft@example.com"}}},"search":"draft"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner draft contact"}],"common:name":[{"@xml:lang":"en","#text":"Owner draft contact"}],"email":"draft@example.com"}}},"search":"draft"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    0,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '4 days',
+    now() - interval '4 days'
+  ),
+  (
+    '37000000-0000-0000-0000-000000000004',
+    '01.00.001',
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner review contact"}],"common:name":[{"@xml:lang":"en","#text":"Owner review contact"}],"email":"review@example.com"}}},"search":"review"}'::jsonb,
+    '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner review contact"}],"common:name":[{"@xml:lang":"en","#text":"Owner review contact"}],"email":"review@example.com"}}},"search":"review"}'::json,
+    '17000000-0000-0000-0000-000000000001',
+    20,
+    '27000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '1 hour',
+    now() - interval '1 hour'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '17000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select version::text
+    from public.get_latest_contact_versions(10, 1, 'tg', '17000000-0000-0000-0000-000000000001')
+    where id = '37000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'open contact list returns the highest visible version for a UUID'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_contact_versions(10, 1, 'tg', '17000000-0000-0000-0000-000000000001')
+    where id = '37000000-0000-0000-0000-000000000001'
+  ),
+  2::bigint,
+  'open contact list reports version_count for the visible UUID group'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.get_latest_contact_versions(10, 1, 'tg', '17000000-0000-0000-0000-000000000001')
+  ),
+  3::bigint,
+  'open contact list total_count counts unique UUIDs, not version rows'
+);
+
+select is(
+  (
+    select count(*)
+    from public.get_latest_contact_versions(
+      10,
+      1,
+      'tg',
+      '17000000-0000-0000-0000-000000000001',
+      '27000000-0000-0000-0000-000000000001'
+    )
+  ),
+  2::bigint,
+  'team filter limits open contact latest-version rows before pagination'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_contact_versions(
+      10,
+      1,
+      'my',
+      '17000000-0000-0000-0000-000000000001'
+    )
+    where id = '37000000-0000-0000-0000-000000000004'
+  ),
+  2::bigint,
+  'my data without a state filter counts all owner-visible versions'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_contact_versions(
+      10,
+      1,
+      'my',
+      '17000000-0000-0000-0000-000000000001',
+      null,
+      20
+    )
+    where id = '37000000-0000-0000-0000-000000000004'
+  ),
+  1::bigint,
+  'my data state filter is applied before version_count is calculated'
+);
+
+select is(
+  (
+    select version::text
+    from public.pgroonga_search_contacts_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '17000000-0000-0000-0000-000000000001'
+    )
+    where id = '37000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'search can match an older version while returning the highest visible version for that UUID'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.pgroonga_search_contacts_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '17000000-0000-0000-0000-000000000001'
+    )
+  ),
+  1::bigint,
+  'search total_count counts matching UUIDs after grouping'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(8);
+select plan(5);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -143,15 +143,6 @@ select is(
   'open contact list returns the highest visible version for a UUID'
 );
 
-select is(
-  (
-    select version_count
-    from public.get_latest_contact_versions(10, 1, 'tg', '17000000-0000-0000-0000-000000000001')
-    where id = '37000000-0000-0000-0000-000000000001'
-  ),
-  2::bigint,
-  'open contact list reports version_count for the visible UUID group'
-);
 
 select is(
   (
@@ -177,37 +168,7 @@ select is(
   'team filter limits open contact latest-version rows before pagination'
 );
 
-select is(
-  (
-    select version_count
-    from public.get_latest_contact_versions(
-      10,
-      1,
-      'my',
-      '17000000-0000-0000-0000-000000000001'
-    )
-    where id = '37000000-0000-0000-0000-000000000004'
-  ),
-  2::bigint,
-  'my data without a state filter counts all owner-visible versions'
-);
 
-select is(
-  (
-    select version_count
-    from public.get_latest_contact_versions(
-      10,
-      1,
-      'my',
-      '17000000-0000-0000-0000-000000000001',
-      null,
-      20
-    )
-    where id = '37000000-0000-0000-0000-000000000004'
-  ),
-  1::bigint,
-  'my data state filter is applied before version_count is calculated'
-);
 
 select is(
   (

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -1,0 +1,300 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(15);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '16000000-0000-0000-0000-000000000047',
+    'authenticated',
+    'authenticated',
+    'latest-core-datasets-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"16000000-0000-0000-0000-000000000047","email":"latest-core-datasets-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('26000000-0000-0000-0000-000000000048', '{"name":"Latest Core Dataset Team"}'::jsonb, 1, false);
+
+create temporary table latest_zero_embedding (value text) on commit drop;
+insert into latest_zero_embedding (value)
+select '[' || string_agg('0', ',') || ']'
+from generate_series(1, 1024);
+
+alter table public.flows disable trigger "flows_json_sync_trigger";
+alter table public.processes disable trigger "processes_json_sync_trigger";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_trigger";
+
+insert into public.flows (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '47000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-old","#text":"Old class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"legacy-flow-token"}'::jsonb,
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-old","#text":"Old class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"legacy-flow-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '47000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-new","#text":"New class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"latest-flow-token"}'::jsonb,
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-new","#text":"New class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"latest-flow-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '47000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-single","#text":"Single class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"single-flow-token"}'::jsonb,
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single flow"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"c-single","#text":"Single class"}]}}},"geography":{"locationOfSupply":"GLO"}},"modellingAndValidation":{"LCIMethod":{"typeOfDataSet":"Product flow"}}},"search":"single-flow-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  );
+
+insert into public.processes (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '48000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-old","#text":"Old class"}]}}},"time":{"common:referenceYear":"2020"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"legacy-process-token"}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-old","#text":"Old class"}]}}},"time":{"common:referenceYear":"2020"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"legacy-process-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '48000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-new","#text":"New class"}]}}},"time":{"common:referenceYear":"2021"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"latest-process-token"}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-new","#text":"New class"}]}}},"time":{"common:referenceYear":"2021"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"latest-process-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '48000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-single","#text":"Single class"}]}}},"time":{"common:referenceYear":"2022"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"single-process-token"}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single process"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"p-single","#text":"Single class"}]}}},"time":{"common:referenceYear":"2022"},"geography":{"locationOfOperationSupplyOrProduction":{"@location":"GLO"}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"single-process-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  );
+
+insert into public.lifecyclemodels (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '49000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-old","#text":"Old class"}]}}}}},"search":"legacy-lifecycle-token"}'::jsonb,
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Legacy lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-old","#text":"Old class"}]}}}}},"search":"legacy-lifecycle-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '49000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-new","#text":"New class"}]}}}}},"search":"latest-lifecycle-token"}'::jsonb,
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Latest lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-new","#text":"New class"}]}}}}},"search":"latest-lifecycle-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '49000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-single","#text":"Single class"}]}}}}},"search":"single-lifecycle-token"}'::jsonb,
+    '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Single lifecycle model"}]},"classificationInformation":{"common:classification":{"common:class":[{"@classId":"l-single","#text":"Single class"}]}}}}},"search":"single-lifecycle-token"}'::json,
+    '16000000-0000-0000-0000-000000000047',
+    100,
+    '26000000-0000-0000-0000-000000000048',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '16000000-0000-0000-0000-000000000047', true);
+
+select is(
+  (select version::text from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'flow list returns the highest visible version for a UUID'
+);
+
+select is(
+  (select version_count from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
+  2::bigint,
+  'flow list reports version_count for the visible UUID group'
+);
+
+select is(
+  (select max(total_count) from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
+  2::bigint,
+  'flow list total_count counts unique UUIDs'
+);
+
+select is(
+  (select version::text from public.pgroonga_search_flows_latest('legacy-flow-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'flow PGroonga search can match an older version while returning the highest visible version'
+);
+
+select is(
+  (select version::text from public.hybrid_search_flows('legacy-flow-token', (select value from latest_zero_embedding), '{}', 0.1, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) where id = '47000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'flow hybrid search returns the highest visible version for a matching UUID'
+);
+
+select is(
+  (select version::text from public.get_latest_process_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '48000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'process list returns the highest visible version for a UUID'
+);
+
+select is(
+  (select version_count from public.get_latest_process_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '48000000-0000-0000-0000-000000000001'),
+  2::bigint,
+  'process list reports version_count for the visible UUID group'
+);
+
+select is(
+  (select max(total_count) from public.get_latest_process_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
+  2::bigint,
+  'process list total_count counts unique UUIDs'
+);
+
+select is(
+  (select version::text from public.pgroonga_search_processes_latest('legacy-process-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '48000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'process PGroonga search can match an older version while returning the highest visible version'
+);
+
+select is(
+  (select version::text from public.hybrid_search_processes('legacy-process-token', (select value from latest_zero_embedding), '{}', 0.1, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) where id = '48000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'process hybrid search returns the highest visible version for a matching UUID'
+);
+
+select is(
+  (select version::text from public.get_latest_lifecyclemodel_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'lifecyclemodel list returns the highest visible version for a UUID'
+);
+
+select is(
+  (select version_count from public.get_latest_lifecyclemodel_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
+  2::bigint,
+  'lifecyclemodel list reports version_count for the visible UUID group'
+);
+
+select is(
+  (select max(total_count) from public.get_latest_lifecyclemodel_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
+  2::bigint,
+  'lifecyclemodel list total_count counts unique UUIDs'
+);
+
+select is(
+  (select version::text from public.pgroonga_search_lifecyclemodels_latest('legacy-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'lifecyclemodel PGroonga search can match an older version while returning the highest visible version'
+);
+
+select is(
+  (select version::text from public.hybrid_search_lifecyclemodels('legacy-lifecycle-token', (select value from latest_zero_embedding), '{}', 0.1, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) where id = '49000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'lifecyclemodel hybrid search returns the highest visible version for a matching UUID'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(34);
+select plan(31);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -211,11 +211,6 @@ select is(
   'flow list returns the highest visible version for a UUID'
 );
 
-select is(
-  (select version_count from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
-  2::bigint,
-  'flow list reports version_count for the visible UUID group'
-);
 
 select is(
   (select max(total_count) from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
@@ -253,11 +248,6 @@ select is(
   'process list returns the highest visible version for a UUID'
 );
 
-select is(
-  (select version_count from public.get_latest_process_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '48000000-0000-0000-0000-000000000001'),
-  2::bigint,
-  'process list reports version_count for the visible UUID group'
-);
 
 select is(
   (select max(total_count) from public.get_latest_process_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
@@ -283,11 +273,6 @@ select is(
   'lifecyclemodel list returns the highest visible version for a UUID'
 );
 
-select is(
-  (select version_count from public.get_latest_lifecyclemodel_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
-  2::bigint,
-  'lifecyclemodel list reports version_count for the visible UUID group'
-);
 
 select is(
   (select max(total_count) from public.get_latest_lifecyclemodel_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(31);
+select plan(33);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -343,6 +343,16 @@ select is(
 select ok(
   to_regclass('public.flows_public_latest_keys_cover_idx') is not null,
   'flow open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
+  to_regclass('public.flows_public_json_pgroonga_idx') is not null,
+  'flow open-data latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'JOIN LATERAL') > 0,
+  'flow open-data latest PGroonga search fetches latest versions with lateral index lookups'
 );
 
 select ok(

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(23);
+select plan(25);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -221,6 +221,18 @@ select is(
   (select max(total_count) from public.get_latest_flow_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000047')),
   2::bigint,
   'flow list total_count counts unique UUIDs'
+);
+
+select is(
+  (select version::text from public.get_latest_flow_versions(10, 1, 'my', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'flow my data list returns the highest user-owned version for a UUID'
+);
+
+select is(
+  (select max(total_count) from public.get_latest_flow_versions(10, 1, 'my', '16000000-0000-0000-0000-000000000047')),
+  2::bigint,
+  'flow my data list total_count counts user-owned unique UUIDs'
 );
 
 select is(

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(29);
+select plan(34);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -361,6 +361,16 @@ select ok(
 );
 
 select ok(
+  to_regclass('public.processes_public_latest_keys_cover_idx') is not null,
+  'process open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
+  to_regclass('public.lifecyclemodels_public_latest_keys_cover_idx') is not null,
+  'lifecyclemodel open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
   exists (
     select 1
     from pg_proc p
@@ -391,6 +401,39 @@ select ok(
       and cfg = 'statement_timeout=60s'
   ),
   'lifecyclemodel latest list has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'flow latest PGroonga search has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'process latest PGroonga search has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'lifecyclemodel latest PGroonga search has a function-level timeout budget'
 );
 
 select * from finish();

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(15);
+select plan(23);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -293,6 +293,54 @@ select is(
   (select version::text from public.hybrid_search_lifecyclemodels('legacy-lifecycle-token', (select value from latest_zero_embedding), '{}', 0.1, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) where id = '49000000-0000-0000-0000-000000000001'),
   '01.00.002',
   'lifecyclemodel hybrid search returns the highest visible version for a matching UUID'
+);
+
+select is(
+  (select version::text from public.get_latest_process_versions(10, 1, 'my', '16000000-0000-0000-0000-000000000047') where id = '48000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'process my data list returns the highest user-owned version for a UUID'
+);
+
+select is(
+  (select max(total_count) from public.get_latest_process_versions(10, 1, 'my', '16000000-0000-0000-0000-000000000047')),
+  2::bigint,
+  'process my data list total_count counts user-owned unique UUIDs'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.get_latest_flow_versions(bigint,bigint,text,text,uuid,integer,jsonb,text,text)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'flow latest list does not cast user_id on the my-data predicate'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.get_latest_process_versions(bigint,bigint,text,text,uuid,integer,text,text,text)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'process latest list does not cast user_id on the my-data predicate'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.get_latest_lifecyclemodel_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'lifecyclemodel latest list does not cast user_id on the my-data predicate'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.pgroonga_search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'flow latest search does not cast user_id on the my-data predicate'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.pgroonga_search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'process latest search does not cast user_id on the my-data predicate'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.pgroonga_search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'lifecyclemodel latest search does not cast user_id on the my-data predicate'
 );
 
 select * from finish();

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(25);
+select plan(29);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -353,6 +353,44 @@ select is(
   strpos(pg_get_functiondef('public.pgroonga_search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'user_id::text = this_user_id'),
   0,
   'lifecyclemodel latest search does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  to_regclass('public.flows_public_latest_keys_cover_idx') is not null,
+  'flow open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.get_latest_flow_versions(bigint,bigint,text,text,uuid,integer,jsonb,text,text)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'flow latest list has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.get_latest_process_versions(bigint,bigint,text,text,uuid,integer,text,text,text)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'process latest list has a function-level timeout budget'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.get_latest_lifecyclemodel_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'lifecyclemodel latest list has a function-level timeout budget'
 );
 
 select * from finish();

--- a/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(8);
+select plan(5);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -145,15 +145,6 @@ select is(
   'open flow property list returns the highest visible version for a UUID'
 );
 
-select is(
-  (
-    select version_count
-    from public.get_latest_flowproperty_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
-    where id = '46000000-0000-0000-0000-000000000001'
-  ),
-  2::bigint,
-  'open flow property list reports version_count for the visible UUID group'
-);
 
 select is(
   (
@@ -179,37 +170,7 @@ select is(
   'team filter limits open flow property latest-version rows before pagination'
 );
 
-select is(
-  (
-    select version_count
-    from public.get_latest_flowproperty_versions(
-      10,
-      1,
-      'my',
-      '16000000-0000-0000-0000-000000000046'
-    )
-    where id = '46000000-0000-0000-0000-000000000004'
-  ),
-  2::bigint,
-  'my data without a state filter counts all owner-visible versions'
-);
 
-select is(
-  (
-    select version_count
-    from public.get_latest_flowproperty_versions(
-      10,
-      1,
-      'my',
-      '16000000-0000-0000-0000-000000000046',
-      null,
-      200
-    )
-    where id = '46000000-0000-0000-0000-000000000004'
-  ),
-  1::bigint,
-  'my data state filter is applied before version_count is calculated'
-);
 
 select is(
   (

--- a/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
@@ -1,0 +1,249 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '16000000-0000-0000-0000-000000000046',
+    'authenticated',
+    'authenticated',
+    'latest-flowproperty-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"16000000-0000-0000-0000-000000000046","email":"latest-flowproperty-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('26000000-0000-0000-0000-000000000046', '{"name":"Latest Flowproperty Team A"}'::jsonb, 1, false),
+  ('26000000-0000-0000-0000-000000000047', '{"name":"Latest Flowproperty Team B"}'::jsonb, 2, false);
+
+alter table public.flowproperties disable trigger "flowproperties_json_sync_trigger";
+
+insert into public.flowproperties (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '46000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Legacy matched flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"legacy unique"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Legacy matched flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"legacy unique"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Latest flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"current text"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Latest flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"current text"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Single open flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u2"}},"units":{"unit":[{"@dataSetInternalID":"u2","name":"MJ"}]}},"search":"single"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Single open flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u2"}},"units":{"unit":[{"@dataSetInternalID":"u2","name":"MJ"}]}},"search":"single"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000003',
+    '01.00.001',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Other team flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u3"}},"units":{"unit":[{"@dataSetInternalID":"u3","name":"m"}]}},"search":"other team"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Other team flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u3"}},"units":{"unit":[{"@dataSetInternalID":"u3","name":"m"}]}},"search":"other team"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000047',
+    true,
+    now() - interval '3 days',
+    now() - interval '3 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner draft flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"draft"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner draft flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"draft"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    0,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '4 days',
+    now() - interval '4 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000004',
+    '01.00.001',
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner review flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"review"}'::jsonb,
+    '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner review flow property"}]},"quantitativeReference":{"referenceToReferenceUnitGroup":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"review"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    200,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '1 hour',
+    now() - interval '1 hour'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '16000000-0000-0000-0000-000000000046', true);
+
+select is(
+  (
+    select version::text
+    from public.get_latest_flowproperty_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'open flow property list returns the highest visible version for a UUID'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_flowproperty_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  2::bigint,
+  'open flow property list reports version_count for the visible UUID group'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.get_latest_flowproperty_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+  ),
+  3::bigint,
+  'open flow property list total_count counts unique UUIDs, not version rows'
+);
+
+select is(
+  (
+    select count(*)
+    from public.get_latest_flowproperty_versions(
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046',
+      '26000000-0000-0000-0000-000000000046'
+    )
+  ),
+  2::bigint,
+  'team filter limits open flow property latest-version rows before pagination'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_flowproperty_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000046'
+    )
+    where id = '46000000-0000-0000-0000-000000000004'
+  ),
+  2::bigint,
+  'my data without a state filter counts all owner-visible versions'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_flowproperty_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000046',
+      null,
+      200
+    )
+    where id = '46000000-0000-0000-0000-000000000004'
+  ),
+  1::bigint,
+  'my data state filter is applied before version_count is calculated'
+);
+
+select is(
+  (
+    select version::text
+    from public.pgroonga_search_flowproperties_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046'
+    )
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'search can match an older version while returning the highest visible version for that UUID'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.pgroonga_search_flowproperties_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046'
+    )
+  ),
+  1::bigint,
+  'search total_count counts matching UUIDs after grouping'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260520_sources_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_sources_latest_version_query_rpcs.sql
@@ -1,0 +1,247 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '16000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'latest-source-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"16000000-0000-0000-0000-000000000001","email":"latest-source-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('26000000-0000-0000-0000-000000000001', '{"name":"Latest Source Team A"}'::jsonb, 1, false),
+  ('26000000-0000-0000-0000-000000000002', '{"name":"Latest Source Team B"}'::jsonb, 2, false);
+
+insert into public.sources (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '36000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Legacy matched source"}]}}},"search":"legacy unique"}'::jsonb,
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Legacy matched source"}]}}},"search":"legacy unique"}'::json,
+    '16000000-0000-0000-0000-000000000001',
+    100,
+    '26000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '36000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Latest source"}]}}},"search":"current text"}'::jsonb,
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Latest source"}]}}},"search":"current text"}'::json,
+    '16000000-0000-0000-0000-000000000001',
+    100,
+    '26000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '36000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Single open source"}]}}},"search":"single"}'::jsonb,
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Single open source"}]}}},"search":"single"}'::json,
+    '16000000-0000-0000-0000-000000000001',
+    100,
+    '26000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    '36000000-0000-0000-0000-000000000003',
+    '01.00.001',
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Other team source"}]}}},"search":"other team"}'::jsonb,
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Other team source"}]}}},"search":"other team"}'::json,
+    '16000000-0000-0000-0000-000000000001',
+    100,
+    '26000000-0000-0000-0000-000000000002',
+    true,
+    now() - interval '3 days',
+    now() - interval '3 days'
+  ),
+  (
+    '36000000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner draft source"}]}}},"search":"draft"}'::jsonb,
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner draft source"}]}}},"search":"draft"}'::json,
+    '16000000-0000-0000-0000-000000000001',
+    0,
+    '26000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '4 days',
+    now() - interval '4 days'
+  ),
+  (
+    '36000000-0000-0000-0000-000000000004',
+    '01.00.001',
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner review source"}]}}},"search":"review"}'::jsonb,
+    '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Owner review source"}]}}},"search":"review"}'::json,
+    '16000000-0000-0000-0000-000000000001',
+    20,
+    '26000000-0000-0000-0000-000000000001',
+    true,
+    now() - interval '1 hour',
+    now() - interval '1 hour'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '16000000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select version::text
+    from public.get_latest_source_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000001')
+    where id = '36000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'open source list returns the highest visible version for a UUID'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_source_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000001')
+    where id = '36000000-0000-0000-0000-000000000001'
+  ),
+  2::bigint,
+  'open source list reports version_count for the visible UUID group'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.get_latest_source_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000001')
+  ),
+  3::bigint,
+  'open source list total_count counts unique UUIDs, not version rows'
+);
+
+select is(
+  (
+    select count(*)
+    from public.get_latest_source_versions(
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000001',
+      '26000000-0000-0000-0000-000000000001'
+    )
+  ),
+  2::bigint,
+  'team filter limits open source latest-version rows before pagination'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_source_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000001'
+    )
+    where id = '36000000-0000-0000-0000-000000000004'
+  ),
+  2::bigint,
+  'my data without a state filter counts all owner-visible versions'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_source_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000001',
+      null,
+      20
+    )
+    where id = '36000000-0000-0000-0000-000000000004'
+  ),
+  1::bigint,
+  'my data state filter is applied before version_count is calculated'
+);
+
+select is(
+  (
+    select version::text
+    from public.pgroonga_search_sources_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000001'
+    )
+    where id = '36000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'search can match an older version while returning the highest visible version for that UUID'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.pgroonga_search_sources_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000001'
+    )
+  ),
+  1::bigint,
+  'search total_count counts matching UUIDs after grouping'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260520_sources_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_sources_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(8);
+select plan(5);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -143,15 +143,6 @@ select is(
   'open source list returns the highest visible version for a UUID'
 );
 
-select is(
-  (
-    select version_count
-    from public.get_latest_source_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000001')
-    where id = '36000000-0000-0000-0000-000000000001'
-  ),
-  2::bigint,
-  'open source list reports version_count for the visible UUID group'
-);
 
 select is(
   (
@@ -177,37 +168,7 @@ select is(
   'team filter limits open source latest-version rows before pagination'
 );
 
-select is(
-  (
-    select version_count
-    from public.get_latest_source_versions(
-      10,
-      1,
-      'my',
-      '16000000-0000-0000-0000-000000000001'
-    )
-    where id = '36000000-0000-0000-0000-000000000004'
-  ),
-  2::bigint,
-  'my data without a state filter counts all owner-visible versions'
-);
 
-select is(
-  (
-    select version_count
-    from public.get_latest_source_versions(
-      10,
-      1,
-      'my',
-      '16000000-0000-0000-0000-000000000001',
-      null,
-      20
-    )
-    where id = '36000000-0000-0000-0000-000000000004'
-  ),
-  1::bigint,
-  'my data state filter is applied before version_count is calculated'
-);
 
 select is(
   (

--- a/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(8);
+select plan(5);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -145,15 +145,6 @@ select is(
   'open unit group list returns the highest visible version for a UUID'
 );
 
-select is(
-  (
-    select version_count
-    from public.get_latest_unitgroup_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
-    where id = '46000000-0000-0000-0000-000000000001'
-  ),
-  2::bigint,
-  'open unit group list reports version_count for the visible UUID group'
-);
 
 select is(
   (
@@ -179,37 +170,7 @@ select is(
   'team filter limits open unit group latest-version rows before pagination'
 );
 
-select is(
-  (
-    select version_count
-    from public.get_latest_unitgroup_versions(
-      10,
-      1,
-      'my',
-      '16000000-0000-0000-0000-000000000046'
-    )
-    where id = '46000000-0000-0000-0000-000000000004'
-  ),
-  2::bigint,
-  'my data without a state filter counts all owner-visible versions'
-);
 
-select is(
-  (
-    select version_count
-    from public.get_latest_unitgroup_versions(
-      10,
-      1,
-      'my',
-      '16000000-0000-0000-0000-000000000046',
-      null,
-      200
-    )
-    where id = '46000000-0000-0000-0000-000000000004'
-  ),
-  1::bigint,
-  'my data state filter is applied before version_count is calculated'
-);
 
 select is(
   (

--- a/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
@@ -44,6 +44,8 @@ values
   ('26000000-0000-0000-0000-000000000046', '{"name":"Latest Unitgroup Team A"}'::jsonb, 1, false),
   ('26000000-0000-0000-0000-000000000047', '{"name":"Latest Unitgroup Team B"}'::jsonb, 2, false);
 
+alter table public.unitgroups disable trigger "unitgroups_json_sync_trigger";
+
 insert into public.unitgroups (
   id,
   version,

--- a/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
@@ -1,0 +1,247 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '16000000-0000-0000-0000-000000000046',
+    'authenticated',
+    'authenticated',
+    'latest-unitgroup-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"16000000-0000-0000-0000-000000000046","email":"latest-unitgroup-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('26000000-0000-0000-0000-000000000046', '{"name":"Latest Unitgroup Team A"}'::jsonb, 1, false),
+  ('26000000-0000-0000-0000-000000000047', '{"name":"Latest Unitgroup Team B"}'::jsonb, 2, false);
+
+insert into public.unitgroups (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  created_at,
+  modified_at
+)
+values
+  (
+    '46000000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Legacy matched unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"legacy unique"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Legacy matched unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"legacy unique"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '5 days',
+    now() - interval '5 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000001',
+    '01.00.002',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Latest unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"current text"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Latest unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u1"}},"units":{"unit":[{"@dataSetInternalID":"u1","name":"kg"}]}},"search":"current text"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000002',
+    '01.00.001',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Single open unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u2"}},"units":{"unit":[{"@dataSetInternalID":"u2","name":"MJ"}]}},"search":"single"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Single open unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u2"}},"units":{"unit":[{"@dataSetInternalID":"u2","name":"MJ"}]}},"search":"single"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000003',
+    '01.00.001',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Other team unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u3"}},"units":{"unit":[{"@dataSetInternalID":"u3","name":"m"}]}},"search":"other team"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Other team unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u3"}},"units":{"unit":[{"@dataSetInternalID":"u3","name":"m"}]}},"search":"other team"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    100,
+    '26000000-0000-0000-0000-000000000047',
+    true,
+    now() - interval '3 days',
+    now() - interval '3 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner draft unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"draft"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner draft unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"draft"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    0,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '4 days',
+    now() - interval '4 days'
+  ),
+  (
+    '46000000-0000-0000-0000-000000000004',
+    '01.00.001',
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner review unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"review"}'::jsonb,
+    '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Owner review unit group"}]},"quantitativeReference":{"referenceToReferenceUnit":"u4"}},"units":{"unit":[{"@dataSetInternalID":"u4","name":"s"}]}},"search":"review"}'::json,
+    '16000000-0000-0000-0000-000000000046',
+    200,
+    '26000000-0000-0000-0000-000000000046',
+    true,
+    now() - interval '1 hour',
+    now() - interval '1 hour'
+  );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '16000000-0000-0000-0000-000000000046', true);
+
+select is(
+  (
+    select version::text
+    from public.get_latest_unitgroup_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'open unit group list returns the highest visible version for a UUID'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_unitgroup_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  2::bigint,
+  'open unit group list reports version_count for the visible UUID group'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.get_latest_unitgroup_versions(10, 1, 'tg', '16000000-0000-0000-0000-000000000046')
+  ),
+  3::bigint,
+  'open unit group list total_count counts unique UUIDs, not version rows'
+);
+
+select is(
+  (
+    select count(*)
+    from public.get_latest_unitgroup_versions(
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046',
+      '26000000-0000-0000-0000-000000000046'
+    )
+  ),
+  2::bigint,
+  'team filter limits open unit group latest-version rows before pagination'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_unitgroup_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000046'
+    )
+    where id = '46000000-0000-0000-0000-000000000004'
+  ),
+  2::bigint,
+  'my data without a state filter counts all owner-visible versions'
+);
+
+select is(
+  (
+    select version_count
+    from public.get_latest_unitgroup_versions(
+      10,
+      1,
+      'my',
+      '16000000-0000-0000-0000-000000000046',
+      null,
+      200
+    )
+    where id = '46000000-0000-0000-0000-000000000004'
+  ),
+  1::bigint,
+  'my data state filter is applied before version_count is calculated'
+);
+
+select is(
+  (
+    select version::text
+    from public.pgroonga_search_unitgroups_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046'
+    )
+    where id = '46000000-0000-0000-0000-000000000001'
+  ),
+  '01.00.002',
+  'search can match an older version while returning the highest visible version for that UUID'
+);
+
+select is(
+  (
+    select max(total_count)
+    from public.pgroonga_search_unitgroups_latest(
+      'legacy unique',
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '16000000-0000-0000-0000-000000000046'
+    )
+  ),
+  1::bigint,
+  'search total_count counts matching UUIDs after grouping'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 4547abfaf702bab17dea46b0fb7a2a7368badb0b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 099def790221c0e7c2cba0456b4bf157d915f019
+lastReviewedAt: 2026-05-21
+lastReviewedCommit: 4547abfaf702bab17dea46b0fb7a2a7368badb0b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #46

## Summary
- promote current `dev` into `main` after latest-version list/search rollout and follow-up performance fixes
- includes latest-version RPCs for sources, contacts, unitgroups, flowproperties, flows, processes, and lifecyclemodels
- includes core latest search / hybrid search UUID deduplication, open-data timeout fixes, `version_count` removal, and the open flow PGroonga search optimization
- includes the latest docpact CLI wrapper update from `dev`

## Validation
- `git diff --check origin/main..HEAD`
- `./scripts/docpact validate-config --root . --strict`
- `./scripts/docpact lint --root . --worktree`
- Upstream `dev` PRs #47-#53 have passed their PR checks; relevant database changes have also passed Supabase Dev on `dev` before this promote PR.

## Notes
- This promote branch was forked from latest `origin/dev` first, then `origin/main` was merged into it to carry main-only history and avoid a naked long-lived-branch PR.
- Root workspace submodule integration remains a separate follow-up after the `database-engine/main` promote PR is merged.
