### PR TITLE
chore: promote extracted text search fixes to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-26"
-lastReviewedCommit: "937fb37de0b14a1bcbc900577bcaad3437d2c81a"
+lastReviewedAt: "2026-05-27"
+lastReviewedCommit: "349117a01a90b53b925dc5e882be89e369cf657f"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "8ac4eabf01724c2020fbb90c4829f9cf6e8db585"
+lastReviewedCommit: "15731c8158aa7a5c26ec60aaf5039b09267f201c"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "15731c8158aa7a5c26ec60aaf5039b09267f201c"
+lastReviewedCommit: "946d342d43fb938254eebd327f73180a5ab5f72f"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "349117a01a90b53b925dc5e882be89e369cf657f"
+lastReviewedCommit: "8ac4eabf01724c2020fbb90c4829f9cf6e8db585"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
+lastReviewedCommit: 24c149a4f70596fc1cde7cc2979e02676d55b2d1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 24c149a4f70596fc1cde7cc2979e02676d55b2d1
+lastReviewedCommit: 5270e2ab14750122337a641b4638bc2505b43760
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 937fb37de0b14a1bcbc900577bcaad3437d2c81a
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 937fb37de0b14a1bcbc900577bcaad3437d2c81a
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
+lastReviewedCommit: 8ac4eabf01724c2020fbb90c4829f9cf6e8db585
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 8ac4eabf01724c2020fbb90c4829f9cf6e8db585
+lastReviewedCommit: 15731c8158aa7a5c26ec60aaf5039b09267f201c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 15731c8158aa7a5c26ec60aaf5039b09267f201c
+lastReviewedCommit: 946d342d43fb938254eebd327f73180a5ab5f72f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 937fb37de0b14a1bcbc900577bcaad3437d2c81a
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 8ac4eabf01724c2020fbb90c4829f9cf6e8db585
+lastReviewedCommit: 15731c8158aa7a5c26ec60aaf5039b09267f201c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 15731c8158aa7a5c26ec60aaf5039b09267f201c
+lastReviewedCommit: 946d342d43fb938254eebd327f73180a5ab5f72f
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 349117a01a90b53b925dc5e882be89e369cf657f
+lastReviewedCommit: 8ac4eabf01724c2020fbb90c4829f9cf6e8db585
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260527071703_dataset_extracted_text_contract.sql
+++ b/supabase/migrations/20260527071703_dataset_extracted_text_contract.sql
@@ -123,40 +123,89 @@ $$;
 
 alter function util.queue_dataset_extraction_jobs() owner to postgres;
 
-update public.flows as f
-   set extracted_text = util.dataset_json_search_text(f.json)
- where f.json is not null
-   and f.extracted_text is distinct from util.dataset_json_search_text(f.json);
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
 
-update public.processes as p
-   set extracted_text = util.dataset_json_search_text(p.json)
- where p.json is not null
-   and p.extracted_text is distinct from util.dataset_json_search_text(p.json);
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%I
+         where json is not null
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      updated as (
+        update public.%I as dataset
+           set extracted_text = util.dataset_json_search_text(dataset.json)
+          from page
+         where dataset.id = page.id
+           and dataset.version = page.version
+           and dataset.extracted_text is distinct from util.dataset_json_search_text(dataset.json)
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
 
-update public.lifecyclemodels as lm
-   set extracted_text = util.dataset_json_search_text(lm.json)
- where lm.json is not null
-   and lm.extracted_text is distinct from util.dataset_json_search_text(lm.json);
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
 
-update public.contacts as c
-   set extracted_text = util.dataset_json_search_text(c.json)
- where c.json is not null
-   and c.extracted_text is distinct from util.dataset_json_search_text(c.json);
-
-update public.sources as s
-   set extracted_text = util.dataset_json_search_text(s.json)
- where s.json is not null
-   and s.extracted_text is distinct from util.dataset_json_search_text(s.json);
-
-update public.unitgroups as u
-   set extracted_text = util.dataset_json_search_text(u.json)
- where u.json is not null
-   and u.extracted_text is distinct from util.dataset_json_search_text(u.json);
-
-update public.flowproperties as fp
-   set extracted_text = util.dataset_json_search_text(fp.json)
- where fp.json is not null
-   and fp.extracted_text is distinct from util.dataset_json_search_text(fp.json);
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) to service_role;
 
 comment on function util.dataset_json_search_text(jsonb) is
   'Builds deterministic dataset full-text search input from every scalar JSON value, preserving all authored languages without LLM summarization.';
@@ -166,3 +215,6 @@ comment on function util.set_dataset_extracted_text_from_json() is
 
 comment on function util.queue_dataset_extraction_jobs() is
   'Queues compact dataset extraction jobs for asynchronous extracted_md generation without carrying json/json_ordered in the transaction payload.';
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. Call repeatedly with the returned cursor; migrations must not run full-table backfills synchronously.';

