### PR TITLE
promote: dev to main for process PGroonga search fix

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-21"
-lastReviewedCommit: "f7c400dbbdf4f834286520d405687199a0c451f1"
+lastReviewedAt: "2026-05-24"
+lastReviewedCommit: "3f74bec17bb265859b7ad10af143b4b21c9715d7"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: f7c400dbbdf4f834286520d405687199a0c451f1
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 3f74bec17bb265859b7ad10af143b4b21c9715d7
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: f7c400dbbdf4f834286520d405687199a0c451f1
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 3f74bec17bb265859b7ad10af143b4b21c9715d7
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-21
-lastReviewedCommit: f7c400dbbdf4f834286520d405687199a0c451f1
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 3f74bec17bb265859b7ad10af143b4b21c9715d7
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260524103000_tune_process_latest_pgroonga_search.sql
+++ b/supabase/migrations/20260524103000_tune_process_latest_pgroonga_search.sql
@@ -1,0 +1,330 @@
+CREATE INDEX IF NOT EXISTS "processes_public_json_pgroonga_idx"
+ON "public"."processes" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 100;
+
+CREATE INDEX IF NOT EXISTS "processes_co_json_pgroonga_idx"
+ON "public"."processes" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 200;
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_processes_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "type_of_data_set_filter" text DEFAULT 'all'::text
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "model_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  IF data_source = 'tg' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT
+          p.id,
+          max(pgroonga_score(p.tableoid, p.ctid)) AS search_score
+        FROM public.processes p
+        WHERE p.state_code = 100
+          AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+          AND p.json @> filter_condition_jsonb
+          AND p.json &@~ query_text
+          AND (
+            coalesce(type_of_data_set_filter, 'all') = 'all'
+            OR p.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+          )
+        GROUP BY p.id
+      ),
+      latest_rows AS (
+        SELECT
+          matched_ids.id,
+          latest_row.json,
+          latest_row.version,
+          latest_row.modified_at,
+          latest_row.team_id,
+          latest_row.model_id,
+          matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT
+            p2.json,
+            p2.version,
+            p2.modified_at,
+            p2.team_id,
+            p2.model_id
+          FROM public.processes p2
+          WHERE p2.state_code = 100
+            AND p2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR p2.team_id = team_id_filter)
+          ORDER BY p2.version DESC, p2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT
+          rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+          counted_rows.*
+        FROM counted_rows
+      )
+      SELECT
+        ranked_rows.rank,
+        ranked_rows.id,
+        ranked_rows.json,
+        ranked_rows.version,
+        ranked_rows.modified_at,
+        ranked_rows.team_id,
+        ranked_rows.model_id,
+        ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'co' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT
+          p.id,
+          max(pgroonga_score(p.tableoid, p.ctid)) AS search_score
+        FROM public.processes p
+        WHERE p.state_code = 200
+          AND (team_id_filter IS NULL OR p.team_id = team_id_filter)
+          AND p.json @> filter_condition_jsonb
+          AND p.json &@~ query_text
+          AND (
+            coalesce(type_of_data_set_filter, 'all') = 'all'
+            OR p.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+          )
+        GROUP BY p.id
+      ),
+      latest_rows AS (
+        SELECT
+          matched_ids.id,
+          latest_row.json,
+          latest_row.version,
+          latest_row.modified_at,
+          latest_row.team_id,
+          latest_row.model_id,
+          matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT
+            p2.json,
+            p2.version,
+            p2.modified_at,
+            p2.team_id,
+            p2.model_id
+          FROM public.processes p2
+          WHERE p2.state_code = 200
+            AND p2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR p2.team_id = team_id_filter)
+          ORDER BY p2.version DESC, p2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT
+          rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+          counted_rows.*
+        FROM counted_rows
+      )
+      SELECT
+        ranked_rows.rank,
+        ranked_rows.id,
+        ranked_rows.json,
+        ranked_rows.version,
+        ranked_rows.modified_at,
+        ranked_rows.team_id,
+        ranked_rows.model_id,
+        ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'my' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT
+          p.id,
+          max(pgroonga_score(p.tableoid, p.ctid)) AS search_score
+        FROM public.processes p
+        WHERE normalized_this_user_id IS NOT NULL
+          AND p.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+          AND p.json @> filter_condition_jsonb
+          AND p.json &@~ query_text
+          AND (
+            coalesce(type_of_data_set_filter, 'all') = 'all'
+            OR p.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+          )
+        GROUP BY p.id
+      ),
+      latest_rows AS (
+        SELECT
+          matched_ids.id,
+          latest_row.json,
+          latest_row.version,
+          latest_row.modified_at,
+          latest_row.team_id,
+          latest_row.model_id,
+          matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT
+            p2.json,
+            p2.version,
+            p2.modified_at,
+            p2.team_id,
+            p2.model_id
+          FROM public.processes p2
+          WHERE normalized_this_user_id IS NOT NULL
+            AND p2.user_id = normalized_this_user_id
+            AND p2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR p2.state_code = state_code_filter)
+          ORDER BY p2.version DESC, p2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT
+          rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+          counted_rows.*
+        FROM counted_rows
+      )
+      SELECT
+        ranked_rows.rank,
+        ranked_rows.id,
+        ranked_rows.json,
+        ranked_rows.version,
+        ranked_rows.modified_at,
+        ranked_rows.team_id,
+        ranked_rows.model_id,
+        ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'te' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT
+          p.id,
+          max(pgroonga_score(p.tableoid, p.ctid)) AS search_score
+        FROM public.processes p
+        WHERE team_id_filter IS NOT NULL
+          AND p.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR p.state_code = state_code_filter)
+          AND p.json @> filter_condition_jsonb
+          AND p.json &@~ query_text
+          AND (
+            coalesce(type_of_data_set_filter, 'all') = 'all'
+            OR p.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = type_of_data_set_filter
+          )
+        GROUP BY p.id
+      ),
+      latest_rows AS (
+        SELECT
+          matched_ids.id,
+          latest_row.json,
+          latest_row.version,
+          latest_row.modified_at,
+          latest_row.team_id,
+          latest_row.model_id,
+          matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT
+            p2.json,
+            p2.version,
+            p2.modified_at,
+            p2.team_id,
+            p2.model_id
+          FROM public.processes p2
+          WHERE team_id_filter IS NOT NULL
+            AND p2.team_id = team_id_filter
+            AND p2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR p2.state_code = state_code_filter)
+          ORDER BY p2.version DESC, p2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT
+          rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank,
+          counted_rows.*
+        FROM counted_rows
+      )
+      SELECT
+        ranked_rows.rank,
+        ranked_rows.id,
+        ranked_rows.json,
+        ranked_rows.version,
+        ranked_rows.modified_at,
+        ranked_rows.team_id,
+        ranked_rows.model_id,
+        ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_processes_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) TO "service_role";

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(33);
+select plan(37);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -47,6 +47,7 @@ create temporary table latest_zero_embedding (value text) on commit drop;
 insert into latest_zero_embedding (value)
 select '[' || string_agg('0', ',') || ']'
 from generate_series(1, 1024);
