### PR TITLE
Fix docpact gate review feedback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "bc098b2cb6159d57ff363d02b6b4176a77607639"
+lastReviewedCommit: "b44864d9e2058629d99e0a92e130417d8baa14a1"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "2b4a98d420c1404884bb432ade7951e3853ed210"
+lastReviewedCommit: "bc098b2cb6159d57ff363d02b6b4176a77607639"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "b44864d9e2058629d99e0a92e130417d8baa14a1"
+lastReviewedCommit: "b39776ecca40115b9af574bfda4522a93d2eed55"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -31,4 +31,6 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: scripts/docpact-gate.sh --base "$BASE_REF"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -2,6 +2,11 @@ name: ai-doc-lint
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref for the manual docpact comparison.
+        required: false
+        default: origin/dev
 
 permissions:
   contents: read
@@ -16,8 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch main
-        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+      - name: Fetch branches
+        run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -26,4 +31,4 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: bc098b2cb6159d57ff363d02b6b4176a77607639
+lastReviewedCommit: b44864d9e2058629d99e0a92e130417d8baa14a1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 66105189b230c47f79fd8a5bbdf74f9e14250eae
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: bc098b2cb6159d57ff363d02b6b4176a77607639
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b44864d9e2058629d99e0a92e130417d8baa14a1
+lastReviewedCommit: b39776ecca40115b9af574bfda4522a93d2eed55
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b44864d9e2058629d99e0a92e130417d8baa14a1
+lastReviewedCommit: b39776ecca40115b9af574bfda4522a93d2eed55
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 4f06bc9ddbad4d2a8e8cf2c1cd1d346e1d519d57
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: b44864d9e2058629d99e0a92e130417d8baa14a1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b44864d9e2058629d99e0a92e130417d8baa14a1
+lastReviewedCommit: b39776ecca40115b9af574bfda4522a93d2eed55
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 2b4a98d420c1404884bb432ade7951e3853ed210
+lastReviewedCommit: bc098b2cb6159d57ff363d02b6b4176a77607639
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: bc098b2cb6159d57ff363d02b6b4176a77607639
+lastReviewedCommit: b44864d9e2058629d99e0a92e130417d8baa14a1
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- address Codex review feedback from the ai-doc local-gate rollout
- make manual ai-doc/docpact fallback workflows accept an explicit base_ref and fetch remote branches
- make release tag docpact gates compare the tag commit against its parent instead of a base that can collapse to the tag commit
- refresh governance review evidence for the touched workflow guidance docs

## Validation
- YAML workflow parse passed from the workspace root
- local docpact/ai-doc gate passed for this branch

Refs tiangong-lca/workspace#183