### PR TITLE
fix: batch dataset extracted text backfill

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "8ac4eabf01724c2020fbb90c4829f9cf6e8db585"
+lastReviewedCommit: "15731c8158aa7a5c26ec60aaf5039b09267f201c"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "349117a01a90b53b925dc5e882be89e369cf657f"
+lastReviewedCommit: "8ac4eabf01724c2020fbb90c4829f9cf6e8db585"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
+lastReviewedCommit: 24c149a4f70596fc1cde7cc2979e02676d55b2d1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
+lastReviewedCommit: 8ac4eabf01724c2020fbb90c4829f9cf6e8db585
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 8ac4eabf01724c2020fbb90c4829f9cf6e8db585
+lastReviewedCommit: 15731c8158aa7a5c26ec60aaf5039b09267f201c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 8ac4eabf01724c2020fbb90c4829f9cf6e8db585
+lastReviewedCommit: 15731c8158aa7a5c26ec60aaf5039b09267f201c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
+lastReviewedCommit: 8ac4eabf01724c2020fbb90c4829f9cf6e8db585
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260527071703_dataset_extracted_text_contract.sql
+++ b/supabase/migrations/20260527071703_dataset_extracted_text_contract.sql
@@ -123,40 +123,89 @@ $$;
 
 alter function util.queue_dataset_extraction_jobs() owner to postgres;
 
-update public.flows as f
-   set extracted_text = util.dataset_json_search_text(f.json)
- where f.json is not null
-   and f.extracted_text is distinct from util.dataset_json_search_text(f.json);
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
 
-update public.processes as p
-   set extracted_text = util.dataset_json_search_text(p.json)
- where p.json is not null
-   and p.extracted_text is distinct from util.dataset_json_search_text(p.json);
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%I
+         where json is not null
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      updated as (
+        update public.%I as dataset
+           set extracted_text = util.dataset_json_search_text(dataset.json)
+          from page
+         where dataset.id = page.id
+           and dataset.version = page.version
+           and dataset.extracted_text is distinct from util.dataset_json_search_text(dataset.json)
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
 
-update public.lifecyclemodels as lm
-   set extracted_text = util.dataset_json_search_text(lm.json)
- where lm.json is not null
-   and lm.extracted_text is distinct from util.dataset_json_search_text(lm.json);
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
 
-update public.contacts as c
-   set extracted_text = util.dataset_json_search_text(c.json)
- where c.json is not null
-   and c.extracted_text is distinct from util.dataset_json_search_text(c.json);
-
-update public.sources as s
-   set extracted_text = util.dataset_json_search_text(s.json)
- where s.json is not null
-   and s.extracted_text is distinct from util.dataset_json_search_text(s.json);
-
-update public.unitgroups as u
-   set extracted_text = util.dataset_json_search_text(u.json)
- where u.json is not null
-   and u.extracted_text is distinct from util.dataset_json_search_text(u.json);
-
-update public.flowproperties as fp
-   set extracted_text = util.dataset_json_search_text(fp.json)
- where fp.json is not null
-   and fp.extracted_text is distinct from util.dataset_json_search_text(fp.json);
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) to service_role;
 
 comment on function util.dataset_json_search_text(jsonb) is
   'Builds deterministic dataset full-text search input from every scalar JSON value, preserving all authored languages without LLM summarization.';
@@ -166,3 +215,6 @@ comment on function util.set_dataset_extracted_text_from_json() is
 
 comment on function util.queue_dataset_extraction_jobs() is
   'Queues compact dataset extraction jobs for asynchronous extracted_md generation without carrying json/json_ordered in the transaction payload.';
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. Call repeatedly with the returned cursor; migrations must not run full-table backfills synchronously.';

--- a/supabase/tests/20260527_dataset_extracted_text_contract.sql
+++ b/supabase/tests/20260527_dataset_extracted_text_contract.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(16);
+select plan(18);
 
 select ok(
   util.dataset_json_search_text(
@@ -110,6 +110,13 @@ select ok(
   strpos(pg_get_functiondef('util.queue_dataset_extraction_jobs()'::regprocedure), '''extracted_md''') > 0
     and strpos(pg_get_functiondef('util.queue_dataset_extraction_jobs()'::regprocedure), '''extracted_text''') = 0,
   'dataset extraction queue only enqueues markdown extraction jobs'
+);
+
+select ok(
+  has_function_privilege('service_role', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute')
+    and not has_function_privilege('authenticated', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute')
+    and not has_function_privilege('anon', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute'),
+  'dataset extracted_text historical backfill RPC is service-role only'
 );
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -329,6 +336,48 @@ select ok(
     where id = '99000000-0000-0000-0000-000000000088'
   ),
   'lifecyclemodel extracted_text trigger preserves all authored languages'
+);
+
+update public.flows
+   set extracted_text = 'stale extracted text'
+ where id = '97000000-0000-0000-0000-000000000088';
+
+do $$
+declare
+  v_payload jsonb;
+  v_after_id uuid;
+  v_after_version text;
+begin
+  for i in 1..20 loop
+    v_payload := public.cmd_dataset_extracted_text_backfill(
+      'flows',
+      5000,
+      v_after_id,
+      v_after_version
+    );
+    v_after_id := (v_payload->>'last_id')::uuid;
+    v_after_version := v_payload->>'last_version';
+
+    exit when coalesce((v_payload->>'has_more')::boolean, false) is false
+      or exists (
+        select 1
+        from public.flows
+        where id = '97000000-0000-0000-0000-000000000088'
+          and extracted_text ~ '交流电'
+          and extracted_text ~ 'electricity'
+          and extracted_text ~ 'Wechselstrom'
+      );
+  end loop;
+end
+$$;
+
+select ok(
+  (select extracted_text ~ '交流电'
+      and extracted_text ~ 'electricity'
+      and extracted_text ~ 'Wechselstrom'
+   from public.flows
+   where id = '97000000-0000-0000-0000-000000000088'),
+  'dataset extracted_text backfill RPC repairs stale rows in bounded batches'
 );
 
 set local role authenticated;


### PR DESCRIPTION
Closes #88

## Summary
- Remove synchronous full-table `extracted_text` backfill from `20260527071703_dataset_extracted_text_contract.sql` so `supabase db push` no longer times out on large `flows` data.
- Add service-role-only `public.cmd_dataset_extracted_text_backfill(...)` for bounded historical repair using `(id, version)` cursor pagination.
- Preserve the extracted_text contract: deterministic JSON scalar text, including every authored language/value, not only Chinese and English.

## Validation
- `supabase db reset`
- `supabase test db supabase/tests/20260527_dataset_extracted_text_contract.sql supabase/tests/20260526_dataset_extraction_jobs.sql supabase/tests/20260526_drop_flows_json_pgroonga.sql --local`
- `supabase test db --local`
- `scripts/docpact lint --root . --base origin/dev --head HEAD --mode enforce`

## Rollout notes
- This fixes the failed dev migration deployment from PR #89, where the workflow hit `SQLSTATE 57014` on a synchronous `public.flows` full-table update.
- Historical rows should be backfilled after deployment by repeatedly calling the bounded RPC with the returned cursor.
