### PR TITLE
Remove full flow JSON PGroonga index

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-26"
-lastReviewedCommit: "4383dda3faed399ea6fdaca2407eb470e95ffcae"
+lastReviewedCommit: "6170aed2347de6a69473947c8eed97419539f19d"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
+lastReviewedCommit: 6170aed2347de6a69473947c8eed97419539f19d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
+lastReviewedCommit: 6170aed2347de6a69473947c8eed97419539f19d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 4383dda3faed399ea6fdaca2407eb470e95ffcae
+lastReviewedCommit: 6170aed2347de6a69473947c8eed97419539f19d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260526071025_drop_flows_json_pgroonga.sql
+++ b/supabase/migrations/20260526071025_drop_flows_json_pgroonga.sql
@@ -1,0 +1,1 @@
+drop index concurrently if exists public.flows_json_pgroonga;

--- a/supabase/tests/20260526_drop_flows_json_pgroonga.sql
+++ b/supabase/tests/20260526_drop_flows_json_pgroonga.sql
@@ -1,0 +1,59 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(6);
+
+select ok(
+  to_regclass('public.flows_json_pgroonga') is null,
+  'flow full-table JSON PGroonga index is removed from the create write path'
+);
+
+select ok(
+  to_regclass('public.flows_public_json_pgroonga_idx') is not null,
+  'flow open-data latest search keeps the state_code=100 partial JSON PGroonga index'
+);
+
+select ok(
+  to_regclass('public.flows_co_json_pgroonga_idx') is not null,
+  'flow collaborative latest search keeps the state_code=200 partial JSON PGroonga index'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_dataset_extraction_trigger_insert'
+      and not tgisinternal
+  ),
+  'flow insert still queues compact dataset extraction jobs'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname in ('flow_extract_md_trigger_insert', 'flow_extract_text_trigger_insert')
+      and not tgisinternal
+  ),
+  'legacy full-row flow insert webhook triggers remain removed'
+);
+
+select is(
+  (
+    select count(*)
+    from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname in ('flow_extract_md_trigger_update', 'flow_extract_text_trigger_update')
+      and not tgisinternal
+  ),
+  2::bigint,
+  'flow json update extraction triggers remain unchanged for the non-insert path'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary

- Drop `public.flows_json_pgroonga` so INSERT no longer maintains the full-row JSON PGroonga index.
- Keep the narrower latest-search PGroonga indexes: `flows_public_json_pgroonga_idx` and `flows_co_json_pgroonga_idx`.
- Add a SQL regression test that locks the trigger boundary: compact INSERT extraction trigger remains, legacy INSERT webhook triggers remain absent, UPDATE extraction triggers remain unchanged.

## Production Observation

This was first applied directly on production with `DROP INDEX CONCURRENTLY IF EXISTS public.flows_json_pgroonga` for observation. After removal, a synthetic `cmd_dataset_create('flows', ...)` create returned in 19 ms for flow `fd2c76d2-57f8-4743-8a5a-11ebbe772cbf`, enqueued 2 compact dataset extraction jobs, and the worker drained both jobs successfully. No dataset extraction failures or long-running create sessions were observed for that smoke flow.

## Trigger Decision

No additional trigger removal is part of this PR. The create blocker was the full JSON PGroonga index maintenance. `flow_dataset_extraction_trigger_insert` stays because it only enqueues compact jobs and was verified in the smoke. The old full-row INSERT webhook triggers are already gone. The flow UPDATE extraction triggers remain for a separate follow-up because they are not on the INSERT create path.

## Validation

- `supabase db reset`
- `supabase test db supabase/tests/20260526_drop_flows_json_pgroonga.sql --local`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -X -f supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -X -f supabase/tests/20260526_dataset_extraction_jobs.sql`
- `scripts/docpact lint --root . --files AGENTS.md,.docpact/config.yaml,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,supabase/migrations/20260526071025_drop_flows_json_pgroonga.sql,supabase/tests/20260526_drop_flows_json_pgroonga.sql --format json`

## Rollback

If a critical query regression appears, recreate `public.flows_json_pgroonga` concurrently. The retained partial indexes cover the known latest public/collaborative search paths and are not removed here.

Closes #80
Refs #67
Refs tiangong-lca/workspace#160