### PR TITLE
fix: tune dataset extracted text backfill

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "15731c8158aa7a5c26ec60aaf5039b09267f201c"
+lastReviewedCommit: "946d342d43fb938254eebd327f73180a5ab5f72f"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 24c149a4f70596fc1cde7cc2979e02676d55b2d1
+lastReviewedCommit: 5270e2ab14750122337a641b4638bc2505b43760
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 15731c8158aa7a5c26ec60aaf5039b09267f201c
+lastReviewedCommit: 946d342d43fb938254eebd327f73180a5ab5f72f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 15731c8158aa7a5c26ec60aaf5039b09267f201c
+lastReviewedCommit: 946d342d43fb938254eebd327f73180a5ab5f72f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260527080720_tune_dataset_extracted_text_backfill_rpc.sql
+++ b/supabase/migrations/20260527080720_tune_dataset_extracted_text_backfill_rpc.sql
@@ -1,0 +1,110 @@
+drop function if exists public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text);
+
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null,
+  p_mode text default 'empty'
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_mode text := lower(btrim(coalesce(p_mode, 'empty')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
+
+  if v_mode not in ('empty', 'stale') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_BACKFILL_MODE',
+      'message', format('Unsupported extracted_text backfill mode: %s', coalesce(p_mode, '<null>'))
+    );
+  end if;
+
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%1$I
+         where json is not null
+           and ($4 <> 'empty' or coalesce(extracted_text, '') = '')
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      computed as (
+        select dataset.id,
+               dataset.version,
+               util.dataset_json_search_text(dataset.json) as next_extracted_text
+          from public.%1$I as dataset
+          join page on page.id = dataset.id
+                   and page.version = dataset.version
+      ),
+      updated as (
+        update public.%1$I as dataset
+           set extracted_text = computed.next_extracted_text
+          from computed
+         where dataset.id = computed.id
+           and dataset.version = computed.version
+           and (
+             $4 = 'empty'
+             or dataset.extracted_text is distinct from computed.next_extracted_text
+           )
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size, v_mode
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
+
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'mode', v_mode,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) to service_role;
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. Default mode repairs empty rows only; mode=stale performs full consistency repair. The next extracted text is computed once per selected row.';

--- a/supabase/tests/20260527_dataset_extracted_text_contract.sql
+++ b/supabase/tests/20260527_dataset_extracted_text_contract.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(18);
+select plan(19);
 
 select ok(
   util.dataset_json_search_text(
@@ -113,9 +113,9 @@ select ok(
 );
 
 select ok(
-  has_function_privilege('service_role', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute')
-    and not has_function_privilege('authenticated', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute')
-    and not has_function_privilege('anon', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute'),
+  has_function_privilege('service_role', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text)', 'execute')
+    and not has_function_privilege('authenticated', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text)', 'execute')
+    and not has_function_privilege('anon', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text)', 'execute'),
   'dataset extracted_text historical backfill RPC is service-role only'
 );
 
@@ -339,7 +339,7 @@ select ok(
 );
 
 update public.flows
-   set extracted_text = 'stale extracted text'
+   set extracted_text = ''
  where id = '97000000-0000-0000-0000-000000000088';
 
 do $$
@@ -353,7 +353,8 @@ begin
       'flows',
       5000,
       v_after_id,
-      v_after_version
+      v_after_version,
+      'empty'
     );
     v_after_id := (v_payload->>'last_id')::uuid;
     v_after_version := v_payload->>'last_version';
@@ -377,7 +378,50 @@ select ok(
       and extracted_text ~ 'Wechselstrom'
    from public.flows
    where id = '97000000-0000-0000-0000-000000000088'),
-  'dataset extracted_text backfill RPC repairs stale rows in bounded batches'
+  'dataset extracted_text empty-mode backfill repairs missing rows in bounded batches'
+);
+
+update public.flows
+   set extracted_text = 'stale extracted text'
+ where id = '97000000-0000-0000-0000-000000000088';
+
+do $$
+declare
+  v_payload jsonb;
+  v_after_id uuid;
+  v_after_version text;
+begin
+  for i in 1..20 loop
+    v_payload := public.cmd_dataset_extracted_text_backfill(
+      'flows',
+      5000,
+      v_after_id,
+      v_after_version,
+      'stale'
+    );
+    v_after_id := (v_payload->>'last_id')::uuid;
+    v_after_version := v_payload->>'last_version';
+
+    exit when coalesce((v_payload->>'has_more')::boolean, false) is false
+      or exists (
+        select 1
+        from public.flows
+        where id = '97000000-0000-0000-0000-000000000088'
+          and extracted_text ~ '交流电'
+          and extracted_text ~ 'electricity'
+          and extracted_text ~ 'Wechselstrom'
+      );
+  end loop;
+end
+$$;
+
+select ok(
+  (select extracted_text ~ '交流电'
+      and extracted_text ~ 'electricity'
+      and extracted_text ~ 'Wechselstrom'
+   from public.flows
+   where id = '97000000-0000-0000-0000-000000000088'),
+  'dataset extracted_text stale-mode backfill repairs non-empty stale rows'
 );
 
 set local role authenticated;


### PR DESCRIPTION
Closes #88

## Summary
- Add a follow-up migration that replaces `cmd_dataset_extracted_text_backfill` after dev validation showed `flows` historical backfill is still too heavy.
- Compute `util.dataset_json_search_text(json)` once per selected row instead of repeating it in `SET` and `WHERE`.
- Add `p_mode text default 'empty'` so the default backfill repairs only missing/empty `extracted_text`; full consistency repair is explicit with `p_mode = 'stale'`.
- Keep service-role-only access, cursor pagination, `FOR UPDATE SKIP LOCKED`, and bounded batch size.

## Validation
- `supabase db reset`
- `supabase test db supabase/tests/20260527_dataset_extracted_text_contract.sql supabase/tests/20260526_dataset_extraction_jobs.sql supabase/tests/20260526_drop_flows_json_pgroonga.sql --local`
- `supabase test db --local`
- `scripts/docpact lint --root . --base origin/dev --head HEAD --mode enforce`

## Dev validation finding
- `flows` full/stale historical backfill with batch size 2000 stayed active about 90 seconds in IO wait and was cancelled.
- `lifecyclemodels` historical backfill completed: 842 rows, about 14.5s with 500-row batches.
- `processes` 500-row batches mostly ran in 7-20s but one later batch hit 30s statement timeout, so it also needs bounded/resumable handling.

## Rollout notes
- For `flows`, first use empty-mode with small batches (`100` or `250`).
- Full stale consistency for `flows` should be done in a maintenance window by temporarily dropping `flows_text_pgroonga`, backfilling, recreating the index concurrently, and running `analyze public.flows`.
