### PR TITLE
Promote extracted text hotfix to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "946d342d43fb938254eebd327f73180a5ab5f72f"
+lastReviewedCommit: "4f06bc9ddbad4d2a8e8cf2c1cd1d346e1d519d57"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 5270e2ab14750122337a641b4638bc2505b43760
+lastReviewedCommit: 66105189b230c47f79fd8a5bbdf74f9e14250eae
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 946d342d43fb938254eebd327f73180a5ab5f72f
+lastReviewedCommit: 4f06bc9ddbad4d2a8e8cf2c1cd1d346e1d519d57
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 946d342d43fb938254eebd327f73180a5ab5f72f
+lastReviewedCommit: 4f06bc9ddbad4d2a8e8cf2c1cd1d346e1d519d57
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260527091249_dataset_extracted_text_whitelist.sql
+++ b/supabase/migrations/20260527091249_dataset_extracted_text_whitelist.sql
@@ -1,0 +1,318 @@
+create or replace function util.dataset_json_search_text_allowed_prefixes(p_table text)
+returns text[]
+language sql
+immutable
+parallel safe
+as $$
+  select case lower(btrim(coalesce(p_table, '')))
+    when 'flows' then array[
+      'flowDataSet.flowInformation.dataSetInformation.name',
+      'flowDataSet.flowInformation.dataSetInformation.classificationInformation',
+      'flowDataSet.flowInformation.dataSetInformation.CASNumber',
+      'flowDataSet.flowInformation.dataSetInformation.common:other',
+      'flowDataSet.flowInformation.dataSetInformation.common:synonyms',
+      'flowDataSet.flowInformation.dataSetInformation.common:generalComment',
+      'flowDataSet.modellingAndValidation.LCIMethod.typeOfDataSet',
+      'flowDataSet.flowProperties.flowProperty.referenceToFlowPropertyDataSet.common:shortDescription'
+    ]
+    when 'processes' then array[
+      'processDataSet.processInformation.dataSetInformation.name',
+      'processDataSet.processInformation.dataSetInformation.classificationInformation',
+      'processDataSet.processInformation.dataSetInformation.common:generalComment',
+      'processDataSet.processInformation.geography.locationOfOperationSupplyOrProduction',
+      'processDataSet.processInformation.time',
+      'processDataSet.processInformation.technology',
+      'processDataSet.processInformation.quantitativeReference.referenceToReferenceFlow.common:shortDescription',
+      'processDataSet.modellingAndValidation.LCIMethod.typeOfDataSet'
+    ]
+    when 'lifecyclemodels' then array[
+      'lifeCycleModelDataSet.lifeCycleModelInformation.dataSetInformation.name',
+      'lifeCycleModelDataSet.lifeCycleModelInformation.dataSetInformation.classificationInformation',
+      'lifeCycleModelDataSet.lifeCycleModelInformation.dataSetInformation.common:generalComment',
+      'lifeCycleModelDataSet.lifeCycleModelInformation.technology.processes.processInstance.referenceToProcess.common:shortDescription'
+    ]
+    when 'contacts' then array[
+      'contactDataSet.contactInformation.dataSetInformation.common:name',
+      'contactDataSet.contactInformation.dataSetInformation.common:shortName',
+      'contactDataSet.contactInformation.dataSetInformation.name',
+      'contactDataSet.contactInformation.dataSetInformation.shortName',
+      'contactDataSet.contactInformation.dataSetInformation.email',
+      'contactDataSet.contactInformation.dataSetInformation.telephone',
+      'contactDataSet.contactInformation.dataSetInformation.wwwAddress',
+      'contactDataSet.contactInformation.dataSetInformation.classificationInformation'
+    ]
+    when 'sources' then array[
+      'sourceDataSet.sourceInformation.dataSetInformation.common:name',
+      'sourceDataSet.sourceInformation.dataSetInformation.common:shortName',
+      'sourceDataSet.sourceInformation.dataSetInformation.classificationInformation',
+      'sourceDataSet.sourceInformation.dataSetInformation.sourceDescriptionOrComment'
+    ]
+    when 'unitgroups' then array[
+      'unitGroupDataSet.unitGroupInformation.dataSetInformation.common:name',
+      'unitGroupDataSet.unitGroupInformation.dataSetInformation.common:shortName',
+      'unitGroupDataSet.unitGroupInformation.dataSetInformation.common:synonyms',
+      'unitGroupDataSet.unitGroupInformation.dataSetInformation.common:generalComment',
+      'unitGroupDataSet.unitGroupInformation.dataSetInformation.classificationInformation',
+      'unitGroupDataSet.units.unit.name'
+    ]
+    when 'flowproperties' then array[
+      'flowPropertyDataSet.flowPropertiesInformation.dataSetInformation.common:name',
+      'flowPropertyDataSet.flowPropertiesInformation.dataSetInformation.common:shortName',
+      'flowPropertyDataSet.flowPropertiesInformation.dataSetInformation.common:synonyms',
+      'flowPropertyDataSet.flowPropertiesInformation.dataSetInformation.common:generalComment',
+      'flowPropertyDataSet.flowPropertiesInformation.dataSetInformation.classificationInformation',
+      'flowPropertyDataSet.flowPropertiesInformation.quantitativeReference.referenceToReferenceUnitGroup.common:shortDescription'
+    ]
+    else array[
+      'name',
+      'common:name',
+      'shortName',
+      'common:shortName',
+      'classificationInformation',
+      'common:synonyms',
+      'common:generalComment',
+      'sourceDescriptionOrComment',
+      'technology',
+      'time',
+      'geography'
+    ]
+  end;
+$$;
+
+create or replace function util.dataset_json_search_text_is_noise(
+  p_text text,
+  p_leaf_key text
+) returns boolean
+language sql
+immutable
+parallel safe
+as $$
+  select coalesce(
+    nullif(btrim(p_text), '') is null
+    or coalesce(p_leaf_key, '') like '@%'
+    or coalesce(p_leaf_key, '') in (
+      'common:UUID',
+      'common:dataSetVersion',
+      'common:permanentDataSetURI',
+      'common:timeStamp',
+      'meanValue',
+      'resultingAmount',
+      'referenceToReferenceUnit'
+    )
+    or btrim(p_text) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+    or lower(btrim(p_text)) like 'http://%'
+    or lower(btrim(p_text)) like 'https://%'
+    or btrim(p_text) like '../%'
+    or btrim(p_text) like '/%'
+    or lower(btrim(p_text)) like '%.xsd%'
+    or lower(btrim(p_text)) like '%.xml%'
+    or lower(btrim(p_text)) like '%/schemas/%'
+    or btrim(p_text) ~* '^[0-9]{4}-[0-9]{2}-[0-9]{2}t[0-9]{2}:[0-9]{2}:[0-9]{2}',
+    true
+  );
+$$;
+
+create or replace function util.dataset_json_search_text(
+  p_table text,
+  p_json jsonb
+) returns text
+language sql
+immutable
+parallel safe
+as $$
+  with recursive walk(path, value) as (
+    select array[]::text[], p_json
+    where p_json is not null
+
+    union all
+
+    select w.path || child.key, child.value
+    from walk w
+    cross join lateral (
+      select elem.ordinality::text as key, elem.value
+      from jsonb_array_elements(
+        case when jsonb_typeof(w.value) = 'array' then w.value else '[]'::jsonb end
+      ) with ordinality as elem(value, ordinality)
+
+      union all
+
+      select obj.key, obj.value
+      from jsonb_each(
+        case when jsonb_typeof(w.value) = 'object' then w.value else '{}'::jsonb end
+      ) as obj(key, value)
+    ) child
+  ),
+  scalar_text as (
+    select distinct
+           nullif(btrim(value #>> '{}'), '') as text_value,
+           path[cardinality(path)] as leaf_key,
+           array_to_string(path, '.') as path_text
+    from walk
+    where jsonb_typeof(value) in ('string', 'number', 'boolean')
+  )
+  select coalesce(
+    string_agg(text_value, ' ' order by lower(text_value), text_value),
+    ''
+  )
+  from scalar_text
+  where text_value is not null
+    and exists (
+      select 1
+      from unnest(util.dataset_json_search_text_allowed_prefixes(p_table)) as allowed(prefix)
+      where scalar_text.path_text = allowed.prefix
+         or scalar_text.path_text like allowed.prefix || '.%'
+    )
+    and not util.dataset_json_search_text_is_noise(text_value, leaf_key);
+$$;
+
+create or replace function util.dataset_json_search_text(p_json jsonb)
+returns text
+language sql
+immutable
+parallel safe
+as $$
+  select util.dataset_json_search_text('generic', p_json);
+$$;
+
+alter function util.dataset_json_search_text_allowed_prefixes(text) owner to postgres;
+alter function util.dataset_json_search_text_is_noise(text, text) owner to postgres;
+alter function util.dataset_json_search_text(text, jsonb) owner to postgres;
+alter function util.dataset_json_search_text(jsonb) owner to postgres;
+
+revoke all on function util.dataset_json_search_text_allowed_prefixes(text) from public;
+revoke all on function util.dataset_json_search_text_is_noise(text, text) from public;
+revoke all on function util.dataset_json_search_text(text, jsonb) from public;
+revoke all on function util.dataset_json_search_text(jsonb) from public;
+
+grant execute on function util.dataset_json_search_text(text, jsonb) to service_role;
+grant execute on function util.dataset_json_search_text(jsonb) to service_role;
+
+create or replace function util.set_dataset_extracted_text_from_json()
+returns trigger
+language plpgsql
+set search_path to 'public', 'util', 'pg_temp'
+as $$
+begin
+  new.extracted_text := util.dataset_json_search_text(TG_TABLE_NAME, new.json);
+  return new;
+end;
+$$;
+
+alter function util.set_dataset_extracted_text_from_json() owner to postgres;
+revoke all on function util.set_dataset_extracted_text_from_json() from public;
+grant execute on function util.set_dataset_extracted_text_from_json() to service_role;
+
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null,
+  p_mode text default 'empty'
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_mode text := lower(btrim(coalesce(p_mode, 'empty')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
+
+  if v_mode not in ('empty', 'stale') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_BACKFILL_MODE',
+      'message', format('Unsupported extracted_text backfill mode: %s', coalesce(p_mode, '<null>'))
+    );
+  end if;
+
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%1$I
+         where json is not null
+           and ($4 <> 'empty' or coalesce(extracted_text, '') = '')
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      computed as (
+        select dataset.id,
+               dataset.version,
+               util.dataset_json_search_text($5, dataset.json) as next_extracted_text
+          from public.%1$I as dataset
+          join page on page.id = dataset.id
+                   and page.version = dataset.version
+      ),
+      updated as (
+        update public.%1$I as dataset
+           set extracted_text = computed.next_extracted_text
+          from computed
+         where dataset.id = computed.id
+           and dataset.version = computed.version
+           and (
+             $4 = 'empty'
+             or dataset.extracted_text is distinct from computed.next_extracted_text
+           )
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size, v_mode, v_table
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
+
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'mode', v_mode,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) to service_role;
+
+comment on function util.dataset_json_search_text(text, jsonb) is
+  'Builds deterministic dataset full-text search input from entity-specific core JSON paths, preserving all authored languages while excluding reference/schema metadata noise.';
+
+comment on function util.dataset_json_search_text(jsonb) is
+  'Compatibility wrapper for deterministic generic JSON search text extraction; table-aware callers should use util.dataset_json_search_text(text, jsonb).';
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. Default mode repairs empty rows only; mode=stale performs full consistency repair using table-aware core-field extraction.';

--- a/supabase/migrations/20260527092406_dataset_extracted_text_subtree_paths.sql
+++ b/supabase/migrations/20260527092406_dataset_extracted_text_subtree_paths.sql
@@ -1,0 +1,92 @@
+create or replace function util.dataset_json_search_text(
+  p_table text,
+  p_json jsonb
+) returns text
+language sql
+immutable
+parallel safe
+as $$
+  with recursive allowed(prefix, prefix_path) as (
+    select prefix, string_to_array(prefix, '.') as prefix_path
+    from unnest(util.dataset_json_search_text_allowed_prefixes(p_table)) as allowed(prefix)
+  ),
+  path_nodes(prefix, remaining_path, value) as (
+    select allowed.prefix, allowed.prefix_path, p_json
+    from allowed
+    where p_json is not null
+
+    union all
+
+    select n.prefix,
+           case
+             when jsonb_typeof(n.value) = 'array' then n.remaining_path
+             when cardinality(n.remaining_path) > 1 then n.remaining_path[2:cardinality(n.remaining_path)]
+             else array[]::text[]
+           end as remaining_path,
+           child.value
+    from path_nodes n
+    cross join lateral (
+      select elem.value
+      from jsonb_array_elements(
+        case when jsonb_typeof(n.value) = 'array' then n.value else '[]'::jsonb end
+      ) as elem(value)
+
+      union all
+
+      select n.value -> n.remaining_path[1]
+      where jsonb_typeof(n.value) = 'object'
+        and cardinality(n.remaining_path) > 0
+        and n.value ? n.remaining_path[1]
+    ) child
+    where cardinality(n.remaining_path) > 0
+  ),
+  subtrees as (
+    select distinct value
+    from path_nodes
+    where cardinality(remaining_path) = 0
+      and value is not null
+  ),
+  walk(path, value) as (
+    select array[]::text[], value
+    from subtrees
+
+    union all
+
+    select w.path || child.key, child.value
+    from walk w
+    cross join lateral (
+      select elem.ordinality::text as key, elem.value
+      from jsonb_array_elements(
+        case when jsonb_typeof(w.value) = 'array' then w.value else '[]'::jsonb end
+      ) with ordinality as elem(value, ordinality)
+
+      union all
+
+      select obj.key, obj.value
+      from jsonb_each(
+        case when jsonb_typeof(w.value) = 'object' then w.value else '{}'::jsonb end
+      ) as obj(key, value)
+    ) child
+  ),
+  scalar_text as (
+    select distinct
+           nullif(btrim(value #>> '{}'), '') as text_value,
+           path[cardinality(path)] as leaf_key
+    from walk
+    where jsonb_typeof(value) in ('string', 'number', 'boolean')
+  )
+  select coalesce(
+    string_agg(text_value, ' ' order by lower(text_value), text_value),
+    ''
+  )
+  from scalar_text
+  where text_value is not null
+    and not util.dataset_json_search_text_is_noise(text_value, leaf_key);
+$$;
+
+alter function util.dataset_json_search_text(text, jsonb) owner to postgres;
+revoke all on function util.dataset_json_search_text(text, jsonb) from public;
+grant execute on function util.dataset_json_search_text(text, jsonb) to service_role;
+
+comment on function util.dataset_json_search_text(text, jsonb) is
+  'Builds deterministic dataset full-text search input by walking only entity-specific core JSON subtrees, preserving all authored languages while excluding reference/schema metadata noise.';

--- a/supabase/migrations/20260527092919_dataset_extracted_text_backfill_rewrite_selected.sql
+++ b/supabase/migrations/20260527092919_dataset_extracted_text_backfill_rewrite_selected.sql
@@ -1,0 +1,104 @@
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null,
+  p_mode text default 'empty'
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_mode text := lower(btrim(coalesce(p_mode, 'empty')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
+
+  if v_mode not in ('empty', 'stale') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_BACKFILL_MODE',
+      'message', format('Unsupported extracted_text backfill mode: %s', coalesce(p_mode, '<null>'))
+    );
+  end if;
+
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%1$I
+         where json is not null
+           and ($4 <> 'empty' or coalesce(extracted_text, '') = '')
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      computed as (
+        select dataset.id,
+               dataset.version,
+               util.dataset_json_search_text($5, dataset.json) as next_extracted_text
+          from public.%1$I as dataset
+          join page on page.id = dataset.id
+                   and page.version = dataset.version
+      ),
+      updated as (
+        update public.%1$I as dataset
+           set extracted_text = computed.next_extracted_text
+          from computed
+         where dataset.id = computed.id
+           and dataset.version = computed.version
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size, v_mode, v_table
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
+
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'mode', v_mode,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) to service_role;
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. It rewrites selected rows directly so stale repairs do not read old oversized extracted_text values for comparison.';

--- a/supabase/migrations/20260527093305_dataset_extracted_text_backfill_noisy_mode.sql
+++ b/supabase/migrations/20260527093305_dataset_extracted_text_backfill_noisy_mode.sql
@@ -1,0 +1,111 @@
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null,
+  p_mode text default 'empty'
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_mode text := lower(btrim(coalesce(p_mode, 'empty')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
+
+  if v_mode not in ('empty', 'stale', 'noisy') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_BACKFILL_MODE',
+      'message', format('Unsupported extracted_text backfill mode: %s', coalesce(p_mode, '<null>'))
+    );
+  end if;
+
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%1$I
+         where json is not null
+           and ($4 <> 'empty' or coalesce(extracted_text, '') = '')
+           and (
+             $4 <> 'noisy'
+             or extracted_text like '%%../%%'
+             or extracted_text like '%%schemas/%%'
+             or extracted_text ~* 'https?://'
+             or extracted_text ~* '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+           )
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      computed as (
+        select dataset.id,
+               dataset.version,
+               util.dataset_json_search_text($5, dataset.json) as next_extracted_text
+          from public.%1$I as dataset
+          join page on page.id = dataset.id
+                   and page.version = dataset.version
+      ),
+      updated as (
+        update public.%1$I as dataset
+           set extracted_text = computed.next_extracted_text
+          from computed
+         where dataset.id = computed.id
+           and dataset.version = computed.version
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size, v_mode, v_table
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
+
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'mode', v_mode,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) to service_role;
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. Modes: empty repairs empty rows, noisy rewrites rows with reference/schema metadata noise, stale rewrites every selected row.';

--- a/supabase/migrations/20260527094127_dataset_extracted_text_noisy_path_only.sql
+++ b/supabase/migrations/20260527094127_dataset_extracted_text_noisy_path_only.sql
@@ -1,0 +1,110 @@
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null,
+  p_mode text default 'empty'
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_mode text := lower(btrim(coalesce(p_mode, 'empty')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
+
+  if v_mode not in ('empty', 'stale', 'noisy') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_BACKFILL_MODE',
+      'message', format('Unsupported extracted_text backfill mode: %s', coalesce(p_mode, '<null>'))
+    );
+  end if;
+
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%1$I
+         where json is not null
+           and ($4 <> 'empty' or coalesce(extracted_text, '') = '')
+           and (
+             $4 <> 'noisy'
+             or extracted_text like '%%../%%'
+             or extracted_text like '%%schemas/%%'
+             or extracted_text ~* 'https?://'
+           )
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      computed as (
+        select dataset.id,
+               dataset.version,
+               util.dataset_json_search_text($5, dataset.json) as next_extracted_text
+          from public.%1$I as dataset
+          join page on page.id = dataset.id
+                   and page.version = dataset.version
+      ),
+      updated as (
+        update public.%1$I as dataset
+           set extracted_text = computed.next_extracted_text
+          from computed
+         where dataset.id = computed.id
+           and dataset.version = computed.version
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size, v_mode, v_table
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
+
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'mode', v_mode,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) to service_role;
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. Modes: empty repairs empty rows, noisy rewrites rows with path/schema/URL metadata noise, stale rewrites every selected row.';

--- a/supabase/migrations/20260527095015_dataset_extracted_text_noisy_schema_path_only.sql
+++ b/supabase/migrations/20260527095015_dataset_extracted_text_noisy_schema_path_only.sql
@@ -1,0 +1,109 @@
+create or replace function public.cmd_dataset_extracted_text_backfill(
+  p_table text,
+  p_batch_size integer default 1000,
+  p_after_id uuid default null,
+  p_after_version text default null,
+  p_mode text default 'empty'
+) returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  v_table text := lower(btrim(coalesce(p_table, '')));
+  v_mode text := lower(btrim(coalesce(p_mode, 'empty')));
+  v_batch_size integer := least(greatest(coalesce(p_batch_size, 1000), 1), 5000);
+  v_scanned_count integer := 0;
+  v_updated_count integer := 0;
+  v_last_id uuid;
+  v_last_version text;
+begin
+  if v_table not in (
+    'flows',
+    'processes',
+    'lifecyclemodels',
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_DATASET_TABLE',
+      'message', format('Unsupported dataset table: %s', coalesce(p_table, '<null>'))
+    );
+  end if;
+
+  if v_mode not in ('empty', 'stale', 'noisy') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'UNSUPPORTED_BACKFILL_MODE',
+      'message', format('Unsupported extracted_text backfill mode: %s', coalesce(p_mode, '<null>'))
+    );
+  end if;
+
+  execute format(
+    $sql$
+      with page as (
+        select id, version
+          from public.%1$I
+         where json is not null
+           and ($4 <> 'empty' or coalesce(extracted_text, '') = '')
+           and (
+             $4 <> 'noisy'
+             or extracted_text like '%%../%%'
+             or extracted_text like '%%schemas/%%'
+           )
+           and ($1 is null or (id, version) > ($1, coalesce($2, '')::character(9)))
+         order by id, version
+         limit $3
+         for update skip locked
+      ),
+      computed as (
+        select dataset.id,
+               dataset.version,
+               util.dataset_json_search_text($5, dataset.json) as next_extracted_text
+          from public.%1$I as dataset
+          join page on page.id = dataset.id
+                   and page.version = dataset.version
+      ),
+      updated as (
+        update public.%1$I as dataset
+           set extracted_text = computed.next_extracted_text
+          from computed
+         where dataset.id = computed.id
+           and dataset.version = computed.version
+         returning 1
+      )
+      select
+        (select count(*)::integer from page),
+        (select count(*)::integer from updated),
+        (select id from page order by id desc, version desc limit 1),
+        (select version::text from page order by id desc, version desc limit 1)
+    $sql$,
+    v_table
+  )
+  using p_after_id, p_after_version, v_batch_size, v_mode, v_table
+  into v_scanned_count, v_updated_count, v_last_id, v_last_version;
+
+  return jsonb_build_object(
+    'ok', true,
+    'table', v_table,
+    'mode', v_mode,
+    'scanned_count', v_scanned_count,
+    'updated_count', v_updated_count,
+    'last_id', v_last_id,
+    'last_version', v_last_version,
+    'has_more', v_scanned_count = v_batch_size
+  );
+end;
+$$;
+
+alter function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) owner to postgres;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from public;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from anon;
+revoke all on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) from authenticated;
+grant execute on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) to service_role;
+
+comment on function public.cmd_dataset_extracted_text_backfill(text, integer, uuid, text, text) is
+  'Service-role RPC for bounded historical extracted_text backfill. Modes: empty repairs empty rows, noisy rewrites rows with schema/path metadata noise, stale rewrites every selected row.';

--- a/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
@@ -167,7 +167,7 @@ select ok(
     from public.contacts
     where id = '37000000-0000-0000-0000-000000000099'
       and version = '01.00.000'
-  ) like '%service role trigger text%',
+  ) like '%Service role trigger contact%',
   'service_role direct contact insert can run the extracted_text trigger'
 );
 
@@ -215,7 +215,7 @@ select is(
   (
     select version::text
     from public.pgroonga_search_contacts_latest(
-      'legacy unique',
+      'Legacy matched contact',
       '{}'::jsonb,
       10,
       1,
@@ -232,7 +232,7 @@ select is(
   (
     select max(total_count)
     from public.pgroonga_search_contacts_latest(
-      'legacy unique',
+      'Legacy matched contact',
       '{}'::jsonb,
       10,
       1,

--- a/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
@@ -176,7 +176,7 @@ select is(
   (
     select version::text
     from public.pgroonga_search_flowproperties_latest(
-      'legacy unique',
+      'Legacy matched flow property',
       '{}'::jsonb,
       10,
       1,
@@ -193,7 +193,7 @@ select is(
   (
     select max(total_count)
     from public.pgroonga_search_flowproperties_latest(
-      'legacy unique',
+      'Legacy matched flow property',
       '{}'::jsonb,
       10,
       1,

--- a/supabase/tests/20260520_sources_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_sources_latest_version_query_rpcs.sql
@@ -176,7 +176,7 @@ select is(
   (
     select version::text
     from public.pgroonga_search_sources_latest(
-      'legacy unique',
+      'Legacy matched source',
       '{}'::jsonb,
       10,
       1,
@@ -193,7 +193,7 @@ select is(
   (
     select max(total_count)
     from public.pgroonga_search_sources_latest(
-      'legacy unique',
+      'Legacy matched source',
       '{}'::jsonb,
       10,
       1,

--- a/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
@@ -176,7 +176,7 @@ select is(
   (
     select version::text
     from public.pgroonga_search_unitgroups_latest(
-      'legacy unique',
+      'Legacy matched unit group',
       '{}'::jsonb,
       10,
       1,
@@ -193,7 +193,7 @@ select is(
   (
     select max(total_count)
     from public.pgroonga_search_unitgroups_latest(
-      'legacy unique',
+      'Legacy matched unit group',
       '{}'::jsonb,
       10,
       1,

--- a/supabase/tests/20260527_dataset_extracted_text_contract.sql
+++ b/supabase/tests/20260527_dataset_extracted_text_contract.sql
@@ -3,70 +3,182 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(19);
+select plan(24);
 
 select ok(
   util.dataset_json_search_text(
+    'flows',
     '{
-      "name": [
-        {"@xml:lang":"zh","#text":"交流电"},
-        {"@xml:lang":"en","#text":"electricity"},
-        {"@xml:lang":"de","#text":"Wechselstrom"}
-      ],
-      "classification": {"@classId":"class-ac-001", "#text":"能源"},
-      "amount": 42,
-      "active": true
+      "flowDataSet": {
+        "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/Flow ../../schemas/ILCD_FlowDataSet.xsd",
+        "flowInformation": {
+          "dataSetInformation": {
+            "common:UUID": "97000000-0000-0000-0000-000000000088",
+            "name": {
+              "baseName": [
+                {"@xml:lang":"zh","#text":"交流电"},
+                {"@xml:lang":"en","#text":"electricity"},
+                {"@xml:lang":"de","#text":"Wechselstrom"}
+              ]
+            },
+            "common:synonyms": [
+              {"@xml:lang":"zh","#text":"交流电力"},
+              {"@xml:lang":"en","#text":"alternating current electricity"}
+            ],
+            "classificationInformation": {
+              "common:classification": {
+                "common:class": {"@classId":"class-ac-001", "#text":"能源"}
+              }
+            },
+            "common:other": {
+              "ecn:ECNumber": "EC-123-456"
+            }
+          }
+        },
+        "administrativeInformation": {
+          "dataEntryBy": {
+            "common:referenceToDataSetFormat": {
+              "@uri": "../sources/97000000-0000-0000-0000-000000000088.xml",
+              "@refObjectId": "97000000-0000-0000-0000-000000000088",
+              "common:shortDescription": {"@xml:lang":"en","#text":"ILCD format"}
+            }
+          }
+        }
+      }
     }'::jsonb
   ) ~ '交流电'
   and util.dataset_json_search_text(
+    'flows',
     '{
-      "name": [
-        {"@xml:lang":"zh","#text":"交流电"},
-        {"@xml:lang":"en","#text":"electricity"},
-        {"@xml:lang":"de","#text":"Wechselstrom"}
-      ],
-      "classification": {"@classId":"class-ac-001", "#text":"能源"},
-      "amount": 42,
-      "active": true
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {
+              "baseName": [
+                {"@xml:lang":"zh","#text":"交流电"},
+                {"@xml:lang":"en","#text":"electricity"},
+                {"@xml:lang":"de","#text":"Wechselstrom"}
+              ]
+            },
+            "common:synonyms": [{"@xml:lang":"en","#text":"alternating current electricity"}],
+            "classificationInformation": {
+              "common:classification": {
+                "common:class": {"@classId":"class-ac-001", "#text":"能源"}
+              }
+            },
+            "common:other": {"ecn:ECNumber": "EC-123-456"}
+          }
+        },
+        "administrativeInformation": {
+          "dataEntryBy": {
+            "common:referenceToDataSetFormat": {
+              "@uri": "../sources/97000000-0000-0000-0000-000000000088.xml",
+              "@refObjectId": "97000000-0000-0000-0000-000000000088",
+              "common:shortDescription": {"@xml:lang":"en","#text":"ILCD format"}
+            }
+          }
+        }
+      }
     }'::jsonb
   ) ~ 'electricity'
   and util.dataset_json_search_text(
+    'flows',
     '{
-      "name": [
-        {"@xml:lang":"zh","#text":"交流电"},
-        {"@xml:lang":"en","#text":"electricity"},
-        {"@xml:lang":"de","#text":"Wechselstrom"}
-      ],
-      "classification": {"@classId":"class-ac-001", "#text":"能源"},
-      "amount": 42,
-      "active": true
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {"baseName": [{"@xml:lang":"de","#text":"Wechselstrom"}]},
+            "classificationInformation": {
+              "common:classification": {
+                "common:class": {"@classId":"class-ac-001", "#text":"能源"}
+              }
+            },
+            "common:other": {"ecn:ECNumber": "EC-123-456"}
+          }
+        }
+      }
     }'::jsonb
   ) ~ 'Wechselstrom'
   and util.dataset_json_search_text(
+    'flows',
     '{
-      "name": [
-        {"@xml:lang":"zh","#text":"交流电"},
-        {"@xml:lang":"en","#text":"electricity"},
-        {"@xml:lang":"de","#text":"Wechselstrom"}
-      ],
-      "classification": {"@classId":"class-ac-001", "#text":"能源"},
-      "amount": 42,
-      "active": true
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {"baseName": [{"@xml:lang":"zh","#text":"交流电"}]},
+            "classificationInformation": {
+              "common:classification": {
+                "common:class": {"@classId":"class-ac-001", "#text":"能源"}
+              }
+            },
+            "common:other": {"ecn:ECNumber": "EC-123-456"}
+          }
+        }
+      }
     }'::jsonb
-  ) ~ 'class-ac-001'
+  ) ~ '能源'
   and util.dataset_json_search_text(
+    'flows',
     '{
-      "name": [
-        {"@xml:lang":"zh","#text":"交流电"},
-        {"@xml:lang":"en","#text":"electricity"},
-        {"@xml:lang":"de","#text":"Wechselstrom"}
-      ],
-      "classification": {"@classId":"class-ac-001", "#text":"能源"},
-      "amount": 42,
-      "active": true
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {"baseName": [{"@xml:lang":"zh","#text":"交流电"}]},
+            "common:other": {"ecn:ECNumber": "EC-123-456"}
+          }
+        }
+      }
     }'::jsonb
-  ) ~ '42',
-  'dataset searchable text keeps all authored language values and scalar metadata'
+  ) ~ 'EC-123-456'
+  and util.dataset_json_search_text(
+    'flows',
+    '{
+      "flowDataSet": {
+        "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/Flow ../../schemas/ILCD_FlowDataSet.xsd",
+        "flowInformation": {
+          "dataSetInformation": {
+            "common:UUID": "97000000-0000-0000-0000-000000000088",
+            "name": {"baseName": [{"@xml:lang":"zh","#text":"交流电"}]},
+            "classificationInformation": {
+              "common:classification": {
+                "common:class": {"@classId":"class-ac-001", "#text":"能源"}
+              }
+            }
+          }
+        },
+        "administrativeInformation": {
+          "dataEntryBy": {
+            "common:referenceToDataSetFormat": {
+              "@uri": "../sources/97000000-0000-0000-0000-000000000088.xml",
+              "@refObjectId": "97000000-0000-0000-0000-000000000088",
+              "common:shortDescription": {"@xml:lang":"en","#text":"ILCD format"}
+            }
+          }
+        }
+      }
+    }'::jsonb
+  ) !~ '(class-ac-001|97000000-0000-0000-0000-000000000088|ILCD format|schemas)'
+  and strpos(util.dataset_json_search_text(
+    'flows',
+    '{
+      "flowDataSet": {
+        "flowInformation": {
+          "dataSetInformation": {
+            "name": {"baseName": [{"@xml:lang":"zh","#text":"交流电"}]}
+          }
+        },
+        "administrativeInformation": {
+          "dataEntryBy": {
+            "common:referenceToDataSetFormat": {
+              "@uri": "../sources/97000000-0000-0000-0000-000000000088.xml",
+              "common:shortDescription": {"@xml:lang":"en","#text":"ILCD format"}
+            }
+          }
+        }
+      }
+    }'::jsonb
+  ), '../') = 0,
+  'dataset searchable text keeps core authored values and excludes reference metadata noise'
 );
 
 select is(
@@ -191,6 +303,7 @@ values (
   '01.00.000',
   '{
     "flowDataSet": {
+      "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/Flow ../../schemas/ILCD_FlowDataSet.xsd",
       "flowInformation": {
         "dataSetInformation": {
           "common:UUID": "97000000-0000-0000-0000-000000000088",
@@ -201,6 +314,17 @@ values (
               {"@xml:lang": "de", "#text": "Wechselstrom"}
             ]
           },
+          "common:synonyms": [
+            {"@xml:lang": "zh", "#text": "交流电力"},
+            {"@xml:lang": "en", "#text": "alternating current electricity"}
+          ],
+          "common:generalComment": [
+            {"@xml:lang": "zh", "#text": "用于测试的交流电流"},
+            {"@xml:lang": "en", "#text": "Alternating current for search testing"}
+          ],
+          "common:other": {
+            "ecn:ECNumber": "EC-123-456"
+          },
           "classificationInformation": {
             "common:classification": {
               "common:class": [{"@classId": "flow-energy", "#text": "能源"}]
@@ -209,7 +333,17 @@ values (
         }
       },
       "administrativeInformation": {
+        "dataEntryBy": {
+          "common:referenceToDataSetFormat": {
+            "@uri": "../sources/97000000-0000-0000-0000-000000000088.xml",
+            "@type": "source data set",
+            "@version": "01.00.000",
+            "@refObjectId": "97000000-0000-0000-0000-000000000088",
+            "common:shortDescription": {"@xml:lang": "en", "#text": "ILCD format"}
+          }
+        },
         "publicationAndOwnership": {
+          "common:permanentDataSetURI": "https://lcdn.tiangong.earth/flows/97000000-0000-0000-0000-000000000088?version=01.00.000",
           "common:dataSetVersion": "01.00.000"
         }
       }
@@ -235,6 +369,7 @@ values (
   '01.00.000',
   '{
     "processDataSet": {
+      "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/Process ../../schemas/ILCD_ProcessDataSet.xsd",
       "processInformation": {
         "dataSetInformation": {
           "common:UUID": "98000000-0000-0000-0000-000000000088",
@@ -244,16 +379,55 @@ values (
               {"@xml:lang": "en", "#text": "electricity process"},
               {"@xml:lang": "de", "#text": "Wechselstrom Prozess"}
             ]
+          },
+          "classificationInformation": {
+            "common:classification": {
+              "common:class": {"@classId": "process-energy", "#text": "能源过程"}
+            }
           }
         },
-        "modellingAndValidation": {
-          "LCIMethodAndAllocation": {
-            "typeOfDataSet": "Unit process"
+        "geography": {
+          "locationOfOperationSupplyOrProduction": {
+            "descriptionOfRestrictions": [
+              {"@xml:lang": "zh", "#text": "中国电网"},
+              {"@xml:lang": "en", "#text": "China grid"}
+            ]
+          }
+        },
+        "technology": {
+          "technologyDescriptionAndIncludedProcesses": [
+            {"@xml:lang": "zh", "#text": "交流电生产技术"},
+            {"@xml:lang": "en", "#text": "alternating current production technology"}
+          ]
+        },
+        "quantitativeReference": {
+          "referenceToReferenceFlow": {
+            "@uri": "../flows/98000000-0000-0000-0000-000000000088.xml",
+            "@refObjectId": "98000000-0000-0000-0000-000000000088",
+            "common:shortDescription": [
+              {"@xml:lang": "zh", "#text": "交流电产品"},
+              {"@xml:lang": "en", "#text": "electricity product"}
+            ]
+          }
+        }
+      },
+      "modellingAndValidation": {
+        "LCIMethod": {
+          "typeOfDataSet": "Unit process"
+        }
+      },
+      "exchanges": {
+        "exchange": {
+          "referenceToFlowDataSet": {
+            "@uri": "../flows/11111111-1111-1111-1111-111111111111.xml",
+            "@refObjectId": "11111111-1111-1111-1111-111111111111",
+            "common:shortDescription": {"@xml:lang": "en", "#text": "exchange side noise"}
           }
         }
       },
       "administrativeInformation": {
         "publicationAndOwnership": {
+          "common:permanentDataSetURI": "https://lcdn.tiangong.earth/processes/98000000-0000-0000-0000-000000000088?version=01.00.000",
           "common:dataSetVersion": "01.00.000"
         }
       }
@@ -279,6 +453,7 @@ values (
   '01.00.000',
   '{
     "lifeCycleModelDataSet": {
+      "@xsi:schemaLocation": "http://lca.jrc.it/ILCD/LCIAMethod ../../schemas/ILCD_LifeCycleModelDataSet.xsd",
       "lifeCycleModelInformation": {
         "dataSetInformation": {
           "common:UUID": "99000000-0000-0000-0000-000000000088",
@@ -288,11 +463,31 @@ values (
               {"@xml:lang": "en", "#text": "electricity model"},
               {"@xml:lang": "de", "#text": "Wechselstrom Modell"}
             ]
+          },
+          "classificationInformation": {
+            "common:classification": {
+              "common:class": {"@classId": "model-energy", "#text": "能源模型"}
+            }
+          }
+        },
+        "technology": {
+          "processes": {
+            "processInstance": {
+              "referenceToProcess": {
+                "@uri": "../processes/99000000-0000-0000-0000-000000000088.xml",
+                "@refObjectId": "99000000-0000-0000-0000-000000000088",
+                "common:shortDescription": [
+                  {"@xml:lang": "zh", "#text": "交流电生产过程"},
+                  {"@xml:lang": "en", "#text": "electricity production process"}
+                ]
+              }
+            }
           }
         }
       },
       "administrativeInformation": {
         "publicationAndOwnership": {
+          "common:permanentDataSetURI": "https://lcdn.tiangong.earth/models/99000000-0000-0000-0000-000000000088?version=01.00.000",
           "common:dataSetVersion": "01.00.000"
         }
       }
@@ -309,11 +504,24 @@ select ok(
     select extracted_text ~ '交流电'
        and extracted_text ~ 'electricity'
        and extracted_text ~ 'Wechselstrom'
-       and extracted_text ~ 'flow-energy'
+       and extracted_text ~ '交流电力'
+       and extracted_text ~ 'alternating current electricity'
+       and extracted_text ~ 'EC-123-456'
+       and extracted_text ~ '能源'
     from public.flows
     where id = '97000000-0000-0000-0000-000000000088'
   ),
-  'flow extracted_text trigger preserves all authored languages and codes'
+  'flow extracted_text trigger preserves all authored languages and core fields'
+);
+
+select ok(
+  (
+    select extracted_text !~ '(flow-energy|97000000-0000-0000-0000-000000000088|ILCD format|schemas|https?://)'
+       and strpos(extracted_text, '../') = 0
+    from public.flows
+    where id = '97000000-0000-0000-0000-000000000088'
+  ),
+  'flow extracted_text trigger excludes UUID, schema, URI, and reference metadata noise'
 );
 
 select ok(
@@ -321,10 +529,24 @@ select ok(
     select extracted_text ~ '交流电过程'
        and extracted_text ~ 'electricity process'
        and extracted_text ~ 'Wechselstrom Prozess'
+       and extracted_text ~ '中国电网'
+       and extracted_text ~ 'China grid'
+       and extracted_text ~ '交流电产品'
+       and extracted_text ~ 'electricity product'
     from public.processes
     where id = '98000000-0000-0000-0000-000000000088'
   ),
-  'process extracted_text trigger preserves all authored languages'
+  'process extracted_text trigger preserves all authored languages and core fields'
+);
+
+select ok(
+  (
+    select extracted_text !~ '(process-energy|98000000-0000-0000-0000-000000000088|exchange side noise|schemas|https?://)'
+       and strpos(extracted_text, '../') = 0
+    from public.processes
+    where id = '98000000-0000-0000-0000-000000000088'
+  ),
+  'process extracted_text trigger excludes reference metadata and exchange noise'
 );
 
 select ok(
@@ -332,10 +554,22 @@ select ok(
     select extracted_text ~ '交流电模型'
        and extracted_text ~ 'electricity model'
        and extracted_text ~ 'Wechselstrom Modell'
+       and extracted_text ~ '交流电生产过程'
+       and extracted_text ~ 'electricity production process'
     from public.lifecyclemodels
     where id = '99000000-0000-0000-0000-000000000088'
   ),
-  'lifecyclemodel extracted_text trigger preserves all authored languages'
+  'lifecyclemodel extracted_text trigger preserves all authored languages and process references'
+);
+
+select ok(
+  (
+    select extracted_text !~ '(model-energy|99000000-0000-0000-0000-000000000088|schemas|https?://)'
+       and strpos(extracted_text, '../') = 0
+    from public.lifecyclemodels
+    where id = '99000000-0000-0000-0000-000000000088'
+  ),
+  'lifecyclemodel extracted_text trigger excludes reference metadata noise'
 );
 
 update public.flows
@@ -422,6 +656,57 @@ select ok(
    from public.flows
    where id = '97000000-0000-0000-0000-000000000088'),
   'dataset extracted_text stale-mode backfill repairs non-empty stale rows'
+);
+
+select ok(
+  (select extracted_text !~ '(flow-energy|97000000-0000-0000-0000-000000000088|ILCD format|schemas|https?://)'
+      and strpos(extracted_text, '../') = 0
+   from public.flows
+   where id = '97000000-0000-0000-0000-000000000088'),
+  'dataset extracted_text stale-mode backfill keeps repaired rows free of metadata noise'
+);
+
+update public.flows
+   set extracted_text = '../sources/97000000-0000-0000-0000-000000000088.xml ILCD format'
+ where id = '97000000-0000-0000-0000-000000000088';
+
+do $$
+declare
+  v_payload jsonb;
+  v_after_id uuid;
+  v_after_version text;
+begin
+  for i in 1..20 loop
+    v_payload := public.cmd_dataset_extracted_text_backfill(
+      'flows',
+      5000,
+      v_after_id,
+      v_after_version,
+      'noisy'
+    );
+    v_after_id := (v_payload->>'last_id')::uuid;
+    v_after_version := v_payload->>'last_version';
+
+    exit when coalesce((v_payload->>'has_more')::boolean, false) is false
+      or exists (
+        select 1
+        from public.flows
+        where id = '97000000-0000-0000-0000-000000000088'
+          and extracted_text ~ '交流电'
+          and extracted_text !~ 'ILCD format'
+          and strpos(extracted_text, '../') = 0
+      );
+  end loop;
+end
+$$;
+
+select ok(
+  (select extracted_text ~ '交流电'
+      and extracted_text !~ 'ILCD format'
+      and strpos(extracted_text, '../') = 0
+   from public.flows
+   where id = '97000000-0000-0000-0000-000000000088'),
+  'dataset extracted_text noisy-mode backfill repairs metadata-polluted rows'
 );
 
 set local role authenticated;


### PR DESCRIPTION
Closes #93

## Summary
- Promote the extracted_text whitelist/subtree hotfix from dev to main.
- Keep generated search text constrained to entity-specific core fields while preserving all authored languages.
- Include bounded backfill RPC refinements for empty/stale/noisy extracted_text repair.

## Dev validation
- Applied the migrations to Supabase dev.
- Ran targeted noisy backfill on flows, processes, lifecyclemodels, contacts, sources, unitgroups, and flowproperties.
- Rebuilt and validated all *_text_pgroonga indexes on dev.
- Verified schema/path pollution count is zero across affected searchable tables.
- Verified dev search smoke cases for lifecyclemodels, flows, and processes.

## Local validation
- supabase db reset
- supabase test db: 22 files, 366 tests passed
- scripts/docpact lint --root . --merge-base origin/dev --mode enforce
- git diff --check

## Notes
- supabase db lint exits successfully but still reports pre-existing historical lint findings unrelated to this hotfix.
- Production backfill should use the same phased approach used on dev: drop/rebuild text PGroonga indexes around the bounded backfill and validate search/index state afterward.