### PR TITLE
Fix hybrid search text recall path

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "6f96a58753b81beccf75a88a9368e12bba012640"
+lastReviewedCommit: "983a9085ea04a6babc978fd45d82d7d32921171d"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
+lastReviewedCommit: 983a9085ea04a6babc978fd45d82d7d32921171d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
+lastReviewedCommit: 983a9085ea04a6babc978fd45d82d7d32921171d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
+lastReviewedCommit: 983a9085ea04a6babc978fd45d82d7d32921171d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260528172000_hybrid_search_use_latest_text_candidates.sql
+++ b/supabase/migrations/20260528172000_hybrid_search_use_latest_text_candidates.sql
@@ -1,0 +1,384 @@
+-- Keep hybrid search aligned with ordinary latest search semantics.  The text
+-- side now uses the same extracted_text/latest-version/visibility path as
+-- search_*_latest instead of the legacy JSON PGroonga + text_v1 helpers.
+
+create or replace function public.hybrid_search_flows(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_flows_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from public.semantic_search_flows_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select f.*
+      from public.flows f
+      join fused on fused.id = f.id
+      where (
+        (data_source = 'tg' and f.state_code = 100)
+        or (data_source = 'co' and f.state_code = 200)
+        or (data_source = 'my' and f.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = f.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+create or replace function public.hybrid_search_processes(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  model_id uuid,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_processes_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer,
+        'all'
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from public.semantic_search_processes_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select p.*
+      from public.processes p
+      join fused on fused.id = p.id
+      where (
+        (data_source = 'tg' and p.state_code = 100)
+        or (data_source = 'co' and p.state_code = 200)
+        or (data_source = 'my' and p.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = p.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.model_id,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.model_id,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+create or replace function public.hybrid_search_lifecyclemodels(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_lifecyclemodels_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from public.semantic_search_lifecyclemodels_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select l.*
+      from public.lifecyclemodels l
+      join fused on fused.id = l.id
+      where (
+        (data_source = 'tg' and l.state_code = 100)
+        or (data_source = 'co' and l.state_code = 200)
+        or (data_source = 'my' and l.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = l.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+alter function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+alter function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+alter function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+
+grant all on function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;

--- a/supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
+++ b/supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
@@ -1,0 +1,167 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(12);
+
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger_name text)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger_name
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger_name);
+  end if;
+end;
+$$;
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_flows_latest') > 0,
+  'flow hybrid search uses latest text search for text candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_processes_latest') > 0,
+  'process hybrid search uses latest text search for text candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_lifecyclemodels_latest') > 0,
+  'lifecyclemodel hybrid search uses latest text search for text candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'pgroonga_search_processes_v1') = 0
+    and strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'pgroonga_search_processes_text_v1') = 0,
+  'process hybrid search no longer depends on legacy process PGroonga helpers'
+);
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('a1000000-0000-0000-0000-000000000101', '{"email":"hybrid-search-owner@example.com"}'::jsonb, null),
+  ('b2000000-0000-0000-0000-000000000101', '{"email":"hybrid-search-outsider@example.com"}'::jsonb, null);
+
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flows_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_dataset_extraction_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'zz_flows_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'processes_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'zz_processes_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodel_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'zz_lifecyclemodels_extracted_text_sync_trigger');
+
+insert into public.flows (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('f1000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-public-flow-token"}'::jsonb, '{"search":"hybrid-public-flow-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 100, null, 'hybrid-public-flow-token 电子器件', true, now(), now()),
+  ('f2000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-owner-flow-token"}'::jsonb, '{"search":"hybrid-owner-flow-token"}'::json, 'a1000000-0000-0000-0000-000000000101', 0, null, 'hybrid-owner-flow-token 电子器件', true, now(), now()),
+  ('f3000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-outsider-flow-token"}'::jsonb, '{"search":"hybrid-outsider-flow-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 0, null, 'hybrid-outsider-flow-token 电子器件', true, now(), now());
+
+insert into public.processes (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('e1000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-public-process-token"}'::jsonb, '{"search":"hybrid-public-process-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 100, null, 'hybrid-public-process-token 正极材料 cathode material', true, now(), now()),
+  ('e2000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-owner-process-token"}'::jsonb, '{"search":"hybrid-owner-process-token"}'::json, 'a1000000-0000-0000-0000-000000000101', 0, null, 'hybrid-owner-process-token 正极材料 cathode material', true, now(), now()),
+  ('e3000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-outsider-process-token"}'::jsonb, '{"search":"hybrid-outsider-process-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 0, null, 'hybrid-outsider-process-token 正极材料 cathode material', true, now(), now());
+
+insert into public.lifecyclemodels (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('d1000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-public-lifecycle-token"}'::jsonb, '{"search":"hybrid-public-lifecycle-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 100, null, 'hybrid-public-lifecycle-token 交流电', true, now(), now()),
+  ('d2000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-owner-lifecycle-token"}'::jsonb, '{"search":"hybrid-owner-lifecycle-token"}'::json, 'a1000000-0000-0000-0000-000000000101', 0, null, 'hybrid-owner-lifecycle-token 交流电', true, now(), now()),
+  ('d3000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-outsider-lifecycle-token"}'::jsonb, '{"search":"hybrid-outsider-lifecycle-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 0, null, 'hybrid-outsider-lifecycle-token 交流电', true, now(), now());
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', 'a1000000-0000-0000-0000-000000000101', true);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_flows('(电子器件) OR (electronic component)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  'f1000000-0000-0000-0000-000000000101',
+  'flow hybrid tg search returns a text candidate through latest search'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_flows('(电子器件) OR (electronic component)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  'f2000000-0000-0000-0000-000000000101',
+  'flow hybrid my search returns the authenticated owner text candidate'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select count(*) from public.hybrid_search_flows('hybrid-outsider-flow-token', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1)),
+  0::bigint,
+  'flow hybrid my search cannot return another user text candidate'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_processes('(正极材料) OR (cathode material)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  'e1000000-0000-0000-0000-000000000101',
+  'process hybrid tg search returns a text candidate through latest search'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_processes('(正极材料) OR (cathode material)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  'e2000000-0000-0000-0000-000000000101',
+  'process hybrid my search returns the authenticated owner text candidate'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select count(*) from public.hybrid_search_processes('hybrid-outsider-process-token', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1)),
+  0::bigint,
+  'process hybrid my search cannot return another user text candidate'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_lifecyclemodels('(交流电) OR (electricity)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  'd1000000-0000-0000-0000-000000000101',
+  'lifecyclemodel hybrid tg search returns a text candidate through latest search'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_lifecyclemodels('(交流电) OR (electricity)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  'd2000000-0000-0000-0000-000000000101',
+  'lifecyclemodel hybrid my search returns the authenticated owner text candidate'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary
- align hybrid_search_flows/processes/lifecyclemodels text candidates with search_*_latest
- remove hybrid dependency on legacy JSON/text v1 PGroonga candidate helpers for the text side
- add pgTAP coverage for tg/my hybrid recall using raw Chinese fallback queries

## Findings
- flows/tg query 电子器件 was not a query-plan bug: dev had 4 stale extracted_text rows where the table-aware extractor produced the Chinese term but the stored extracted_text did not.
- production/main already has those 4 rows repaired; search_flows_latest('电子器件', data_source='tg') returns 3 rows.
- production/main search_processes_latest('正极材料', data_source='my') and direct hybrid_search_processes with authenticated context both return the expected user-owned row, so the remaining hardening is to keep hybrid text recall on the same latest extracted_text path as ordinary search.

## Validation
- supabase db reset
- supabase test db supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql supabase/tests/20260528_dataset_search_text_first_plan.sql supabase/tests/20260528_dataset_search_rls_private_helpers.sql supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
- supabase test db
- supabase migration list --local
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --staged --mode enforce
- git diff --cached --check

## Operational notes
- Applied a targeted dev data repair for the 4 flows whose json/extractor output contains 电子器件 but stored extracted_text did not.
- No production data write was needed for that case because production/main is already repaired.
- This is a routine database-engine PR to dev; workspace integration remains pending after promote.

Closes #101