### PR TITLE
Fix dataset extraction service-key RPC auth

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-26"
-lastReviewedCommit: "e4c1a46ab3d22d84dc860893fb06e3de319cde49"
+lastReviewedCommit: "876fe9b0b20dc192caa15ee5ba375f3e857b8f9d"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
+lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
+lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
+lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260526045934_dataset_extraction_service_request_auth.sql
+++ b/supabase/migrations/20260526045934_dataset_extraction_service_request_auth.sql
@@ -1,0 +1,273 @@
+create or replace function util.is_service_request()
+returns boolean
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_role text;
+  v_claims jsonb;
+  v_headers jsonb;
+  v_api_key text;
+  v_authorization text;
+  v_bearer_token text;
+  v_project_secret_key text;
+begin
+  v_role := nullif(current_setting('request.jwt.claim.role', true), '');
+
+  if v_role = 'service_role' then
+    return true;
+  end if;
+
+  begin
+    v_claims := nullif(current_setting('request.jwt.claims', true), '')::jsonb;
+  exception when others then
+    v_claims := null;
+  end;
+
+  if v_claims->>'role' = 'service_role' then
+    return true;
+  end if;
+
+  begin
+    v_headers := nullif(current_setting('request.headers', true), '')::jsonb;
+  exception when others then
+    v_headers := null;
+  end;
+
+  if v_headers is null then
+    return false;
+  end if;
+
+  select h.value #>> '{}'
+  into v_api_key
+  from jsonb_each(v_headers) as h(key, value)
+  where lower(h.key) = 'apikey'
+  limit 1;
+
+  select h.value #>> '{}'
+  into v_authorization
+  from jsonb_each(v_headers) as h(key, value)
+  where lower(h.key) = 'authorization'
+  limit 1;
+
+  if v_authorization ~* '^bearer[[:space:]]+' then
+    v_bearer_token := regexp_replace(v_authorization, '^bearer[[:space:]]+', '', 'i');
+  end if;
+
+  if nullif(v_api_key, '') is null and nullif(v_bearer_token, '') is null then
+    return false;
+  end if;
+
+  begin
+    v_project_secret_key := util.project_secret_key();
+  exception when others then
+    return false;
+  end;
+
+  return nullif(v_project_secret_key, '') is not null
+    and (
+      coalesce(v_api_key = v_project_secret_key, false)
+      or coalesce(v_bearer_token = v_project_secret_key, false)
+    );
+end;
+$$;
+
+alter function util.is_service_request() owner to postgres;
+revoke all on function util.is_service_request() from public;
+
+comment on function util.is_service_request() is
+  'Returns true for service-role Data API requests, including legacy JWT claim GUCs, request.jwt.claims, and branch-local project_secret_key headers.';
+
+create or replace function public.cmd_dataset_extraction_claim(
+  p_qty integer default 10,
+  p_vt_seconds integer default 300,
+  p_max_read_count integer default 5
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_qty integer;
+  v_vt_seconds integer;
+  v_max_read_count integer;
+  v_jobs jsonb := '[]'::jsonb;
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  v_qty := least(greatest(coalesce(p_qty, 10), 1), 50);
+  v_vt_seconds := least(greatest(coalesce(p_vt_seconds, 300), 1), 3600);
+  v_max_read_count := least(greatest(coalesce(p_max_read_count, 5), 1), 100);
+
+  with expired_jobs as (
+    select
+      q.msg_id,
+      q.message,
+      q.read_ct
+    from pgmq.q_dataset_extraction_jobs q
+    where q.vt <= clock_timestamp()
+      and q.read_ct >= v_max_read_count
+    order by q.msg_id
+    limit greatest(v_qty, 100)
+  ),
+  recorded_failures as (
+    insert into util.dataset_extraction_job_failures (
+      queue_name,
+      msg_id,
+      read_count,
+      reason,
+      message
+    )
+    select
+      'dataset_extraction_jobs',
+      e.msg_id,
+      e.read_ct,
+      format('read_ct reached retry cap %s', v_max_read_count),
+      e.message
+    from expired_jobs e
+    on conflict (queue_name, msg_id) do update
+    set
+      read_count = excluded.read_count,
+      reason = excluded.reason,
+      message = excluded.message,
+      created_at = now()
+    returning msg_id
+  )
+  delete from pgmq.q_dataset_extraction_jobs q
+  using recorded_failures f
+  where q.msg_id = f.msg_id;
+
+  with claimed_jobs as (
+    select *
+    from pgmq.read('dataset_extraction_jobs', v_vt_seconds, v_qty)
+  )
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'msg_id', msg_id,
+        'read_ct', read_ct,
+        'enqueued_at', enqueued_at,
+        'vt', vt,
+        'message', message
+      )
+      order by msg_id
+    ),
+    '[]'::jsonb
+  )
+  into v_jobs
+  from claimed_jobs;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_jobs
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_claim(integer, integer, integer) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_claim(integer, integer, integer) from public;
+grant execute on function public.cmd_dataset_extraction_claim(integer, integer, integer) to service_role;
+
+create or replace function public.cmd_dataset_extraction_ack(
+  p_msg_ids bigint[]
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_deleted jsonb := '[]'::jsonb;
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  if coalesce(array_length(p_msg_ids, 1), 0) = 0 then
+    return jsonb_build_object('ok', true, 'data', jsonb_build_object('deleted_msg_ids', v_deleted));
+  end if;
+
+  select coalesce(jsonb_agg(deleted_msg_id order by deleted_msg_id), '[]'::jsonb)
+  into v_deleted
+  from pgmq.delete('dataset_extraction_jobs', p_msg_ids) as deleted_msg_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object('deleted_msg_ids', v_deleted)
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_ack(bigint[]) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_ack(bigint[]) from public;
+grant execute on function public.cmd_dataset_extraction_ack(bigint[]) to service_role;
+
+create or replace function public.cmd_dataset_extraction_record_failure(
+  p_msg_id bigint,
+  p_read_count integer,
+  p_reason text,
+  p_message jsonb,
+  p_last_error text default null,
+  p_delete boolean default true
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  insert into util.dataset_extraction_job_failures (
+    queue_name,
+    msg_id,
+    read_count,
+    reason,
+    message,
+    last_error
+  )
+  values (
+    'dataset_extraction_jobs',
+    p_msg_id,
+    coalesce(p_read_count, 0),
+    coalesce(nullif(p_reason, ''), 'worker failure'),
+    coalesce(p_message, '{}'::jsonb),
+    p_last_error
+  )
+  on conflict (queue_name, msg_id) do update
+  set
+    read_count = excluded.read_count,
+    reason = excluded.reason,
+    message = excluded.message,
+    last_error = excluded.last_error,
+    created_at = now();
+
+  if coalesce(p_delete, true) then
+    perform pgmq.delete('dataset_extraction_jobs', p_msg_id);
+  end if;
+
+  return jsonb_build_object('ok', true);
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) from public;
+grant execute on function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) to service_role;

