### PR TITLE
chore: promote latest PGroonga search optimizations to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-24"
-lastReviewedCommit: "3f74bec17bb265859b7ad10af143b4b21c9715d7"
+lastReviewedAt: "2026-05-25"
+lastReviewedCommit: "227d8b994221a632bab51805cd26f53b0c7312b5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 3f74bec17bb265859b7ad10af143b4b21c9715d7
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 227d8b994221a632bab51805cd26f53b0c7312b5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 3f74bec17bb265859b7ad10af143b4b21c9715d7
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 227d8b994221a632bab51805cd26f53b0c7312b5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 3f74bec17bb265859b7ad10af143b4b21c9715d7
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 227d8b994221a632bab51805cd26f53b0c7312b5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260525103000_tune_remaining_latest_pgroonga_search.sql
+++ b/supabase/migrations/20260525103000_tune_remaining_latest_pgroonga_search.sql
@@ -1,0 +1,1507 @@
+CREATE INDEX IF NOT EXISTS "sources_public_json_pgroonga_idx"
+ON "public"."sources" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 100;
+
+CREATE INDEX IF NOT EXISTS "sources_co_json_pgroonga_idx"
+ON "public"."sources" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 200;
+
+CREATE INDEX IF NOT EXISTS "contacts_public_json_pgroonga_idx"
+ON "public"."contacts" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 100;
+
+CREATE INDEX IF NOT EXISTS "contacts_co_json_pgroonga_idx"
+ON "public"."contacts" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 200;
+
+CREATE INDEX IF NOT EXISTS "unitgroups_public_json_pgroonga_idx"
+ON "public"."unitgroups" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 100;
+
+CREATE INDEX IF NOT EXISTS "unitgroups_co_json_pgroonga_idx"
+ON "public"."unitgroups" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 200;
+
+CREATE INDEX IF NOT EXISTS "flowproperties_public_json_pgroonga_idx"
+ON "public"."flowproperties" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 100;
+
+CREATE INDEX IF NOT EXISTS "flowproperties_co_json_pgroonga_idx"
+ON "public"."flowproperties" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 200;
+
+CREATE INDEX IF NOT EXISTS "flows_co_json_pgroonga_idx"
+ON "public"."flows" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 200;
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_public_json_pgroonga_idx"
+ON "public"."lifecyclemodels" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 100;
+
+CREATE INDEX IF NOT EXISTS "lifecyclemodels_co_json_pgroonga_idx"
+ON "public"."lifecyclemodels" USING "pgroonga" ("json" "extensions"."pgroonga_jsonb_full_text_search_ops_v2")
+WHERE "state_code" = 200;
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_sources_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  IF data_source = 'tg' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.sources f
+        WHERE f.state_code = 100
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.sources f2
+          WHERE f2.state_code = 100
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'co' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.sources f
+        WHERE f.state_code = 200
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.sources f2
+          WHERE f2.state_code = 200
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'my' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.sources f
+        WHERE normalized_this_user_id IS NOT NULL
+          AND f.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.sources f2
+          WHERE normalized_this_user_id IS NOT NULL
+            AND f2.user_id = normalized_this_user_id
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'te' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.sources f
+        WHERE team_id_filter IS NOT NULL
+          AND f.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.sources f2
+          WHERE team_id_filter IS NOT NULL
+            AND f2.team_id = team_id_filter
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_sources_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_sources_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_contacts_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  IF data_source = 'tg' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.contacts f
+        WHERE f.state_code = 100
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.contacts f2
+          WHERE f2.state_code = 100
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'co' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.contacts f
+        WHERE f.state_code = 200
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.contacts f2
+          WHERE f2.state_code = 200
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'my' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.contacts f
+        WHERE normalized_this_user_id IS NOT NULL
+          AND f.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.contacts f2
+          WHERE normalized_this_user_id IS NOT NULL
+            AND f2.user_id = normalized_this_user_id
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'te' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.contacts f
+        WHERE team_id_filter IS NOT NULL
+          AND f.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.contacts f2
+          WHERE team_id_filter IS NOT NULL
+            AND f2.team_id = team_id_filter
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_contacts_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_contacts_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_unitgroups_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  IF data_source = 'tg' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.unitgroups f
+        WHERE f.state_code = 100
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.unitgroups f2
+          WHERE f2.state_code = 100
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'co' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.unitgroups f
+        WHERE f.state_code = 200
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.unitgroups f2
+          WHERE f2.state_code = 200
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'my' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.unitgroups f
+        WHERE normalized_this_user_id IS NOT NULL
+          AND f.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.unitgroups f2
+          WHERE normalized_this_user_id IS NOT NULL
+            AND f2.user_id = normalized_this_user_id
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'te' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.unitgroups f
+        WHERE team_id_filter IS NOT NULL
+          AND f.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.unitgroups f2
+          WHERE team_id_filter IS NOT NULL
+            AND f2.team_id = team_id_filter
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_unitgroups_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_unitgroups_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flowproperties_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  IF data_source = 'tg' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flowproperties f
+        WHERE f.state_code = 100
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.flowproperties f2
+          WHERE f2.state_code = 100
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'co' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flowproperties f
+        WHERE f.state_code = 200
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.flowproperties f2
+          WHERE f2.state_code = 200
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'my' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flowproperties f
+        WHERE normalized_this_user_id IS NOT NULL
+          AND f.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.flowproperties f2
+          WHERE normalized_this_user_id IS NOT NULL
+            AND f2.user_id = normalized_this_user_id
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'te' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flowproperties f
+        WHERE team_id_filter IS NOT NULL
+          AND f.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.flowproperties f2
+          WHERE team_id_filter IS NOT NULL
+            AND f2.team_id = team_id_filter
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flowproperties_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flowproperties_latest"(text, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  IF data_source = 'tg' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT l.id, max(pgroonga_score(l.tableoid, l.ctid)) AS search_score
+        FROM public.lifecyclemodels l
+        WHERE l.state_code = 100
+          AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+          AND l.json @> filter_condition_jsonb
+          AND l.json &@~ query_text
+        GROUP BY l.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT l2.json, l2.version, l2.modified_at, l2.team_id
+          FROM public.lifecyclemodels l2
+          WHERE l2.state_code = 100
+            AND l2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR l2.team_id = team_id_filter)
+          ORDER BY l2.version DESC, l2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'co' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT l.id, max(pgroonga_score(l.tableoid, l.ctid)) AS search_score
+        FROM public.lifecyclemodels l
+        WHERE l.state_code = 200
+          AND (team_id_filter IS NULL OR l.team_id = team_id_filter)
+          AND l.json @> filter_condition_jsonb
+          AND l.json &@~ query_text
+        GROUP BY l.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT l2.json, l2.version, l2.modified_at, l2.team_id
+          FROM public.lifecyclemodels l2
+          WHERE l2.state_code = 200
+            AND l2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR l2.team_id = team_id_filter)
+          ORDER BY l2.version DESC, l2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'my' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT l.id, max(pgroonga_score(l.tableoid, l.ctid)) AS search_score
+        FROM public.lifecyclemodels l
+        WHERE normalized_this_user_id IS NOT NULL
+          AND l.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+          AND l.json @> filter_condition_jsonb
+          AND l.json &@~ query_text
+        GROUP BY l.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT l2.json, l2.version, l2.modified_at, l2.team_id
+          FROM public.lifecyclemodels l2
+          WHERE normalized_this_user_id IS NOT NULL
+            AND l2.user_id = normalized_this_user_id
+            AND l2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR l2.state_code = state_code_filter)
+          ORDER BY l2.version DESC, l2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'te' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT l.id, max(pgroonga_score(l.tableoid, l.ctid)) AS search_score
+        FROM public.lifecyclemodels l
+        WHERE team_id_filter IS NOT NULL
+          AND l.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR l.state_code = state_code_filter)
+          AND l.json @> filter_condition_jsonb
+          AND l.json &@~ query_text
+        GROUP BY l.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT l2.json, l2.version, l2.modified_at, l2.team_id
+          FROM public.lifecyclemodels l2
+          WHERE team_id_filter IS NOT NULL
+            AND l2.team_id = team_id_filter
+            AND l2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR l2.state_code = state_code_filter)
+          ORDER BY l2.version DESC, l2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_lifecyclemodels_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."pgroonga_search_flows_latest"(
+  "query_text" text,
+  "filter_condition" jsonb DEFAULT '{}'::jsonb,
+  "order_by" jsonb DEFAULT '{}'::jsonb,
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer
+) RETURNS TABLE(
+  "rank" bigint,
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  IF flow_type IS NOT NULL THEN
+    flow_type_array := string_to_array(flow_type, ',');
+  ELSE
+    flow_type_array := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  IF filter_condition_jsonb ? 'asInput' THEN
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  ELSE
+    as_input := NULL;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  IF jsonb_typeof(filter_condition_jsonb->'classification') = 'array' THEN
+    classification_filter := filter_condition_jsonb->'classification';
+  ELSE
+    classification_filter := '[]'::jsonb;
+  END IF;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+
+  IF data_source = 'tg' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flows f
+        WHERE f.state_code = 100
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+          AND (
+            flow_type IS NULL
+            OR (f.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+          )
+          AND (
+            as_input IS NULL
+            OR as_input = false
+            OR NOT (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+          AND (
+            jsonb_array_length(classification_filter) = 0
+            OR EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+              WHERE
+                (
+                  selected_class.item->>'scope' = 'elementary'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS category(item)
+                    WHERE category.item->>'@catId' = selected_class.item->>'code'
+                  )
+                )
+                OR (
+                  selected_class.item->>'scope' = 'classification'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS class_item(item)
+                    WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                  )
+                )
+            )
+          )
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.flows f2
+          WHERE f2.state_code = 100
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'co' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flows f
+        WHERE f.state_code = 200
+          AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+          AND (
+            flow_type IS NULL
+            OR (f.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+          )
+          AND (
+            as_input IS NULL
+            OR as_input = false
+            OR NOT (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+          AND (
+            jsonb_array_length(classification_filter) = 0
+            OR EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+              WHERE
+                (
+                  selected_class.item->>'scope' = 'elementary'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS category(item)
+                    WHERE category.item->>'@catId' = selected_class.item->>'code'
+                  )
+                )
+                OR (
+                  selected_class.item->>'scope' = 'classification'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS class_item(item)
+                    WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                  )
+                )
+            )
+          )
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.flows f2
+          WHERE f2.state_code = 200
+            AND f2.id = matched_ids.id
+            AND (team_id_filter IS NULL OR f2.team_id = team_id_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'my' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flows f
+        WHERE normalized_this_user_id IS NOT NULL
+          AND f.user_id = normalized_this_user_id
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+          AND (
+            flow_type IS NULL
+            OR (f.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+          )
+          AND (
+            as_input IS NULL
+            OR as_input = false
+            OR NOT (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+          AND (
+            jsonb_array_length(classification_filter) = 0
+            OR EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+              WHERE
+                (
+                  selected_class.item->>'scope' = 'elementary'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS category(item)
+                    WHERE category.item->>'@catId' = selected_class.item->>'code'
+                  )
+                )
+                OR (
+                  selected_class.item->>'scope' = 'classification'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS class_item(item)
+                    WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                  )
+                )
+            )
+          )
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.flows f2
+          WHERE normalized_this_user_id IS NOT NULL
+            AND f2.user_id = normalized_this_user_id
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+
+  IF data_source = 'te' THEN
+    RETURN QUERY
+      WITH matched_ids AS (
+        SELECT f.id, max(pgroonga_score(f.tableoid, f.ctid)) AS search_score
+        FROM public.flows f
+        WHERE team_id_filter IS NOT NULL
+          AND f.team_id = team_id_filter
+          AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+          AND f.json @> filter_condition_jsonb
+          AND f.json &@~ query_text
+          AND (
+            flow_type IS NULL
+            OR (f.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = ANY(flow_type_array)
+          )
+          AND (
+            as_input IS NULL
+            OR as_input = false
+            OR NOT (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+          AND (
+            jsonb_array_length(classification_filter) = 0
+            OR EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(classification_filter) AS selected_class(item)
+              WHERE
+                (
+                  selected_class.item->>'scope' = 'elementary'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS category(item)
+                    WHERE category.item->>'@catId' = selected_class.item->>'code'
+                  )
+                )
+                OR (
+                  selected_class.item->>'scope' = 'classification'
+                  AND EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(
+                      CASE jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        WHEN 'array' THEN f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                        WHEN 'object' THEN jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                        ELSE '[]'::jsonb
+                      END
+                    ) AS class_item(item)
+                    WHERE class_item.item->>'@classId' = selected_class.item->>'code'
+                  )
+                )
+            )
+          )
+        GROUP BY f.id
+      ),
+      latest_rows AS (
+        SELECT matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+        FROM matched_ids
+        JOIN LATERAL (
+          SELECT f2.json, f2.version, f2.modified_at, f2.team_id
+          FROM public.flows f2
+          WHERE team_id_filter IS NOT NULL
+            AND f2.team_id = team_id_filter
+            AND f2.id = matched_ids.id
+            AND (state_code_filter IS NULL OR f2.state_code = state_code_filter)
+          ORDER BY f2.version DESC, f2.modified_at DESC
+          LIMIT 1
+        ) latest_row ON true
+      ),
+      counted_rows AS (
+        SELECT latest_rows.*, count(*) OVER()::bigint AS total_count
+        FROM latest_rows
+      ),
+      ranked_rows AS (
+        SELECT rank() OVER (ORDER BY counted_rows.search_score DESC, counted_rows.modified_at DESC, counted_rows.id)::bigint AS rank, counted_rows.*
+        FROM counted_rows
+      )
+      SELECT ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+      FROM ranked_rows
+      ORDER BY ranked_rows.rank, ranked_rows.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size;
+    RETURN;
+  END IF;
+END;
+$$;
+
+ALTER FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) OWNER TO "postgres";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "anon";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "authenticated";
+GRANT ALL ON FUNCTION "public"."pgroonga_search_flows_latest"(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) TO "service_role";

--- a/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(5);
+select plan(11);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -43,6 +43,8 @@ insert into public.teams (id, json, rank, is_public)
 values
   ('27000000-0000-0000-0000-000000000001', '{"name":"Latest Contact Team A"}'::jsonb, 1, false),
   ('27000000-0000-0000-0000-000000000002', '{"name":"Latest Contact Team B"}'::jsonb, 2, false);
+
+alter table public.contacts disable trigger "contacts_json_sync_trigger";
 
 insert into public.contacts (
   id,
@@ -201,6 +203,43 @@ select is(
   ),
   1::bigint,
   'search total_count counts matching UUIDs after grouping'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.pgroonga_search_contacts_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'contact latest search does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  to_regclass('public.contacts_public_json_pgroonga_idx') is not null,
+  'contact open-data latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  to_regclass('public.contacts_co_json_pgroonga_idx') is not null,
+  'contact collaborative latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_contacts_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'JOIN LATERAL') > 0,
+  'contact latest PGroonga search fetches latest versions with lateral index lookups'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_contacts_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.json &@~ query_text') > 0,
+  'contact latest PGroonga search keeps full-text matching for query_text'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_contacts_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'contact latest PGroonga search has a function-level timeout budget'
 );
 
 select * from finish();

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(37);
+select plan(45);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -52,6 +52,12 @@ grant select on latest_zero_embedding to authenticated;
 alter table public.flows disable trigger "flows_json_sync_trigger";
 alter table public.processes disable trigger "processes_json_sync_trigger";
 alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_trigger";
+alter table public.flows disable trigger "flow_extract_md_trigger_insert";
+alter table public.flows disable trigger "flow_extract_text_trigger_insert";
+alter table public.processes disable trigger "process_extract_md_trigger_insert";
+alter table public.processes disable trigger "process_extract_text_trigger_insert";
+alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
+alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
 
 insert into public.flows (
   id,
@@ -238,6 +244,12 @@ select is(
 );
 
 select is(
+  (select version::text from public.pgroonga_search_flows_latest('legacy-flow-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'my', '16000000-0000-0000-0000-000000000047') where id = '47000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'flow my-data PGroonga search can match an older version while returning the highest user-owned version'
+);
+
+select is(
   (select version::text from public.hybrid_search_flows('legacy-flow-token', (select value from latest_zero_embedding), '{}', 0.1, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) where id = '47000000-0000-0000-0000-000000000001'),
   '01.00.002',
   'flow hybrid search returns the highest visible version for a matching UUID'
@@ -285,6 +297,12 @@ select is(
   (select version::text from public.pgroonga_search_lifecyclemodels_latest('legacy-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
   '01.00.002',
   'lifecyclemodel PGroonga search can match an older version while returning the highest visible version'
+);
+
+select is(
+  (select version::text from public.pgroonga_search_lifecyclemodels_latest('legacy-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'my', '16000000-0000-0000-0000-000000000047') where id = '49000000-0000-0000-0000-000000000001'),
+  '01.00.002',
+  'lifecyclemodel my-data PGroonga search can match an older version while returning the highest user-owned version'
 );
 
 select is(
@@ -352,8 +370,18 @@ select ok(
 );
 
 select ok(
+  to_regclass('public.flows_co_json_pgroonga_idx') is not null,
+  'flow collaborative latest PGroonga search has a partial JSON index'
+);
+
+select ok(
   strpos(pg_get_functiondef('public.pgroonga_search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'JOIN LATERAL') > 0,
   'flow open-data latest PGroonga search fetches latest versions with lateral index lookups'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.json &@~ query_text') > 0,
+  'flow latest PGroonga search keeps full-text matching for query_text'
 );
 
 select ok(
@@ -384,6 +412,26 @@ select ok(
 select ok(
   to_regclass('public.lifecyclemodels_public_latest_keys_cover_idx') is not null,
   'lifecyclemodel open-data latest-version key scan has a partial covering index'
+);
+
+select ok(
+  to_regclass('public.lifecyclemodels_public_json_pgroonga_idx') is not null,
+  'lifecyclemodel open-data latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  to_regclass('public.lifecyclemodels_co_json_pgroonga_idx') is not null,
+  'lifecyclemodel collaborative latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'JOIN LATERAL') > 0,
+  'lifecyclemodel latest PGroonga search fetches latest versions with lateral index lookups'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'l.json &@~ query_text') > 0,
+  'lifecyclemodel latest PGroonga search keeps full-text matching for query_text'
 );
 
 select ok(

--- a/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(5);
+select plan(11);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -203,6 +203,43 @@ select is(
   ),
   1::bigint,
   'search total_count counts matching UUIDs after grouping'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.pgroonga_search_flowproperties_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'flow property latest search does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  to_regclass('public.flowproperties_public_json_pgroonga_idx') is not null,
+  'flow property open-data latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  to_regclass('public.flowproperties_co_json_pgroonga_idx') is not null,
+  'flow property collaborative latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_flowproperties_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'JOIN LATERAL') > 0,
+  'flow property latest PGroonga search fetches latest versions with lateral index lookups'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_flowproperties_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.json &@~ query_text') > 0,
+  'flow property latest PGroonga search keeps full-text matching for query_text'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_flowproperties_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'flow property latest PGroonga search has a function-level timeout budget'
 );
 
 select * from finish();

--- a/supabase/tests/20260520_sources_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_sources_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(5);
+select plan(11);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -43,6 +43,8 @@ insert into public.teams (id, json, rank, is_public)
 values
   ('26000000-0000-0000-0000-000000000001', '{"name":"Latest Source Team A"}'::jsonb, 1, false),
   ('26000000-0000-0000-0000-000000000002', '{"name":"Latest Source Team B"}'::jsonb, 2, false);
+
+alter table public.sources disable trigger "sources_json_sync_trigger";
 
 insert into public.sources (
   id,
@@ -201,6 +203,43 @@ select is(
   ),
   1::bigint,
   'search total_count counts matching UUIDs after grouping'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.pgroonga_search_sources_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'source latest search does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  to_regclass('public.sources_public_json_pgroonga_idx') is not null,
+  'source open-data latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  to_regclass('public.sources_co_json_pgroonga_idx') is not null,
+  'source collaborative latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_sources_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'JOIN LATERAL') > 0,
+  'source latest PGroonga search fetches latest versions with lateral index lookups'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_sources_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.json &@~ query_text') > 0,
+  'source latest PGroonga search keeps full-text matching for query_text'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_sources_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'source latest PGroonga search has a function-level timeout budget'
 );
 
 select * from finish();

--- a/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(5);
+select plan(11);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -203,6 +203,43 @@ select is(
   ),
   1::bigint,
   'search total_count counts matching UUIDs after grouping'
+);
+
+select is(
+  strpos(pg_get_functiondef('public.pgroonga_search_unitgroups_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'user_id::text = this_user_id'),
+  0,
+  'unit group latest search does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  to_regclass('public.unitgroups_public_json_pgroonga_idx') is not null,
+  'unit group open-data latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  to_regclass('public.unitgroups_co_json_pgroonga_idx') is not null,
+  'unit group collaborative latest PGroonga search has a partial JSON index'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_unitgroups_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'JOIN LATERAL') > 0,
+  'unit group latest PGroonga search fetches latest versions with lateral index lookups'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.pgroonga_search_unitgroups_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.json &@~ query_text') > 0,
+  'unit group latest PGroonga search keeps full-text matching for query_text'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_proc p
+    cross join unnest(p.proconfig) cfg
+    where p.oid = 'public.pgroonga_search_unitgroups_latest(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure
+      and cfg = 'statement_timeout=60s'
+  ),
+  'unit group latest PGroonga search has a function-level timeout budget'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes tiangong-lca/database-engine#60

## Summary
- Promote the merged dev changes from #61 to main.
- Includes process-style latest PGroonga search optimization for the remaining RPCs and related partial PGroonga indexes/tests.

## Key Decisions
- This is a dev -> main promote PR for database-engine's M2 branch model; implementation already merged into dev via #61.

## Validation
- Source PR #61 passed Gitleaks Security Scan, ai-doc-lint, and Supabase Preview before merge.
- Local validation from #61: npx -y supabase@latest db reset; affected SQL PGTAP files; migration list --local; docpact staged lint; production-like 6 x 50k row smoke.

## Risks / Rollback
- Promote risk follows #61: high-traffic search RPC definitions and PGroonga indexes. Rollback would be a follow-up migration restoring previous RPC definitions if production validation requires it.

## Follow-ups
- After this promote PR merges to main, update the lca-workspace submodule pointer for database-engine main.

## Workspace Integration
- Workspace integration remains pending until lca-workspace points at the promoted database-engine main commit.