### PR TITLE
Promote compact flow extraction database changes

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-25"
-lastReviewedCommit: "7aafd4f53095e521701dd5e260037ad2f4a329d0"
+lastReviewedAt: "2026-05-26"
+lastReviewedCommit: "e4c1a46ab3d22d84dc860893fb06e3de319cde49"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-26"
-lastReviewedCommit: "e4c1a46ab3d22d84dc860893fb06e3de319cde49"
+lastReviewedCommit: "876fe9b0b20dc192caa15ee5ba375f3e857b8f9d"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-26"
-lastReviewedCommit: "876fe9b0b20dc192caa15ee5ba375f3e857b8f9d"
+lastReviewedCommit: "4383dda3faed399ea6fdaca2407eb470e95ffcae"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
+lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
+lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7aafd4f53095e521701dd5e260037ad2f4a329d0
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
+lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7aafd4f53095e521701dd5e260037ad2f4a329d0
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
+lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
+lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 876fe9b0b20dc192caa15ee5ba375f3e857b8f9d
+lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 7aafd4f53095e521701dd5e260037ad2f4a329d0
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: e4c1a46ab3d22d84dc860893fb06e3de319cde49
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260526040702_dataset_extraction_jobs.sql
+++ b/supabase/migrations/20260526040702_dataset_extraction_jobs.sql
@@ -1,0 +1,510 @@
+do $$
+begin
+  if to_regclass('pgmq.q_dataset_extraction_jobs') is null then
+    perform pgmq.create('dataset_extraction_jobs');
+  end if;
+end
+$$;
+
+create table if not exists util.dataset_extraction_job_failures (
+  id bigserial primary key,
+  queue_name text not null default 'dataset_extraction_jobs',
+  msg_id bigint not null,
+  read_count integer not null default 0,
+  reason text not null,
+  message jsonb not null,
+  last_error text,
+  created_at timestamptz not null default now(),
+  unique (queue_name, msg_id)
+);
+
+alter table util.dataset_extraction_job_failures owner to postgres;
+
+grant select, insert, update on util.dataset_extraction_job_failures to service_role;
+grant usage, select on sequence util.dataset_extraction_job_failures_id_seq to service_role;
+
+create or replace function util.queue_dataset_extraction_jobs() returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_entity_kind text;
+  v_message_base jsonb;
+begin
+  if TG_TABLE_SCHEMA <> 'public' then
+    raise exception 'dataset extraction jobs only support public schema, got %', TG_TABLE_SCHEMA;
+  end if;
+
+  v_entity_kind := case TG_TABLE_NAME
+    when 'flows' then 'flow'
+    when 'processes' then 'process'
+    else null
+  end;
+
+  if v_entity_kind is null then
+    raise exception 'unsupported dataset extraction table %', TG_TABLE_NAME;
+  end if;
+
+  v_message_base := jsonb_build_object(
+    'schema', TG_TABLE_SCHEMA,
+    'table', TG_TABLE_NAME,
+    'id', NEW.id,
+    'version', NEW.version,
+    'entity_kind', v_entity_kind,
+    'created_at', now()
+  );
+
+  perform pgmq.send(
+    queue_name => 'dataset_extraction_jobs',
+    msg => v_message_base || jsonb_build_object('extraction_kind', 'extracted_md')
+  );
+
+  perform pgmq.send(
+    queue_name => 'dataset_extraction_jobs',
+    msg => v_message_base || jsonb_build_object('extraction_kind', 'extracted_text')
+  );
+
+  return NEW;
+end;
+$$;
+
+alter function util.queue_dataset_extraction_jobs() owner to postgres;
+
+create or replace function public.cmd_dataset_extraction_claim(
+  p_qty integer default 10,
+  p_vt_seconds integer default 300,
+  p_max_read_count integer default 5
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_qty integer;
+  v_vt_seconds integer;
+  v_max_read_count integer;
+  v_jobs jsonb := '[]'::jsonb;
+begin
+  if coalesce(current_setting('request.jwt.claim.role', true), '') <> 'service_role' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  v_qty := least(greatest(coalesce(p_qty, 10), 1), 50);
+  v_vt_seconds := least(greatest(coalesce(p_vt_seconds, 300), 1), 3600);
+  v_max_read_count := least(greatest(coalesce(p_max_read_count, 5), 1), 100);
+
+  with expired_jobs as (
+    select
+      q.msg_id,
+      q.message,
+      q.read_ct
+    from pgmq.q_dataset_extraction_jobs q
+    where q.vt <= clock_timestamp()
+      and q.read_ct >= v_max_read_count
+    order by q.msg_id
+    limit greatest(v_qty, 100)
+  ),
+  recorded_failures as (
+    insert into util.dataset_extraction_job_failures (
+      queue_name,
+      msg_id,
+      read_count,
+      reason,
+      message
+    )
+    select
+      'dataset_extraction_jobs',
+      e.msg_id,
+      e.read_ct,
+      format('read_ct reached retry cap %s', v_max_read_count),
+      e.message
+    from expired_jobs e
+    on conflict (queue_name, msg_id) do update
+    set
+      read_count = excluded.read_count,
+      reason = excluded.reason,
+      message = excluded.message,
+      created_at = now()
+    returning msg_id
+  )
+  delete from pgmq.q_dataset_extraction_jobs q
+  using recorded_failures f
+  where q.msg_id = f.msg_id;
+
+  with claimed_jobs as (
+    select *
+    from pgmq.read('dataset_extraction_jobs', v_vt_seconds, v_qty)
+  )
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'msg_id', msg_id,
+        'read_ct', read_ct,
+        'enqueued_at', enqueued_at,
+        'vt', vt,
+        'message', message
+      )
+      order by msg_id
+    ),
+    '[]'::jsonb
+  )
+  into v_jobs
+  from claimed_jobs;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_jobs
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_claim(integer, integer, integer) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_claim(integer, integer, integer) from public;
+grant execute on function public.cmd_dataset_extraction_claim(integer, integer, integer) to service_role;
+
+create or replace function public.cmd_dataset_extraction_ack(
+  p_msg_ids bigint[]
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_deleted jsonb := '[]'::jsonb;
+begin
+  if coalesce(current_setting('request.jwt.claim.role', true), '') <> 'service_role' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  if coalesce(array_length(p_msg_ids, 1), 0) = 0 then
+    return jsonb_build_object('ok', true, 'data', jsonb_build_object('deleted_msg_ids', v_deleted));
+  end if;
+
+  select coalesce(jsonb_agg(deleted_msg_id order by deleted_msg_id), '[]'::jsonb)
+  into v_deleted
+  from pgmq.delete('dataset_extraction_jobs', p_msg_ids) as deleted_msg_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object('deleted_msg_ids', v_deleted)
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_ack(bigint[]) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_ack(bigint[]) from public;
+grant execute on function public.cmd_dataset_extraction_ack(bigint[]) to service_role;
+
+create or replace function public.cmd_dataset_extraction_record_failure(
+  p_msg_id bigint,
+  p_read_count integer,
+  p_reason text,
+  p_message jsonb,
+  p_last_error text default null,
+  p_delete boolean default true
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+begin
+  if coalesce(current_setting('request.jwt.claim.role', true), '') <> 'service_role' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  insert into util.dataset_extraction_job_failures (
+    queue_name,
+    msg_id,
+    read_count,
+    reason,
+    message,
+    last_error
+  )
+  values (
+    'dataset_extraction_jobs',
+    p_msg_id,
+    coalesce(p_read_count, 0),
+    coalesce(nullif(p_reason, ''), 'worker failure'),
+    coalesce(p_message, '{}'::jsonb),
+    p_last_error
+  )
+  on conflict (queue_name, msg_id) do update
+  set
+    read_count = excluded.read_count,
+    reason = excluded.reason,
+    message = excluded.message,
+    last_error = excluded.last_error,
+    created_at = now();
+
+  if coalesce(p_delete, true) then
+    perform pgmq.delete('dataset_extraction_jobs', p_msg_id);
+  end if;
+
+  return jsonb_build_object('ok', true);
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) from public;
+grant execute on function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) to service_role;
+
+drop trigger if exists flow_extract_md_trigger_insert on public.flows;
+drop trigger if exists flow_extract_text_trigger_insert on public.flows;
+drop trigger if exists flow_dataset_extraction_trigger_insert on public.flows;
+
+create trigger flow_dataset_extraction_trigger_insert
+after insert on public.flows
+for each row
+execute function util.queue_dataset_extraction_jobs();
+
+create or replace function public.cmd_dataset_create(
+  p_table text,
+  p_id uuid,
+  p_json_ordered jsonb,
+  p_model_id uuid default null::uuid,
+  p_rule_verification boolean default null::boolean,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_created_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table = 'lifecyclemodels' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'LIFECYCLEMODEL_BUNDLE_REQUIRED',
+      'status', 400,
+      'message', 'Lifecycle models must use bundle create and delete commands'
+    );
+  end if;
+
+  if p_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table'
+    );
+  end if;
+
+  if p_json_ordered is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'JSON_ORDERED_REQUIRED',
+      'status', 400,
+      'message', 'jsonOrdered is required'
+    );
+  end if;
+
+  if p_table <> 'processes' and p_model_id is not null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'MODEL_ID_NOT_ALLOWED',
+      'status', 400,
+      'message', 'modelId is only allowed for process dataset creation'
+    );
+  end if;
+
+  if p_table = 'flows' then
+    perform set_config('lock_timeout', '2s', true);
+    perform set_config('statement_timeout', '8s', true);
+  end if;
+
+  begin
+    if p_table = 'processes' then
+      execute format(
+        'insert into public.%I as t (id, json_ordered, model_id, rule_verification)
+         values ($1, $2::json, $3, $4)
+         returning jsonb_build_object(
+           ''id'', t.id,
+           ''version'', t.version,
+           ''state_code'', t.state_code,
+           ''user_id'', t.user_id,
+           ''team_id'', t.team_id,
+           ''model_id'', t.model_id,
+           ''rule_verification'', t.rule_verification
+         )',
+        p_table
+      )
+        into v_created_row
+        using p_id, p_json_ordered, p_model_id, p_rule_verification;
+    else
+      execute format(
+        'insert into public.%I as t (id, json_ordered, rule_verification)
+         values ($1, $2::json, $3)
+         returning jsonb_build_object(
+           ''id'', t.id,
+           ''version'', t.version,
+           ''state_code'', t.state_code,
+           ''user_id'', t.user_id,
+           ''team_id'', t.team_id,
+           ''model_id'', null,
+           ''rule_verification'', t.rule_verification
+         )',
+        p_table
+      )
+        into v_created_row
+        using p_id, p_json_ordered, p_rule_verification;
+    end if;
+  exception
+    when lock_not_available then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'DATASET_CREATE_LOCK_TIMEOUT',
+        'status', 503,
+        'message', 'Dataset creation is temporarily blocked by concurrent database work'
+      );
+    when query_canceled then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'DATASET_CREATE_TIMEOUT',
+        'status', 503,
+        'message', 'Dataset creation exceeded the database timeout'
+      );
+    when unique_violation then
+      return jsonb_build_object(
+        'ok', false,
+        'code', '23505',
+        'status', 409,
+        'message', 'Dataset with the same id and version already exists'
+      );
+    when not_null_violation then
+      return jsonb_build_object(
+        'ok', false,
+        'code', '23502',
+        'status', 400,
+        'message', 'Dataset creation requires a valid id, version, and jsonOrdered payload'
+      );
+    when check_violation then
+      return jsonb_build_object(
+        'ok', false,
+        'code', sqlstate,
+        'status', 400,
+        'message', sqlerrm
+      );
+  end;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_create',
+    v_actor,
+    p_table,
+    p_id,
+    nullif(v_created_row->>'version', ''),
+    coalesce(p_audit, '{}'::jsonb)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_created_row
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) owner to postgres;
+revoke all on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) from public;
+grant execute on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) to anon;
+grant execute on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) to authenticated;
+grant execute on function public.cmd_dataset_create(text, uuid, jsonb, uuid, boolean, jsonb) to service_role;
+
+create or replace function util.process_dataset_extraction_jobs(
+  batch_size integer default 5,
+  visibility_timeout_seconds integer default 300,
+  max_read_count integer default 5,
+  timeout_milliseconds integer default ((5 * 60) * 1000)
+) returns void
+language plpgsql
+set search_path to ''
+as $$
+begin
+  if batch_size <= 0 then
+    return;
+  end if;
+
+  if not pg_try_advisory_xact_lock(hashtext('util.process_dataset_extraction_jobs')) then
+    return;
+  end if;
+
+  perform util.invoke_edge_function(
+    name => 'process_dataset_extraction_jobs',
+    body => jsonb_build_object(
+      'batchSize', least(batch_size, 50),
+      'visibilityTimeoutSeconds', least(greatest(visibility_timeout_seconds, 1), 3600),
+      'maxReadCount', least(greatest(max_read_count, 1), 100)
+    ),
+    timeout_milliseconds => timeout_milliseconds
+  );
+end;
+$$;
+
+alter function util.process_dataset_extraction_jobs(integer, integer, integer, integer) owner to postgres;
+
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    begin
+      perform cron.unschedule('process-dataset-extraction-jobs');
+    exception when others then
+      null;
+    end;
+
+    perform cron.schedule(
+      'process-dataset-extraction-jobs',
+      '* * * * *',
+      'select util.process_dataset_extraction_jobs();'
+    );
+  end if;
+end
+$$;
+
+comment on table util.dataset_extraction_job_failures is
+  'Records compact dataset extraction jobs that exceeded retry caps or were marked terminal by the Edge worker.';
+
+comment on function util.queue_dataset_extraction_jobs() is
+  'Queues compact dataset extraction jobs for asynchronous extracted_md/extracted_text generation without carrying json/json_ordered in the transaction webhook payload.';
+
+comment on function util.process_dataset_extraction_jobs(integer, integer, integer, integer) is
+  'Invokes the Edge dataset extraction worker that claims and acknowledges compact dataset extraction jobs.';