--- a/supabase/migrations/20260527071703_dataset_extracted_text_contract.sql
+++ b/supabase/migrations/20260527071703_dataset_extracted_text_contract.sql
@@ -1,0 +1,168 @@
+create or replace function util.dataset_json_search_text(p_json jsonb)
+returns text
+language sql
+immutable
+parallel safe
+as $$
+  with recursive walk(value) as (
+    select p_json
+    where p_json is not null
+
+    union all
+
+    select child.value
+    from walk w
+    cross join lateral (
+      select elem.value
+      from jsonb_array_elements(
+        case when jsonb_typeof(w.value) = 'array' then w.value else '[]'::jsonb end
+      ) as elem(value)
+
+      union all
+
+      select obj.value
+      from jsonb_each(
+        case when jsonb_typeof(w.value) = 'object' then w.value else '{}'::jsonb end
+      ) as obj(key, value)
+    ) child
+  ),
+  scalar_text as (
+    select distinct nullif(btrim(value #>> '{}'), '') as text_value
+    from walk
+    where jsonb_typeof(value) in ('string', 'number', 'boolean')
+  )
+  select coalesce(
+    string_agg(text_value, ' ' order by lower(text_value), text_value),
+    ''
+  )
+  from scalar_text
+  where text_value is not null;
+$$;
+
+alter function util.dataset_json_search_text(jsonb) owner to postgres;
+revoke all on function util.dataset_json_search_text(jsonb) from public;
+grant execute on function util.dataset_json_search_text(jsonb) to service_role;
+
+create or replace function util.set_dataset_extracted_text_from_json()
+returns trigger
+language plpgsql
+set search_path to 'public', 'util', 'pg_temp'
+as $$
+begin
+  new.extracted_text := util.dataset_json_search_text(new.json);
+  return new;
+end;
+$$;
+
+alter function util.set_dataset_extracted_text_from_json() owner to postgres;
+revoke all on function util.set_dataset_extracted_text_from_json() from public;
+grant execute on function util.set_dataset_extracted_text_from_json() to service_role;
+
+drop trigger if exists flow_extract_text_trigger_insert on public.flows;
+drop trigger if exists flow_extract_text_trigger_update on public.flows;
+drop trigger if exists process_extract_text_trigger_insert on public.processes;
+drop trigger if exists process_extract_text_trigger_update on public.processes;
+drop trigger if exists lifecyclemodels_extract_text_trigger_insert on public.lifecyclemodels;
+drop trigger if exists lifecyclemodels_extract_text_trigger_update on public.lifecyclemodels;
+
+drop trigger if exists zz_flows_extracted_text_sync_trigger on public.flows;
+create trigger zz_flows_extracted_text_sync_trigger
+  before insert or update of json, json_ordered on public.flows
+  for each row execute function util.set_dataset_extracted_text_from_json();
+
+drop trigger if exists zz_processes_extracted_text_sync_trigger on public.processes;
+create trigger zz_processes_extracted_text_sync_trigger
+  before insert or update of json, json_ordered on public.processes
+  for each row execute function util.set_dataset_extracted_text_from_json();
+
+drop trigger if exists zz_lifecyclemodels_extracted_text_sync_trigger on public.lifecyclemodels;
+create trigger zz_lifecyclemodels_extracted_text_sync_trigger
+  before insert or update of json, json_ordered on public.lifecyclemodels
+  for each row execute function util.set_dataset_extracted_text_from_json();
+
+create or replace function util.queue_dataset_extraction_jobs() returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_entity_kind text;
+  v_message_base jsonb;
+begin
+  if TG_TABLE_SCHEMA <> 'public' then
+    raise exception 'dataset extraction jobs only support public schema, got %', TG_TABLE_SCHEMA;
+  end if;
+
+  v_entity_kind := case TG_TABLE_NAME
+    when 'flows' then 'flow'
+    when 'processes' then 'process'
+    else null
+  end;
+
+  if v_entity_kind is null then
+    raise exception 'unsupported dataset extraction table %', TG_TABLE_NAME;
+  end if;
+
+  v_message_base := jsonb_build_object(
+    'schema', TG_TABLE_SCHEMA,
+    'table', TG_TABLE_NAME,
+    'id', NEW.id,
+    'version', NEW.version,
+    'entity_kind', v_entity_kind,
+    'created_at', now()
+  );
+
+  perform pgmq.send(
+    queue_name => 'dataset_extraction_jobs',
+    msg => v_message_base || jsonb_build_object('extraction_kind', 'extracted_md')
+  );
+
+  return NEW;
+end;
+$$;
+
+alter function util.queue_dataset_extraction_jobs() owner to postgres;
+
+update public.flows as f
+   set extracted_text = util.dataset_json_search_text(f.json)
+ where f.json is not null
+   and f.extracted_text is distinct from util.dataset_json_search_text(f.json);
+
+update public.processes as p
+   set extracted_text = util.dataset_json_search_text(p.json)
+ where p.json is not null
+   and p.extracted_text is distinct from util.dataset_json_search_text(p.json);
+
+update public.lifecyclemodels as lm
+   set extracted_text = util.dataset_json_search_text(lm.json)
+ where lm.json is not null
+   and lm.extracted_text is distinct from util.dataset_json_search_text(lm.json);
+
+update public.contacts as c
+   set extracted_text = util.dataset_json_search_text(c.json)
+ where c.json is not null
+   and c.extracted_text is distinct from util.dataset_json_search_text(c.json);
+
+update public.sources as s
+   set extracted_text = util.dataset_json_search_text(s.json)
+ where s.json is not null
+   and s.extracted_text is distinct from util.dataset_json_search_text(s.json);
+
+update public.unitgroups as u
+   set extracted_text = util.dataset_json_search_text(u.json)
+ where u.json is not null
+   and u.extracted_text is distinct from util.dataset_json_search_text(u.json);
+
+update public.flowproperties as fp
+   set extracted_text = util.dataset_json_search_text(fp.json)
+ where fp.json is not null
+   and fp.extracted_text is distinct from util.dataset_json_search_text(fp.json);
+
+comment on function util.dataset_json_search_text(jsonb) is
+  'Builds deterministic dataset full-text search input from every scalar JSON value, preserving all authored languages without LLM summarization.';
+
+comment on function util.set_dataset_extracted_text_from_json() is
+  'Maintains extracted_text as deterministic searchable text from dataset JSON during INSERT/UPDATE.';
+
+comment on function util.queue_dataset_extraction_jobs() is
+  'Queues compact dataset extraction jobs for asynchronous extracted_md generation without carrying json/json_ordered in the transaction payload.';

--- a/supabase/migrations/20260527080720_tune_dataset_extracted_text_backfill_rpc.sql
+++ b/supabase/migrations/20260527080720_tune_dataset_extracted_text_backfill_rpc.sql
@@ -1,0 +1,110 @@
+drop function if exists public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text);
+
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null,
+  p_mode text default 'empty'
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_mode text := lower(btrim(coalesce(p_mode, 'empty')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
+
+  if v_mode not in ('empty', 'stale') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_BACKFILL_MODE',
+      'message', format('Unsupported extracted_text backfill mode: %s', coalesce(p_mode, '<null>'))
+    );
+  end if;
+
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%1$I
+         where json is not null
+           and ($4 <> 'empty' or coalesce(extracted_text, '') = '')
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      computed as (
+        select dataset.id,
+               dataset.version,
+               util.dataset_json_search_text(dataset.json) as next_extracted_text
+          from public.%1$I as dataset
+          join page on page.id = dataset.id
+                   and page.version = dataset.version
+      ),
+      updated as (
+        update public.%1$I as dataset
+           set extracted_text = computed.next_extracted_text
+          from computed
+         where dataset.id = computed.id
+           and dataset.version = computed.version
+           and (
+             $4 = 'empty'
+             or dataset.extracted_text is distinct from computed.next_extracted_text
+           )
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size, v_mode
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
+
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'mode', v_mode,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) to service_role;
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. Default mode repairs empty rows only; mode=stale performs full consistency repair. The next extracted text is computed once per selected row.';

--- a/supabase/tests/20260404_dataset_command_rpcs.sql
+++ b/supabase/tests/20260404_dataset_command_rpcs.sql
@@ -3,6 +3,23 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
 select plan(13);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -129,8 +146,8 @@ values (
 alter table public.processes disable trigger "processes_json_sync_trigger";
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
 alter table public.processes disable trigger "process_extract_md_trigger_update";
-alter table public.processes disable trigger "process_extract_text_trigger_insert";
-alter table public.processes disable trigger "process_extract_text_trigger_update";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_update');
 
 insert into public.processes (
   id,

--- a/supabase/tests/20260404_review_submit_rpc.sql
+++ b/supabase/tests/20260404_review_submit_rpc.sql
@@ -3,6 +3,23 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
 select plan(14);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -80,7 +97,7 @@ alter table public.processes disable trigger "processes_json_sync_trigger";
 alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_trigger";
 
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
-alter table public.processes disable trigger "process_extract_text_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
 do $$
 begin
   if exists (
@@ -109,7 +126,7 @@ begin
 end
 $$;
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
-alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
 
 insert into public.flows (
   id,

--- a/supabase/tests/20260405_dataset_create_delete_rpcs.sql
+++ b/supabase/tests/20260405_dataset_create_delete_rpcs.sql
@@ -3,6 +3,23 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
 select plan(12);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -106,7 +123,7 @@ values (
 );
 
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
-alter table public.processes disable trigger "process_extract_text_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
 
 set local role authenticated;
 select set_config('request.jwt.claim.sub', '91000000-0000-0000-0000-000000000001', true);

--- a/supabase/tests/20260405_notification_query_command_rpcs.sql
+++ b/supabase/tests/20260405_notification_query_command_rpcs.sql
@@ -3,6 +3,23 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
 select plan(13);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -104,7 +121,7 @@ values (
 alter table public.sources disable trigger "sources_json_sync_trigger";
 alter table public.processes disable trigger "processes_json_sync_trigger";
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
-alter table public.processes disable trigger "process_extract_text_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
 
 insert into public.sources (
   id,

--- a/supabase/tests/20260405_review_workflow_rpcs.sql
+++ b/supabase/tests/20260405_review_workflow_rpcs.sql
@@ -3,6 +3,23 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
 select plan(44);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -121,8 +138,8 @@ alter table public.lifecyclemodels disable trigger "lifecyclemodels_json_sync_tr
 
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
 alter table public.processes disable trigger "process_extract_md_trigger_update";
-alter table public.processes disable trigger "process_extract_text_trigger_insert";
-alter table public.processes disable trigger "process_extract_text_trigger_update";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_update');
 do $$
 begin
   if exists (
@@ -151,11 +168,11 @@ begin
 end
 $$;
 alter table public.flows disable trigger "flow_extract_md_trigger_update";
-alter table public.flows disable trigger "flow_extract_text_trigger_update";
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_text_trigger_update');
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_update";
-alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
-alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_update";
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_update');
 
 insert into public.flows (
   id,

--- a/supabase/tests/20260407_lifecycle_model_bundle_delete.sql
+++ b/supabase/tests/20260407_lifecycle_model_bundle_delete.sql
@@ -3,12 +3,29 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
 select plan(3);
 
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
-alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
-alter table public.processes disable trigger "process_extract_text_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
 
 insert into public.lifecyclemodels (id, version, user_id, json_ordered, json_tg, rule_verification)
 values (

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -3,6 +3,23 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
 select plan(54);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -80,9 +97,9 @@ begin
 end
 $$;
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
-alter table public.processes disable trigger "process_extract_text_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
 alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
-alter table public.lifecyclemodels disable trigger "lifecyclemodels_extract_text_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
 
 insert into public.flows (
   id,

--- a/supabase/tests/20260525_review_submit_gate_runs.sql
+++ b/supabase/tests/20260525_review_submit_gate_runs.sql
@@ -3,6 +3,23 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
 select plan(17);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -76,8 +93,8 @@ values
 alter table public.processes disable trigger "processes_json_sync_trigger";
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
 alter table public.processes disable trigger "process_extract_md_trigger_update";
-alter table public.processes disable trigger "process_extract_text_trigger_insert";
-alter table public.processes disable trigger "process_extract_text_trigger_update";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_update');
 
 insert into public.processes (
   id,

--- a/supabase/tests/20260526_dataset_extraction_jobs.sql
+++ b/supabase/tests/20260526_dataset_extraction_jobs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(24);
+select plan(25);
 
 do $$
 begin
@@ -86,6 +86,14 @@ select public.cmd_dataset_create(
               {
                 "@xml:lang": "en",
                 "#text": "Dataset extraction test flow"
+              },
+              {
+                "@xml:lang": "zh",
+                "#text": "数据抽取测试流"
+              },
+              {
+                "@xml:lang": "de",
+                "#text": "Datensatz Extraktion Testfluss"
               }
             ]
           }
@@ -139,6 +147,18 @@ select ok(
   'minimal create result does not include heavy json or derived embedding fields'
 );
 
+select ok(
+  (
+    select extracted_text ~ 'Dataset extraction test flow'
+       and extracted_text ~ '数据抽取测试流'
+       and extracted_text ~ 'Datensatz Extraktion Testfluss'
+    from public.flows
+    where id = '97000000-0000-0000-0000-000000000001'
+      and version = '01.00.000'
+  ),
+  'flow create synchronously derives multilingual extracted_text from json'
+);
+
 reset role;
 
 select is(
@@ -146,8 +166,8 @@ select is(
     select count(*)::integer
     from pgmq.q_dataset_extraction_jobs
   ),
-  2,
-  'flow create enqueues two dataset extraction jobs'
+  1,
+  'flow create enqueues one dataset extraction job'
 );
 
 select is(
@@ -168,8 +188,8 @@ select is(
     select string_agg(message->>'extraction_kind', ',' order by message->>'extraction_kind')
     from pgmq.q_dataset_extraction_jobs
   ),
-  'extracted_md,extracted_text',
-  'flow create enqueues extracted_md and extracted_text jobs'
+  'extracted_md',
+  'flow create enqueues only extracted_md jobs'
 );
 
 select is(
@@ -184,7 +204,7 @@ select is(
       'entity_kind', 'flow'
     )
   ),
-  2,
+  1,
   'dataset extraction jobs use compact flow identity payloads'
 );
 
@@ -205,23 +225,28 @@ select is(
     select count(*)::integer
     from pg_trigger
     where tgrelid = 'public.flows'::regclass
-      and tgname in ('flow_extract_md_trigger_update', 'flow_extract_text_trigger_update')
+      and tgname = 'flow_extract_text_trigger_update'
       and not tgisinternal
   ),
-  2,
-  'flow UPDATE extraction triggers remain unchanged in v1'
+  0,
+  'flow UPDATE text extraction webhook trigger is removed'
 );
 
 select is(
   (
     select count(*)::integer
     from pg_trigger
-    where tgrelid = 'public.processes'::regclass
-      and tgname in ('process_extract_md_trigger_insert', 'process_extract_text_trigger_insert')
+    where tgrelid in ('public.processes'::regclass, 'public.lifecyclemodels'::regclass)
+      and tgname in (
+        'process_extract_text_trigger_insert',
+        'process_extract_text_trigger_update',
+        'lifecyclemodels_extract_text_trigger_insert',
+        'lifecyclemodels_extract_text_trigger_update'
+      )
       and not tgisinternal
   ),
-  2,
-  'process INSERT webhook triggers remain for the tracked follow-up'
+  0,
+  'process and lifecyclemodel text extraction webhook triggers are removed'
 );
 
 reset role;
@@ -243,8 +268,8 @@ select is(
 
 select is(
   (select jsonb_array_length(result->'data') from claimed_dataset_extraction_jobs),
-  2,
-  'claim returns both queued flow extraction jobs'
+  1,
+  'claim returns the queued flow markdown extraction job'
 );
 
 select ok(

--- a/supabase/tests/20260526_drop_flows_json_pgroonga.sql
+++ b/supabase/tests/20260526_drop_flows_json_pgroonga.sql
@@ -48,11 +48,11 @@ select is(
     select count(*)
     from pg_trigger
     where tgrelid = 'public.flows'::regclass
-      and tgname in ('flow_extract_md_trigger_update', 'flow_extract_text_trigger_update')
+      and tgname = 'flow_extract_md_trigger_update'
       and not tgisinternal
   ),
-  2::bigint,
-  'flow json update extraction triggers remain unchanged for the non-insert path'
+  1::bigint,
+  'flow json update keeps only the markdown extraction webhook trigger'
 );
 
 select * from finish();

--- a/supabase/tests/20260527_dataset_extracted_text_contract.sql
+++ b/supabase/tests/20260527_dataset_extracted_text_contract.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(16);
+select plan(18);
 
 select ok(
   util.dataset_json_search_text(
@@ -110,6 +110,13 @@ select ok(
   strpos(pg_get_functiondef('util.queue_dataset_extraction_jobs()'::regprocedure), '''extracted_md''') > 0
     and strpos(pg_get_functiondef('util.queue_dataset_extraction_jobs()'::regprocedure), '''extracted_text''') = 0,
   'dataset extraction queue only enqueues markdown extraction jobs'
+);
+
+select ok(
+  has_function_privilege('service_role', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute')
+    and not has_function_privilege('authenticated', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute')
+    and not has_function_privilege('anon', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute'),
+  'dataset extracted_text historical backfill RPC is service-role only'
 );
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -329,6 +336,48 @@ select ok(
     where id = '99000000-0000-0000-0000-000000000088'
   ),
   'lifecyclemodel extracted_text trigger preserves all authored languages'
+);
+
+update public.flows
+   set extracted_text = 'stale extracted text'
+ where id = '97000000-0000-0000-0000-000000000088';
+
+do $$
+declare
+  v_payload jsonb;
+  v_after_id uuid;
+  v_after_version text;
+begin
+  for i in 1..20 loop
+    v_payload := public.cmd_dataset_extracted_text_backfill(
+      'flows',
+      5000,
+      v_after_id,
+      v_after_version
+    );
+    v_after_id := (v_payload->>'last_id')::uuid;
+    v_after_version := v_payload->>'last_version';
+
+    exit when coalesce((v_payload->>'has_more')::boolean, false) is false
+      or exists (
+        select 1
+        from public.flows
+        where id = '97000000-0000-0000-0000-000000000088'
+          and extracted_text ~ '交流电'
+          and extracted_text ~ 'electricity'
+          and extracted_text ~ 'Wechselstrom'
+      );
+  end loop;
+end
+$$;
+
+select ok(
+  (select extracted_text ~ '交流电'
+      and extracted_text ~ 'electricity'
+      and extracted_text ~ 'Wechselstrom'
+   from public.flows
+   where id = '97000000-0000-0000-0000-000000000088'),
+  'dataset extracted_text backfill RPC repairs stale rows in bounded batches'
 );
 
 set local role authenticated;

--- a/supabase/tests/20260527_dataset_extracted_text_contract.sql
+++ b/supabase/tests/20260527_dataset_extracted_text_contract.sql
@@ -1,0 +1,393 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(16);
+
+select ok(
+  util.dataset_json_search_text(
+    '{
+      "name": [
+        {"@xml:lang":"zh","#text":"交流电"},
+        {"@xml:lang":"en","#text":"electricity"},
+        {"@xml:lang":"de","#text":"Wechselstrom"}
+      ],
+      "classification": {"@classId":"class-ac-001", "#text":"能源"},
+      "amount": 42,
+      "active": true
+    }'::jsonb
+  ) ~ '交流电'
+  and util.dataset_json_search_text(
+    '{
+      "name": [
+        {"@xml:lang":"zh","#text":"交流电"},
+        {"@xml:lang":"en","#text":"electricity"},
+        {"@xml:lang":"de","#text":"Wechselstrom"}
+      ],
+      "classification": {"@classId":"class-ac-001", "#text":"能源"},
+      "amount": 42,
+      "active": true
+    }'::jsonb
+  ) ~ 'electricity'
+  and util.dataset_json_search_text(
+    '{
+      "name": [
+        {"@xml:lang":"zh","#text":"交流电"},
+        {"@xml:lang":"en","#text":"electricity"},
+        {"@xml:lang":"de","#text":"Wechselstrom"}
+      ],
+      "classification": {"@classId":"class-ac-001", "#text":"能源"},
+      "amount": 42,
+      "active": true
+    }'::jsonb
+  ) ~ 'Wechselstrom'
+  and util.dataset_json_search_text(
+    '{
+      "name": [
+        {"@xml:lang":"zh","#text":"交流电"},
+        {"@xml:lang":"en","#text":"electricity"},
+        {"@xml:lang":"de","#text":"Wechselstrom"}
+      ],
+      "classification": {"@classId":"class-ac-001", "#text":"能源"},
+      "amount": 42,
+      "active": true
+    }'::jsonb
+  ) ~ 'class-ac-001'
+  and util.dataset_json_search_text(
+    '{
+      "name": [
+        {"@xml:lang":"zh","#text":"交流电"},
+        {"@xml:lang":"en","#text":"electricity"},
+        {"@xml:lang":"de","#text":"Wechselstrom"}
+      ],
+      "classification": {"@classId":"class-ac-001", "#text":"能源"},
+      "amount": 42,
+      "active": true
+    }'::jsonb
+  ) ~ '42',
+  'dataset searchable text keeps all authored language values and scalar metadata'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where tgname in (
+      'zz_contacts_extracted_text_sync_trigger',
+      'zz_sources_extracted_text_sync_trigger',
+      'zz_unitgroups_extracted_text_sync_trigger',
+      'zz_flowproperties_extracted_text_sync_trigger',
+      'zz_flows_extracted_text_sync_trigger',
+      'zz_processes_extracted_text_sync_trigger',
+      'zz_lifecyclemodels_extracted_text_sync_trigger'
+    )
+      and not tgisinternal
+  ),
+  7,
+  'all searchable dataset entities have database-side extracted_text sync triggers'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where tgname in (
+      'flow_extract_text_trigger_insert',
+      'flow_extract_text_trigger_update',
+      'process_extract_text_trigger_insert',
+      'process_extract_text_trigger_update',
+      'lifecyclemodels_extract_text_trigger_insert',
+      'lifecyclemodels_extract_text_trigger_update'
+    )
+      and not tgisinternal
+  ),
+  0,
+  'core dataset text extraction webhooks are removed'
+);
+
+select ok(
+  strpos(pg_get_functiondef('util.queue_dataset_extraction_jobs()'::regprocedure), '''extracted_md''') > 0
+    and strpos(pg_get_functiondef('util.queue_dataset_extraction_jobs()'::regprocedure), '''extracted_text''') = 0,
+  'dataset extraction queue only enqueues markdown extraction jobs'
+);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  '96000000-0000-0000-0000-000000000088',
+  'authenticated',
+  'authenticated',
+  'dataset-searchable-text@example.com',
+  'test-password-hash',
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"sub":"96000000-0000-0000-0000-000000000088","email":"dataset-searchable-text@example.com"}'::jsonb,
+  now(),
+  now(),
+  false,
+  false
+);
+
+insert into public.users (id, raw_user_meta_data, contact)
+values (
+  '96000000-0000-0000-0000-000000000088',
+  '{"email":"dataset-searchable-text@example.com"}'::jsonb,
+  null
+);
+
+insert into public.teams (id, json, rank, is_public)
+values ('26000000-0000-0000-0000-000000000088', '{"name":"Searchable Text Team"}'::jsonb, 1, false);
+
+do $$
+begin
+  if exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.flows'::regclass
+      and tgname = 'flow_dataset_extraction_trigger_insert'
+  ) then
+    alter table public.flows disable trigger "flow_dataset_extraction_trigger_insert";
+  end if;
+
+  alter table public.processes disable trigger "process_extract_md_trigger_insert";
+  alter table public.lifecyclemodels disable trigger "lifecyclemodel_extract_md_trigger_insert";
+end
+$$;
+
+insert into public.flows (
+  id,
+  version,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values (
+  '97000000-0000-0000-0000-000000000088',
+  '01.00.000',
+  '{
+    "flowDataSet": {
+      "flowInformation": {
+        "dataSetInformation": {
+          "common:UUID": "97000000-0000-0000-0000-000000000088",
+          "name": {
+            "baseName": [
+              {"@xml:lang": "zh", "#text": "交流电"},
+              {"@xml:lang": "en", "#text": "electricity"},
+              {"@xml:lang": "de", "#text": "Wechselstrom"}
+            ]
+          },
+          "classificationInformation": {
+            "common:classification": {
+              "common:class": [{"@classId": "flow-energy", "#text": "能源"}]
+            }
+          }
+        }
+      },
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json,
+  '96000000-0000-0000-0000-000000000088',
+  100,
+  '26000000-0000-0000-0000-000000000088',
+  true
+);
+
+insert into public.processes (
+  id,
+  version,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values (
+  '98000000-0000-0000-0000-000000000088',
+  '01.00.000',
+  '{
+    "processDataSet": {
+      "processInformation": {
+        "dataSetInformation": {
+          "common:UUID": "98000000-0000-0000-0000-000000000088",
+          "name": {
+            "baseName": [
+              {"@xml:lang": "zh", "#text": "交流电过程"},
+              {"@xml:lang": "en", "#text": "electricity process"},
+              {"@xml:lang": "de", "#text": "Wechselstrom Prozess"}
+            ]
+          }
+        },
+        "modellingAndValidation": {
+          "LCIMethodAndAllocation": {
+            "typeOfDataSet": "Unit process"
+          }
+        }
+      },
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json,
+  '96000000-0000-0000-0000-000000000088',
+  100,
+  '26000000-0000-0000-0000-000000000088',
+  true
+);
+
+insert into public.lifecyclemodels (
+  id,
+  version,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification
+)
+values (
+  '99000000-0000-0000-0000-000000000088',
+  '01.00.000',
+  '{
+    "lifeCycleModelDataSet": {
+      "lifeCycleModelInformation": {
+        "dataSetInformation": {
+          "common:UUID": "99000000-0000-0000-0000-000000000088",
+          "name": {
+            "baseName": [
+              {"@xml:lang": "zh", "#text": "交流电模型"},
+              {"@xml:lang": "en", "#text": "electricity model"},
+              {"@xml:lang": "de", "#text": "Wechselstrom Modell"}
+            ]
+          }
+        }
+      },
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json,
+  '96000000-0000-0000-0000-000000000088',
+  100,
+  '26000000-0000-0000-0000-000000000088',
+  true
+);
+
+select ok(
+  (
+    select extracted_text ~ '交流电'
+       and extracted_text ~ 'electricity'
+       and extracted_text ~ 'Wechselstrom'
+       and extracted_text ~ 'flow-energy'
+    from public.flows
+    where id = '97000000-0000-0000-0000-000000000088'
+  ),
+  'flow extracted_text trigger preserves all authored languages and codes'
+);
+
+select ok(
+  (
+    select extracted_text ~ '交流电过程'
+       and extracted_text ~ 'electricity process'
+       and extracted_text ~ 'Wechselstrom Prozess'
+    from public.processes
+    where id = '98000000-0000-0000-0000-000000000088'
+  ),
+  'process extracted_text trigger preserves all authored languages'
+);
+
+select ok(
+  (
+    select extracted_text ~ '交流电模型'
+       and extracted_text ~ 'electricity model'
+       and extracted_text ~ 'Wechselstrom Modell'
+    from public.lifecyclemodels
+    where id = '99000000-0000-0000-0000-000000000088'
+  ),
+  'lifecyclemodel extracted_text trigger preserves all authored languages'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '96000000-0000-0000-0000-000000000088', true);
+
+select is(
+  (select id::text from public.search_flows_latest('交流电', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088') where id = '97000000-0000-0000-0000-000000000088'),
+  '97000000-0000-0000-0000-000000000088',
+  'flow latest search recalls Chinese authored text'
+);
+
+select is(
+  (select id::text from public.search_flows_latest('Wechselstrom', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088') where id = '97000000-0000-0000-0000-000000000088'),
+  '97000000-0000-0000-0000-000000000088',
+  'flow latest search recalls non-English authored text'
+);
+
+select is(
+  (select id::text from public.search_flows_latest('electricity', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088') where id = '97000000-0000-0000-0000-000000000088'),
+  '97000000-0000-0000-0000-000000000088',
+  'flow latest search recalls English authored text'
+);
+
+select is(
+  (select id::text from public.search_processes_latest('交流电过程', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088', null, null, 'all') where id = '98000000-0000-0000-0000-000000000088'),
+  '98000000-0000-0000-0000-000000000088',
+  'process latest search recalls Chinese authored text'
+);
+
+select is(
+  (select id::text from public.search_processes_latest('Wechselstrom', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088', null, null, 'all') where id = '98000000-0000-0000-0000-000000000088'),
+  '98000000-0000-0000-0000-000000000088',
+  'process latest search recalls non-English authored text'
+);
+
+select is(
+  (select id::text from public.search_processes_latest('electricity', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088', null, null, 'all') where id = '98000000-0000-0000-0000-000000000088'),
+  '98000000-0000-0000-0000-000000000088',
+  'process latest search recalls English authored text'
+);
+
+select is(
+  (select id::text from public.search_lifecyclemodels_latest('交流电模型', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088') where id = '99000000-0000-0000-0000-000000000088'),
+  '99000000-0000-0000-0000-000000000088',
+  'lifecyclemodel latest search recalls Chinese authored text'
+);
+
+select is(
+  (select id::text from public.search_lifecyclemodels_latest('Wechselstrom', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088') where id = '99000000-0000-0000-0000-000000000088'),
+  '99000000-0000-0000-0000-000000000088',
+  'lifecyclemodel latest search recalls non-English authored text'
+);
+
+select is(
+  (select id::text from public.search_lifecyclemodels_latest('electricity', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '96000000-0000-0000-0000-000000000088') where id = '99000000-0000-0000-0000-000000000088'),
+  '99000000-0000-0000-0000-000000000088',
+  'lifecyclemodel latest search recalls English authored text'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260527_dataset_extracted_text_contract.sql
+++ b/supabase/tests/20260527_dataset_extracted_text_contract.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(18);
+select plan(19);
 
 select ok(
   util.dataset_json_search_text(
@@ -113,9 +113,9 @@ select ok(
 );
 
 select ok(
-  has_function_privilege('service_role', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute')
-    and not has_function_privilege('authenticated', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute')
-    and not has_function_privilege('anon', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text)', 'execute'),
+  has_function_privilege('service_role', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text)', 'execute')
+    and not has_function_privilege('authenticated', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text)', 'execute')
+    and not has_function_privilege('anon', 'public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text)', 'execute'),
   'dataset extracted_text historical backfill RPC is service-role only'
 );
 
@@ -339,7 +339,7 @@ select ok(
 );
 
 update public.flows
-   set extracted_text = 'stale extracted text'
+   set extracted_text = ''
  where id = '97000000-0000-0000-0000-000000000088';
 
 do $$
@@ -353,7 +353,8 @@ begin
       'flows',
       5000,
       v_after_id,
-      v_after_version
+      v_after_version,
+      'empty'
     );
     v_after_id := (v_payload->>'last_id')::uuid;
     v_after_version := v_payload->>'last_version';
@@ -377,7 +378,50 @@ select ok(
       and extracted_text ~ 'Wechselstrom'
    from public.flows
    where id = '97000000-0000-0000-0000-000000000088'),
-  'dataset extracted_text backfill RPC repairs stale rows in bounded batches'
+  'dataset extracted_text empty-mode backfill repairs missing rows in bounded batches'
+);
+
+update public.flows
+   set extracted_text = 'stale extracted text'
+ where id = '97000000-0000-0000-0000-000000000088';
+
+do $$
+declare
+  v_payload jsonb;
+  v_after_id uuid;
+  v_after_version text;
+begin
+  for i in 1..20 loop
+    v_payload := public.cmd_dataset_extracted_text_backfill(
+      'flows',
+      5000,
+      v_after_id,
+      v_after_version,
+      'stale'
+    );
+    v_after_id := (v_payload->>'last_id')::uuid;
+    v_after_version := v_payload->>'last_version';
+
+    exit when coalesce((v_payload->>'has_more')::boolean, false) is false
+      or exists (
+        select 1
+        from public.flows
+        where id = '97000000-0000-0000-0000-000000000088'
+          and extracted_text ~ '交流电'
+          and extracted_text ~ 'electricity'
+          and extracted_text ~ 'Wechselstrom'
+      );
+  end loop;
+end
+$$;
+
+select ok(
+  (select extracted_text ~ '交流电'
+      and extracted_text ~ 'electricity'
+      and extracted_text ~ 'Wechselstrom'
+   from public.flows
+   where id = '97000000-0000-0000-0000-000000000088'),
+  'dataset extracted_text stale-mode backfill repairs non-empty stale rows'
 );
 
 set local role authenticated;


### PR DESCRIPTION
Closes #88

## Summary
- Promote the extracted_text search contract and multilingual extraction fixes from dev to main.
- Promote the batched/tuned dataset extracted_text backfill RPC changes.
- Keep JSON fields out of the full-text search source and rely on extracted_text for search recall.

## Promoted dev PRs
- #89
- #90
- #91

## Validation
- Supabase Dev database workflows passed through 40ef1da.
- Dev backfill completed with 0 empty extracted_text rows for flows, processes, and lifecyclemodels.
- Dev search smoke passed for lifecyclemodels, flows, and processes in English and Chinese.
- cmd_dataset_create('flows') smoke returned in ~241ms inside a rollback transaction.

## Rollout
- After merge, apply the database migrations to the main Supabase environment before validating production search.