--- a/supabase/tests/20260526_dataset_extraction_jobs.sql
+++ b/supabase/tests/20260526_dataset_extraction_jobs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(19);
+select plan(24);
 
 do $$
 begin
@@ -17,6 +17,13 @@ $$;
 
 delete from pgmq.q_dataset_extraction_jobs;
 delete from util.dataset_extraction_job_failures;
+delete from vault.secrets where name = 'project_secret_key';
+
+select vault.create_secret(
+  'test-dataset-extraction-service-key',
+  'project_secret_key',
+  'pgTAP dataset extraction service auth'
+);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -271,6 +278,60 @@ select is(
   0,
   'acked dataset extraction jobs are removed from the live queue'
 );
+
+set local role service_role;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+select set_config('request.headers', '{"apikey":"wrong-service-key"}', true);
+
+select is(
+  public.cmd_dataset_extraction_claim(1, 300, 5)->>'code',
+  'SERVICE_ROLE_REQUIRED',
+  'dataset extraction RPCs reject non-service request context'
+);
+
+select set_config('request.jwt.claim.role', '', true);
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+select set_config('request.headers', '{}', true);
+
+select is(
+  public.cmd_dataset_extraction_ack(array[]::bigint[])->>'ok',
+  'true',
+  'dataset extraction RPCs accept service_role in request.jwt.claims'
+);
+
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+select set_config('request.headers', '{"apikey":"test-dataset-extraction-service-key"}', true);
+
+select is(
+  public.cmd_dataset_extraction_claim(1, 300, 5)->>'ok',
+  'true',
+  'dataset extraction RPCs accept project_secret_key apikey headers'
+);
+
+select set_config('request.headers', '{"authorization":"Bearer test-dataset-extraction-service-key"}', true);
+
+select is(
+  public.cmd_dataset_extraction_ack(array[]::bigint[])->>'ok',
+  'true',
+  'dataset extraction RPCs accept project_secret_key authorization headers'
+);
+
+select is(
+  public.cmd_dataset_extraction_record_failure(
+    999001,
+    1,
+    'service auth smoke',
+    '{"schema":"public","table":"flows"}'::jsonb,
+    'test failure',
+    false
+  )->>'ok',
+  'true',
+  'dataset extraction failure RPC accepts project_secret_key headers'
+);
+
+reset role;
+delete from util.dataset_extraction_job_failures where msg_id = 999001;
 
 select pgmq.send(
   queue_name => 'dataset_extraction_jobs',


### PR DESCRIPTION
Closes #75

## Summary
- Add util.is_service_request() so dataset extraction RPCs accept service_role claims, request.jwt.claims, and project_secret_key API headers.
- Update claim, ack, and record_failure guards to reject null/false service checks explicitly.
- Extend dataset extraction pgTAP coverage for wrong headers, request.jwt.claims, apikey headers, Authorization bearer headers, and failure recording.

## Key Decisions
- Keep execution grants service-role scoped; the compatibility change is inside the RPC guard used by the deployed Edge worker path.
- Compare Data API headers only against the branch-local Vault project_secret_key and return false if the secret is missing.

## Validation
- npx --yes supabase@2.84.2 db reset
- npx --yes supabase@2.84.2 test db supabase/tests/20260526_dataset_extraction_jobs.sql
- npx --yes supabase@2.84.2 migration list --local
- ./scripts/docpact lint --root . --files 'AGENTS.md,.docpact/config.yaml,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,supabase/migrations/20260526045934_dataset_extraction_service_request_auth.sql,supabase/tests/20260526_dataset_extraction_jobs.sql' --format json --output .docpact/runs/issue-75.json

## Risks / Rollback
- This is targeted to the compact dataset extraction RPCs; it does not alter cmd_dataset_create or existing flow triggers.

## Follow-ups
- After merge to dev, rerun the pending synthetic flow queue drain canary against process_dataset_extraction_jobs.

## Workspace Integration
- database-engine is M2; routine PR target is dev. Root main integration remains pending until promote to database-engine main.