--- a/supabase/migrations/20260526045934_dataset_extraction_service_request_auth.sql
+++ b/supabase/migrations/20260526045934_dataset_extraction_service_request_auth.sql
@@ -1,0 +1,273 @@
+create or replace function util.is_service_request()
+returns boolean
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_role text;
+  v_claims jsonb;
+  v_headers jsonb;
+  v_api_key text;
+  v_authorization text;
+  v_bearer_token text;
+  v_project_secret_key text;
+begin
+  v_role := nullif(current_setting('request.jwt.claim.role', true), '');
+
+  if v_role = 'service_role' then
+    return true;
+  end if;
+
+  begin
+    v_claims := nullif(current_setting('request.jwt.claims', true), '')::jsonb;
+  exception when others then
+    v_claims := null;
+  end;
+
+  if v_claims->>'role' = 'service_role' then
+    return true;
+  end if;
+
+  begin
+    v_headers := nullif(current_setting('request.headers', true), '')::jsonb;
+  exception when others then
+    v_headers := null;
+  end;
+
+  if v_headers is null then
+    return false;
+  end if;
+
+  select h.value #>> '{}'
+  into v_api_key
+  from jsonb_each(v_headers) as h(key, value)
+  where lower(h.key) = 'apikey'
+  limit 1;
+
+  select h.value #>> '{}'
+  into v_authorization
+  from jsonb_each(v_headers) as h(key, value)
+  where lower(h.key) = 'authorization'
+  limit 1;
+
+  if v_authorization ~* '^bearer[[:space:]]+' then
+    v_bearer_token := regexp_replace(v_authorization, '^bearer[[:space:]]+', '', 'i');
+  end if;
+
+  if nullif(v_api_key, '') is null and nullif(v_bearer_token, '') is null then
+    return false;
+  end if;
+
+  begin
+    v_project_secret_key := util.project_secret_key();
+  exception when others then
+    return false;
+  end;
+
+  return nullif(v_project_secret_key, '') is not null
+    and (
+      coalesce(v_api_key = v_project_secret_key, false)
+      or coalesce(v_bearer_token = v_project_secret_key, false)
+    );
+end;
+$$;
+
+alter function util.is_service_request() owner to postgres;
+revoke all on function util.is_service_request() from public;
+
+comment on function util.is_service_request() is
+  'Returns true for service-role Data API requests, including legacy JWT claim GUCs, request.jwt.claims, and branch-local project_secret_key headers.';
+
+create or replace function public.cmd_dataset_extraction_claim(
+  p_qty integer default 10,
+  p_vt_seconds integer default 300,
+  p_max_read_count integer default 5
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_qty integer;
+  v_vt_seconds integer;
+  v_max_read_count integer;
+  v_jobs jsonb := '[]'::jsonb;
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  v_qty := least(greatest(coalesce(p_qty, 10), 1), 50);
+  v_vt_seconds := least(greatest(coalesce(p_vt_seconds, 300), 1), 3600);
+  v_max_read_count := least(greatest(coalesce(p_max_read_count, 5), 1), 100);
+
+  with expired_jobs as (
+    select
+      q.msg_id,
+      q.message,
+      q.read_ct
+    from pgmq.q_dataset_extraction_jobs q
+    where q.vt <= clock_timestamp()
+      and q.read_ct >= v_max_read_count
+    order by q.msg_id
+    limit greatest(v_qty, 100)
+  ),
+  recorded_failures as (
+    insert into util.dataset_extraction_job_failures (
+      queue_name,
+      msg_id,
+      read_count,
+      reason,
+      message
+    )
+    select
+      'dataset_extraction_jobs',
+      e.msg_id,
+      e.read_ct,
+      format('read_ct reached retry cap %s', v_max_read_count),
+      e.message
+    from expired_jobs e
+    on conflict (queue_name, msg_id) do update
+    set
+      read_count = excluded.read_count,
+      reason = excluded.reason,
+      message = excluded.message,
+      created_at = now()
+    returning msg_id
+  )
+  delete from pgmq.q_dataset_extraction_jobs q
+  using recorded_failures f
+  where q.msg_id = f.msg_id;
+
+  with claimed_jobs as (
+    select *
+    from pgmq.read('dataset_extraction_jobs', v_vt_seconds, v_qty)
+  )
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'msg_id', msg_id,
+        'read_ct', read_ct,
+        'enqueued_at', enqueued_at,
+        'vt', vt,
+        'message', message
+      )
+      order by msg_id
+    ),
+    '[]'::jsonb
+  )
+  into v_jobs
+  from claimed_jobs;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_jobs
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_claim(integer, integer, integer) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_claim(integer, integer, integer) from public;
+grant execute on function public.cmd_dataset_extraction_claim(integer, integer, integer) to service_role;
+
+create or replace function public.cmd_dataset_extraction_ack(
+  p_msg_ids bigint[]
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_deleted jsonb := '[]'::jsonb;
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  if coalesce(array_length(p_msg_ids, 1), 0) = 0 then
+    return jsonb_build_object('ok', true, 'data', jsonb_build_object('deleted_msg_ids', v_deleted));
+  end if;
+
+  select coalesce(jsonb_agg(deleted_msg_id order by deleted_msg_id), '[]'::jsonb)
+  into v_deleted
+  from pgmq.delete('dataset_extraction_jobs', p_msg_ids) as deleted_msg_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object('deleted_msg_ids', v_deleted)
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_ack(bigint[]) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_ack(bigint[]) from public;
+grant execute on function public.cmd_dataset_extraction_ack(bigint[]) to service_role;
+
+create or replace function public.cmd_dataset_extraction_record_failure(
+  p_msg_id bigint,
+  p_read_count integer,
+  p_reason text,
+  p_message jsonb,
+  p_last_error text default null,
+  p_delete boolean default true
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required'
+    );
+  end if;
+
+  insert into util.dataset_extraction_job_failures (
+    queue_name,
+    msg_id,
+    read_count,
+    reason,
+    message,
+    last_error
+  )
+  values (
+    'dataset_extraction_jobs',
+    p_msg_id,
+    coalesce(p_read_count, 0),
+    coalesce(nullif(p_reason, ''), 'worker failure'),
+    coalesce(p_message, '{}'::jsonb),
+    p_last_error
+  )
+  on conflict (queue_name, msg_id) do update
+  set
+    read_count = excluded.read_count,
+    reason = excluded.reason,
+    message = excluded.message,
+    last_error = excluded.last_error,
+    created_at = now();
+
+  if coalesce(p_delete, true) then
+    perform pgmq.delete('dataset_extraction_jobs', p_msg_id);
+  end if;
+
+  return jsonb_build_object('ok', true);
+end;
+$$;
+
+alter function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) owner to postgres;
+revoke all on function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) from public;
+grant execute on function public.cmd_dataset_extraction_record_failure(bigint, integer, text, jsonb, text, boolean) to service_role;