+grant select on latest_zero_embedding to authenticated;
 
 alter table public.flows disable trigger "flows_json_sync_trigger";
 alter table public.processes disable trigger "processes_json_sync_trigger";
@@ -358,6 +359,26 @@ select ok(
 select ok(
   to_regclass('public.processes_public_latest_keys_cover_idx') is not null,
   'process open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
+  to_regclass('public.processes_public_json_pgroonga_idx') is not null,
+  'process open-data latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  to_regclass('public.processes_co_json_pgroonga_idx') is not null,
+  'process collaborative latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'JOIN LATERAL') > 0,
+  'process latest PGroonga search fetches latest versions with lateral index lookups'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'p.json &@~ query_text') > 0,
+  'process latest PGroonga search keeps full-text matching for query_text'
 );
 
 select ok(


### PR DESCRIPTION
Closes #56

## Summary
- Promote the merged dev fix for pgroonga_search_processes_latest timeout handling into main.
- Includes PR #57: process JSON PGroonga partial indexes, data_source-specific function paths, and lateral latest-version lookups while preserving full-text query_text semantics.
- Carries the docpact review evidence required by the database-engine governance gate.

## Key Decisions
- Use the M2 promote path dev -> main for database-engine per workspace branch policy.
- Keep UUID-looking query_text values on the PGroonga full-text path; no id equality shortcut is introduced.

## Validation
- PR #57 checks passed: Gitleaks Security Scan, ai-doc-lint, Supabase Preview.
- For #57, local validation passed: npx -y supabase@latest db reset; npx -y supabase@latest test db --local supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql.

## Risks / Rollback
- Medium: production RPC planner shape changes after promote; rollback is reverting the promoted migration/function change from main before deployment.

## Follow-ups
- After main deployment, run production-like EXPLAIN ANALYZE for the reported data_source='my' request shape and monitor timeout/error rate.

## Workspace Integration
- After this promote PR merges, lca-workspace main may update the database-engine submodule pointer to the promoted database-engine/main commit.