### PR TITLE
Move ai-doc-lint to the local gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "4f06bc9ddbad4d2a8e8cf2c1cd1d346e1d519d57"
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "2b4a98d420c1404884bb432ade7951e3853ed210"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,19 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run docpact lint
-        run: >
-          scripts/docpact lint
-          --root .
-          --base "${{ github.event.pull_request.base.sha }}"
-          --head "${{ github.event.pull_request.head.sha }}"
-          --mode enforce
+      - name: Run local docpact gate
+        run: scripts/docpact-gate.sh --base origin/main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ Do not start from generated schema workspace files, long migration history, or G
 - minimum proof and PR validation note shape live in `docs/agents/repo-validation.md`
 - stable path ownership and generated-workspace rules live in `docs/agents/repo-architecture.md`
 - deeper branch-operation rules live in `docs/agents/supabase-branching.md`
-- repo-local documentation maintenance is enforced by `.github/workflows/ai-doc-lint.yml` with `docpact lint`
+- repo-local documentation maintenance is enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback
 
 ## Minimal Execution Facts
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -125,4 +125,4 @@ If a task changes both schema and app behavior, the SQL truth still starts here.
 
 ## Local Docpact Push Gate
 
-This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; CI remains the authoritative PR enforcement path.
+This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; ordinary PRs and pushes rely on the local gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback for remote reproduction.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 4f06bc9ddbad4d2a8e8cf2c1cd1d346e1d519d57
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 2b4a98d420c1404884bb432ade7951e3853ed210
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- move ai-doc-lint off ordinary PR/push execution and keep it as manual fallback
- keep documentation governance in the local pre-push gate


## Validation
- parsed changed GitHub workflow YAML locally
- ran repo docpact/AI-doc gate against origin/main..HEAD
- ran local test gate where the repo pre-push hook required it

Closes #96