--- a/supabase/migrations/20260526051722_ensure_embedding_jobs_queue.sql
+++ b/supabase/migrations/20260526051722_ensure_embedding_jobs_queue.sql
@@ -1,0 +1,7 @@
+do $$
+begin
+  if to_regclass('pgmq.q_embedding_jobs') is null then
+    perform pgmq.create('embedding_jobs');
+  end if;
+end
+$$;

--- a/supabase/tests/20260404_review_submit_rpc.sql
+++ b/supabase/tests/20260404_review_submit_rpc.sql
@@ -81,8 +81,33 @@ alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_tr
 
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
 alter table public.processes disable trigger "process_extract_text_trigger_insert";
-alter table public.flows disable trigger "flow_extract_md_trigger_insert";
-alter table public.flows disable trigger "flow_extract_text_trigger_insert";
+do $$
+begin
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_extract_md_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_extract_md_trigger_insert";
+  end if;
+
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_extract_text_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_extract_text_trigger_insert";
+  end if;
+
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_dataset_extraction_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_dataset_extraction_trigger_insert";
+  end if;
+end
+$$;
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
 alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
 

--- a/supabase/tests/20260405_dataset_create_delete_rpcs.sql
+++ b/supabase/tests/20260405_dataset_create_delete_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(9);
+select plan(12);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -152,6 +152,106 @@ select is(
     'rule_verification', false
   )::text,
   'cmd_dataset_create persists version, owner, and rule_verification'
