### PR TITLE
Ensure embedding_jobs queue exists

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-26"
-lastReviewedCommit: "876fe9b0b20dc192caa15ee5ba375f3e857b8f9d"
+lastReviewedCommit: "4383dda3faed399ea6fdaca2407eb470e95ffcae"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
+lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
+lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
+lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260526051722_ensure_embedding_jobs_queue.sql
+++ b/supabase/migrations/20260526051722_ensure_embedding_jobs_queue.sql
@@ -1,0 +1,7 @@
+do $$
+begin
+  if to_regclass('pgmq.q_embedding_jobs') is null then
+    perform pgmq.create('embedding_jobs');
+  end if;
+end
+$$;

--- a/supabase/tests/20260525_embedding_backpressure_and_deferred_queue.sql
+++ b/supabase/tests/20260525_embedding_backpressure_and_deferred_queue.sql
@@ -3,7 +3,12 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(14);
+select plan(15);
+
+select ok(
+  to_regclass('pgmq.q_embedding_jobs') is not null,
+  'embedding_jobs queue exists from migration history'
+);
 
 do $$
 begin


### PR DESCRIPTION
Closes #77

## Summary
- Add an idempotent migration that creates pgmq embedding_jobs when q_embedding_jobs is missing.
- Make the embedding backpressure pgTAP test assert the queue exists from migration history before its setup guard.

## Key Decisions
- Keep the migration focused on queue existence; no trigger or policy behavior changes are included.

## Validation
- npx --yes supabase@2.84.2 db reset
- npx --yes supabase@2.84.2 test db supabase/tests/20260525_embedding_backpressure_and_deferred_queue.sql
- npx --yes supabase@2.84.2 test db supabase/tests/20260526_dataset_extraction_jobs.sql
- npx --yes supabase@2.84.2 migration list --local
- ./scripts/docpact lint --root . --files 'AGENTS.md,.docpact/config.yaml,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,supabase/migrations/20260526051722_ensure_embedding_jobs_queue.sql,supabase/tests/20260525_embedding_backpressure_and_deferred_queue.sql,supabase/tests/20260526_dataset_extraction_jobs.sql' --format json --output .docpact/runs/issue-77.json

## Risks / Rollback
- This only creates the queue when absent and is safe for branches where embedding_jobs already exists.

## Follow-ups
- After merge to dev, rerun the dataset extraction worker canary and confirm extraction writeback no longer fails with 42P01.

## Workspace Integration
- database-engine is M2; routine PR target is dev. Root main integration remains pending until promote to database-engine main.