+);
+
+select is(
+  public.cmd_dataset_create(
+    'sources',
+    '94000000-0000-0000-0000-000000000010',
+    '{
+      "sourceDataSet": {
+        "sourceInformation": {
+          "dataSetInformation": {
+            "common:shortName": [
+              {
+                "@xml:lang": "en",
+                "#text": "created-source"
+              }
+            ]
+          }
+        }
+      }
+    }'::jsonb,
+    null,
+    true,
+    '{"command":"dataset_create"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can create a source dataset through cmd_dataset_create'
+);
+
+select is(
+  public.cmd_dataset_create(
+    'unitgroups',
+    '94000000-0000-0000-0000-000000000011',
+    '{
+      "unitGroupDataSet": {
+        "unitGroupInformation": {
+          "dataSetInformation": {
+            "common:name": [
+              {
+                "@xml:lang": "en",
+                "#text": "created-unit-group"
+              }
+            ]
+          },
+          "quantitativeReference": {
+            "referenceToReferenceUnit": "u1"
+          }
+        },
+        "units": {
+          "unit": [
+            {
+              "@dataSetInternalID": "u1",
+              "name": "kg"
+            }
+          ]
+        }
+      }
+    }'::jsonb,
+    null,
+    true,
+    '{"command":"dataset_create"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can create a unit group dataset through cmd_dataset_create'
+);
+
+select is(
+  public.cmd_dataset_create(
+    'flowproperties',
+    '94000000-0000-0000-0000-000000000012',
+    '{
+      "flowPropertyDataSet": {
+        "flowPropertiesInformation": {
+          "dataSetInformation": {
+            "common:name": [
+              {
+                "@xml:lang": "en",
+                "#text": "created-flow-property"
+              }
+            ]
+          },
+          "quantitativeReference": {
+            "referenceToReferenceUnitGroup": "u1"
+          }
+        },
+        "units": {
+          "unit": [
+            {
+              "@dataSetInternalID": "u1",
+              "name": "kg"
+            }
+          ]
+        }
+      }
+    }'::jsonb,
+    null,
+    true,
+    '{"command":"dataset_create"}'::jsonb
+  )->>'ok',
+  'true',
+  'dataset owner can create a flow property dataset through cmd_dataset_create'
 );
 
 select is(

--- a/supabase/tests/20260405_review_workflow_rpcs.sql
+++ b/supabase/tests/20260405_review_workflow_rpcs.sql
@@ -123,9 +123,34 @@ alter table public.processes disable trigger "process_extract_md_trigger_insert"
 alter table public.processes disable trigger "process_extract_md_trigger_update";
 alter table public.processes disable trigger "process_extract_text_trigger_insert";
 alter table public.processes disable trigger "process_extract_text_trigger_update";
-alter table public.flows disable trigger "flow_extract_md_trigger_insert";
+do $$
+begin
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_extract_md_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_extract_md_trigger_insert";
+  end if;
+
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_extract_text_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_extract_text_trigger_insert";
+  end if;
+
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_dataset_extraction_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_dataset_extraction_trigger_insert";
+  end if;
+end
+$$;
 alter table public.flows disable trigger "flow_extract_md_trigger_update";
-alter table public.flows disable trigger "flow_extract_text_trigger_insert";
 alter table public.flows disable trigger "flow_extract_text_trigger_update";
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_update";

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -52,8 +52,33 @@ grant select on latest_zero_embedding to authenticated;
 alter table public.flows disable trigger "flows_json_sync_trigger";
 alter table public.processes disable trigger "processes_json_sync_trigger";
 alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_trigger";
-alter table public.flows disable trigger "flow_extract_md_trigger_insert";
-alter table public.flows disable trigger "flow_extract_text_trigger_insert";
+do $$
+begin
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_extract_md_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_extract_md_trigger_insert";
+  end if;
+
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_extract_text_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_extract_text_trigger_insert";
+  end if;
+
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_dataset_extraction_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_dataset_extraction_trigger_insert";
+  end if;
+end
+$$;
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
 alter table public.processes disable trigger "process_extract_text_trigger_insert";
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";

--- a/supabase/tests/20260525_embedding_backpressure_and_deferred_queue.sql
+++ b/supabase/tests/20260525_embedding_backpressure_and_deferred_queue.sql
@@ -3,7 +3,12 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(14);
+select plan(15);
+
+select ok(
+  to_regclass('pgmq.q_embedding_jobs') is not null,
+  'embedding_jobs queue exists from migration history'
+);
 
 do $$
 begin

--- a/supabase/tests/20260526_dataset_extraction_jobs.sql
+++ b/supabase/tests/20260526_dataset_extraction_jobs.sql
@@ -1,0 +1,318 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(19);
+
+do $$
+begin
+  perform pgmq.create('dataset_extraction_jobs');
+exception when others then
+  if to_regclass('pgmq.q_dataset_extraction_jobs') is null then
+    raise;
+  end if;
+end
+$$;
+
+delete from pgmq.q_dataset_extraction_jobs;
+delete from util.dataset_extraction_job_failures;
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  '96000000-0000-0000-0000-000000000001',
+  'authenticated',
+  'authenticated',
+  'dataset-extraction-owner@example.com',
+  'test-password-hash',
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"sub":"96000000-0000-0000-0000-000000000001","email":"dataset-extraction-owner@example.com"}'::jsonb,
+  now(),
+  now(),
+  false,
+  false
+);
+
+insert into public.users (id, raw_user_meta_data, contact)
+values (
+  '96000000-0000-0000-0000-000000000001',
+  '{"email":"dataset-extraction-owner@example.com"}'::jsonb,
+  null
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '96000000-0000-0000-0000-000000000001', true);
+
+create temporary table dataset_create_results (
+  result jsonb not null
+) on commit drop;
+
+insert into dataset_create_results (result)
+select public.cmd_dataset_create(
+  'flows',
+  '97000000-0000-0000-0000-000000000001',
+  '{
+    "flowDataSet": {
+      "flowInformation": {
+        "dataSetInformation": {
+          "common:UUID": "97000000-0000-0000-0000-000000000001",
+          "name": {
+            "baseName": [
+              {
+                "@xml:lang": "en",
+                "#text": "Dataset extraction test flow"
+              }
+            ]
+          }
+        }
+      },
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::jsonb,
+  null,
+  true,
+  '{"command":"dataset_create"}'::jsonb
+);
+
+select is(
+  (select result->>'ok' from dataset_create_results),
+  'true',
+  'flow cmd_dataset_create succeeds with compact extraction trigger'
+);
+
+select is(
+  (select result->'data'->>'version' from dataset_create_results),
+  '01.00.000',
+  'minimal create result preserves version'
+);
+
+select is(
+  (select result->'data'->>'rule_verification' from dataset_create_results),
+  'true',
+  'minimal create result preserves rule_verification'
+);
+
+select ok(
+  (select result->'data' ? 'id' from dataset_create_results)
+    and (select result->'data' ? 'state_code' from dataset_create_results)
+    and (select result->'data' ? 'user_id' from dataset_create_results)
+    and (select result->'data' ? 'team_id' from dataset_create_results)
+    and (select result->'data' ? 'model_id' from dataset_create_results),
+  'minimal create result exposes the stable create contract keys'
+);
+
+select ok(
+  not (select result->'data' ? 'json' from dataset_create_results)
+    and not (select result->'data' ? 'json_ordered' from dataset_create_results)
+    and not (select result->'data' ? 'embedding_ft' from dataset_create_results)
+    and not (select result->'data' ? 'extracted_md' from dataset_create_results)
+    and not (select result->'data' ? 'extracted_text' from dataset_create_results),
+  'minimal create result does not include heavy json or derived embedding fields'
+);
+
+reset role;
+
+select is(
+  (
+    select count(*)::integer
+    from pgmq.q_dataset_extraction_jobs
+  ),
+  2,
+  'flow create enqueues two dataset extraction jobs'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pgmq.q_dataset_extraction_jobs
+    where message ? 'json'
+       or message ? 'json_ordered'
+       or message ? 'embedding'
+       or message ? 'embedding_ft'
+  ),
+  0,
+  'dataset extraction jobs do not carry json/json_ordered or embedding payloads'
+);
+
+select is(
+  (
+    select string_agg(message->>'extraction_kind', ',' order by message->>'extraction_kind')
+    from pgmq.q_dataset_extraction_jobs
+  ),
+  'extracted_md,extracted_text',
+  'flow create enqueues extracted_md and extracted_text jobs'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pgmq.q_dataset_extraction_jobs
+    where message @> jsonb_build_object(
+      'schema', 'public',
+      'table', 'flows',
+      'id', '97000000-0000-0000-0000-000000000001',
+      'version', '01.00.000',
+      'entity_kind', 'flow'
+    )
+  ),
+  2,
+  'dataset extraction jobs use compact flow identity payloads'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname in ('flow_extract_md_trigger_insert', 'flow_extract_text_trigger_insert')
+      and not tgisinternal
+  ),
+  0,
+  'old flow INSERT webhook triggers are removed'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname in ('flow_extract_md_trigger_update', 'flow_extract_text_trigger_update')
+      and not tgisinternal
+  ),
+  2,
+  'flow UPDATE extraction triggers remain unchanged in v1'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where tgrelid = 'public.processes'::regclass
+      and tgname in ('process_extract_md_trigger_insert', 'process_extract_text_trigger_insert')
+      and not tgisinternal
+  ),
+  2,
+  'process INSERT webhook triggers remain for the tracked follow-up'
+);
+
+reset role;
+set local role service_role;
+select set_config('request.jwt.claim.role', 'service_role', true);
+
+create temporary table claimed_dataset_extraction_jobs (
+  result jsonb not null
+) on commit drop;
+
+insert into claimed_dataset_extraction_jobs (result)
+select public.cmd_dataset_extraction_claim(10, 300, 5);
+
+select is(
+  (select result->>'ok' from claimed_dataset_extraction_jobs),
+  'true',
+  'service role can claim dataset extraction jobs'
+);
+
+select is(
+  (select jsonb_array_length(result->'data') from claimed_dataset_extraction_jobs),
+  2,
+  'claim returns both queued flow extraction jobs'
+);
+
+select ok(
+  (
+    select bool_and(
+      not ((job->'message') ? 'json')
+      and not ((job->'message') ? 'json_ordered')
+    )
+    from claimed_dataset_extraction_jobs,
+      lateral jsonb_array_elements(result->'data') as job
+  ),
+  'claimed jobs stay compact'
+);
+
+select is(
+  (
+    select public.cmd_dataset_extraction_ack(
+      array_agg((job->>'msg_id')::bigint order by (job->>'msg_id')::bigint)
+    )->>'ok'
+    from claimed_dataset_extraction_jobs,
+      lateral jsonb_array_elements(result->'data') as job
+  ),
+  'true',
+  'service role can ack claimed dataset extraction jobs'
+);
+
+reset role;
+
+select is(
+  (select count(*)::integer from pgmq.q_dataset_extraction_jobs),
+  0,
+  'acked dataset extraction jobs are removed from the live queue'
+);
+
+select pgmq.send(
+  queue_name => 'dataset_extraction_jobs',
+  msg => jsonb_build_object(
+    'schema', 'public',
+    'table', 'flows',
+    'id', '97000000-0000-0000-0000-000000000002',
+    'version', '01.00.000',
+    'entity_kind', 'flow',
+    'extraction_kind', 'extracted_md',
+    'created_at', now()
+  )
+);
+
+update pgmq.q_dataset_extraction_jobs
+set
+  read_ct = 5,
+  vt = clock_timestamp() - interval '1 second';
+
+set local role service_role;
+select set_config('request.jwt.claim.role', 'service_role', true);
+
+do $$
+begin
+  perform public.cmd_dataset_extraction_claim(10, 300, 5);
+end
+$$;
+
+reset role;
+
+select is(
+  (select count(*)::integer from util.dataset_extraction_job_failures),
+  1,
+  'retry-capped dataset extraction jobs are recorded as failures'
+);
+
+select is(
+  (select count(*)::integer from pgmq.q_dataset_extraction_jobs),
+  0,
+  'retry-capped dataset extraction jobs are removed from the live queue'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260526_dataset_extraction_jobs.sql
+++ b/supabase/tests/20260526_dataset_extraction_jobs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(19);
+select plan(24);
 
 do $$
 begin
@@ -17,6 +17,13 @@ $$;
 
 delete from pgmq.q_dataset_extraction_jobs;
 delete from util.dataset_extraction_job_failures;
+delete from vault.secrets where name = 'project_secret_key';
+
+select vault.create_secret(
+  'test-dataset-extraction-service-key',
+  'project_secret_key',
+  'pgTAP dataset extraction service auth'
+);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -271,6 +278,60 @@ select is(
   0,
   'acked dataset extraction jobs are removed from the live queue'
 );
+
+set local role service_role;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+select set_config('request.headers', '{"apikey":"wrong-service-key"}', true);
+
+select is(
+  public.cmd_dataset_extraction_claim(1, 300, 5)->>'code',
+  'SERVICE_ROLE_REQUIRED',
+  'dataset extraction RPCs reject non-service request context'
+);
+
+select set_config('request.jwt.claim.role', '', true);
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+select set_config('request.headers', '{}', true);
+
+select is(
+  public.cmd_dataset_extraction_ack(array[]::bigint[])->>'ok',
+  'true',
+  'dataset extraction RPCs accept service_role in request.jwt.claims'
+);
+
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+select set_config('request.headers', '{"apikey":"test-dataset-extraction-service-key"}', true);
+
+select is(
+  public.cmd_dataset_extraction_claim(1, 300, 5)->>'ok',
+  'true',
+  'dataset extraction RPCs accept project_secret_key apikey headers'
+);
+
+select set_config('request.headers', '{"authorization":"Bearer test-dataset-extraction-service-key"}', true);
+
+select is(
+  public.cmd_dataset_extraction_ack(array[]::bigint[])->>'ok',
+  'true',
+  'dataset extraction RPCs accept project_secret_key authorization headers'
+);
+
+select is(
+  public.cmd_dataset_extraction_record_failure(
+    999001,
+    1,
+    'service auth smoke',
+    '{"schema":"public","table":"flows"}'::jsonb,
+    'test failure',
+    false
+  )->>'ok',
+  'true',
+  'dataset extraction failure RPC accepts project_secret_key headers'
+);
+
+reset role;
+delete from util.dataset_extraction_job_failures where msg_id = 999001;
 
 select pgmq.send(
   queue_name => 'dataset_extraction_jobs',


### PR DESCRIPTION
## Summary
- Promote the compact flow extraction database changes from `dev` to `main`.
- Includes compact `dataset_extraction_jobs`, service-key-compatible extraction RPC guards, and idempotent `embedding_jobs` queue creation.
- Carries the pgTAP coverage added on the dev PRs.

## Delivered dev PRs
- Closes #72
- Closes #75
- Closes #77
- Promotes #74, #76, and #78.
- Refs tiangong-lca/workspace#160.

## Validation
- Dev PR validation already passed: `supabase db reset`, targeted pgTAP files, docpact lint, Supabase Preview, and Supabase Dev workflows.
- Dev remote canary passed: compact flow jobs drained with `claimed:2`, `acked:2`, `extracted_md` and `extracted_text` written back, and `dataset_extraction_jobs` drained to 0.
- This PR should receive fresh main-target Supabase Preview / repo checks before merge.

## Risk / Rollback
- This is a promote merge from `dev` to `main`; no new implementation edits were made on the promote branch.
- Root workspace integration is still pending after child main promotion.
