### PR TITLE
Promote dev to main for dataset search fixes

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "a1cb208f77afdaf5bd2b86c59f21990270d5dc53"
+lastReviewedCommit: "6f96a58753b81beccf75a88a9368e12bba012640"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "b39776ecca40115b9af574bfda4522a93d2eed55"
+lastReviewedCommit: "a1cb208f77afdaf5bd2b86c59f21990270d5dc53"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "6f96a58753b81beccf75a88a9368e12bba012640"
+lastReviewedCommit: "983a9085ea04a6babc978fd45d82d7d32921171d"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b39776ecca40115b9af574bfda4522a93d2eed55
+lastReviewedCommit: a1cb208f77afdaf5bd2b86c59f21990270d5dc53
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
+lastReviewedCommit: 983a9085ea04a6babc978fd45d82d7d32921171d
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: a1cb208f77afdaf5bd2b86c59f21990270d5dc53
+lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
+lastReviewedCommit: 983a9085ea04a6babc978fd45d82d7d32921171d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: a1cb208f77afdaf5bd2b86c59f21990270d5dc53
+lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b39776ecca40115b9af574bfda4522a93d2eed55
+lastReviewedCommit: a1cb208f77afdaf5bd2b86c59f21990270d5dc53
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
+lastReviewedCommit: 983a9085ea04a6babc978fd45d82d7d32921171d
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: a1cb208f77afdaf5bd2b86c59f21990270d5dc53
+lastReviewedCommit: 6f96a58753b81beccf75a88a9368e12bba012640
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: b39776ecca40115b9af574bfda4522a93d2eed55
+lastReviewedCommit: a1cb208f77afdaf5bd2b86c59f21990270d5dc53
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260528143000_materialize_dataset_search_text_matches.sql
+++ b/supabase/migrations/20260528143000_materialize_dataset_search_text_matches.sql
@@ -1,0 +1,410 @@
+-- Keep the PGroonga extracted_text predicate as the first candidate-generation step.
+-- Without this fence, the planner can prefer latest-version/state indexes and apply
+-- the full-text predicate late, which is slow for broad public datasets.
+
+create or replace function public._search_simple_dataset_latest(
+  p_table regclass,
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer
+) returns table(
+  rank bigint,
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  json_filter_clause text;
+  v_sql text;
+begin
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := case
+    when coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      then btrim(this_user_id)::uuid
+    else null::uuid
+  end;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+  json_filter_clause := case
+    when filter_condition_jsonb = '{}'::jsonb then ''
+    else 'and d.json @> $2'
+  end;
+
+  v_sql := format($sql$
+    with text_matches as materialized (
+      select d.id,
+             d.json,
+             d.state_code,
+             d.team_id,
+             d.user_id,
+             pgroonga_score(d.tableoid, d.ctid) as search_score
+      from %1$s d
+      where d.extracted_text &@~ $1
+    ),
+    matched_ids as (
+      select d.id, max(d.search_score) as search_score
+      from text_matches d
+      where (
+          ($5 = 'tg' and d.state_code = 100 and ($7 is null or d.team_id = $7))
+          or ($5 = 'co' and d.state_code = 200 and ($7 is null or d.team_id = $7))
+          or ($5 = 'my' and $6 is not null and d.user_id = $6 and ($8 is null or d.state_code = $8))
+          or ($5 = 'te' and $7 is not null and d.team_id = $7 and ($8 is null or d.state_code = $8))
+        )
+        %2$s
+      group by d.id
+    ),
+    latest_rows as (
+      select matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+      from matched_ids
+      join lateral (
+        select d2.json, d2.version, d2.modified_at, d2.team_id
+        from %1$s d2
+        where d2.id = matched_ids.id
+          and (
+            ($5 = 'tg' and d2.state_code = 100 and ($7 is null or d2.team_id = $7))
+            or ($5 = 'co' and d2.state_code = 200 and ($7 is null or d2.team_id = $7))
+            or ($5 = 'my' and $6 is not null and d2.user_id = $6 and ($8 is null or d2.state_code = $8))
+            or ($5 = 'te' and $7 is not null and d2.team_id = $7 and ($8 is null or d2.state_code = $8))
+          )
+        order by d2.version desc, d2.modified_at desc
+        limit 1
+      ) latest_row on true
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    ),
+    ranked_rows as (
+      select rank() over (order by counted_rows.search_score desc, counted_rows.modified_at desc, counted_rows.id)::bigint as rank,
+             counted_rows.*
+      from counted_rows
+    )
+    select ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+    from ranked_rows
+    order by ranked_rows.rank, ranked_rows.id
+    limit $3
+    offset ($4 - 1) * $3
+  $sql$, p_table, json_filter_clause);
+
+  return query execute v_sql
+    using query_text, filter_condition_jsonb, normalized_page_size, normalized_page_current,
+          data_source, normalized_this_user_id, team_id_filter, state_code_filter;
+end;
+$$;
+
+create or replace function public.search_processes_latest(
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  order_by jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer,
+  type_of_data_set_filter text default 'all'::text
+) returns table(
+  rank bigint,
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  model_id uuid,
+  total_count bigint
+)
+language plpgsql
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  json_filter_clause text;
+  v_sql text;
+begin
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := case
+    when coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      then btrim(this_user_id)::uuid
+    else null::uuid
+  end;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+  json_filter_clause := case
+    when filter_condition_jsonb = '{}'::jsonb then ''
+    else 'and p.json @> $2'
+  end;
+
+  v_sql := format($sql$
+    with text_matches as materialized (
+      select p.id,
+             p.json,
+             p.state_code,
+             p.team_id,
+             p.user_id,
+             p.model_id,
+             pgroonga_score(p.tableoid, p.ctid) as search_score
+      from public.processes p
+      where p.extracted_text &@~ $1
+    ),
+    matched_ids as (
+      select p.id, max(p.search_score) as search_score
+      from text_matches p
+      where (
+          ($5 = 'tg' and p.state_code = 100 and ($7 is null or p.team_id = $7))
+          or ($5 = 'co' and p.state_code = 200 and ($7 is null or p.team_id = $7))
+          or ($5 = 'my' and $6 is not null and p.user_id = $6 and ($8 is null or p.state_code = $8))
+          or ($5 = 'te' and $7 is not null and p.team_id = $7 and ($8 is null or p.state_code = $8))
+        )
+        %s
+        and (
+          coalesce($9, 'all') = 'all'
+          or p.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = $9
+        )
+      group by p.id
+    ),
+    latest_rows as (
+      select matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, latest_row.model_id, matched_ids.search_score
+      from matched_ids
+      join lateral (
+        select p2.json, p2.version, p2.modified_at, p2.team_id, p2.model_id
+        from public.processes p2
+        where p2.id = matched_ids.id
+          and (
+            ($5 = 'tg' and p2.state_code = 100 and ($7 is null or p2.team_id = $7))
+            or ($5 = 'co' and p2.state_code = 200 and ($7 is null or p2.team_id = $7))
+            or ($5 = 'my' and $6 is not null and p2.user_id = $6 and ($8 is null or p2.state_code = $8))
+            or ($5 = 'te' and $7 is not null and p2.team_id = $7 and ($8 is null or p2.state_code = $8))
+          )
+        order by p2.version desc, p2.modified_at desc
+        limit 1
+      ) latest_row on true
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    ),
+    ranked_rows as (
+      select rank() over (order by counted_rows.search_score desc, counted_rows.modified_at desc, counted_rows.id)::bigint as rank,
+             counted_rows.*
+      from counted_rows
+    )
+    select ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.model_id, ranked_rows.total_count
+    from ranked_rows
+    order by ranked_rows.rank, ranked_rows.id
+    limit $3
+    offset ($4 - 1) * $3
+  $sql$, json_filter_clause);
+
+  return query execute v_sql
+    using query_text, filter_condition_jsonb, normalized_page_size, normalized_page_current,
+          data_source, normalized_this_user_id, team_id_filter, state_code_filter, type_of_data_set_filter;
+end;
+$$;
+
+create or replace function public.search_flows_latest(
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  order_by jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer
+) returns table(
+  rank bigint,
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_this_user_id uuid;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+  json_filter_clause text;
+  v_sql text;
+begin
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_this_user_id := case
+    when coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      then btrim(this_user_id)::uuid
+    else null::uuid
+  end;
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  if flow_type is not null then
+    flow_type_array := string_to_array(flow_type, ',');
+  else
+    flow_type_array := null;
+  end if;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  if filter_condition_jsonb ? 'asInput' then
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  else
+    as_input := null;
+  end if;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  if jsonb_typeof(filter_condition_jsonb->'classification') = 'array' then
+    classification_filter := filter_condition_jsonb->'classification';
+  else
+    classification_filter := '[]'::jsonb;
+  end if;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+  json_filter_clause := case
+    when filter_condition_jsonb = '{}'::jsonb then ''
+    else 'and f.json @> $2'
+  end;
+
+  v_sql := format($sql$
+    with text_matches as materialized (
+      select f.id,
+             f.json,
+             f.state_code,
+             f.team_id,
+             f.user_id,
+             pgroonga_score(f.tableoid, f.ctid) as search_score
+      from public.flows f
+      where f.extracted_text &@~ $1
+    ),
+    matched_ids as (
+      select f.id, max(f.search_score) as search_score
+      from text_matches f
+      where (
+          ($5 = 'tg' and f.state_code = 100 and ($7 is null or f.team_id = $7))
+          or ($5 = 'co' and f.state_code = 200 and ($7 is null or f.team_id = $7))
+          or ($5 = 'my' and $6 is not null and f.user_id = $6 and ($8 is null or f.state_code = $8))
+          or ($5 = 'te' and $7 is not null and f.team_id = $7 and ($8 is null or f.state_code = $8))
+        )
+        %s
+        and (
+          $9 is null
+          or (f.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = any($10)
+        )
+        and (
+          $11 is null
+          or $11 = false
+          or not (
+            f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        and (
+          jsonb_array_length($12) = 0
+          or exists (
+            select 1
+            from jsonb_array_elements($12) as selected_class(item)
+            where
+              (
+                selected_class.item->>'scope' = 'elementary'
+                and exists (
+                  select 1
+                  from jsonb_array_elements(
+                    case jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      when 'array' then f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      when 'object' then jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      else '[]'::jsonb
+                    end
+                  ) as category(item)
+                  where category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              or (
+                selected_class.item->>'scope' = 'classification'
+                and exists (
+                  select 1
+                  from jsonb_array_elements(
+                    case jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      when 'array' then f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      when 'object' then jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      else '[]'::jsonb
+                    end
+                  ) as class_item(item)
+                  where class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+      group by f.id
+    ),
+    latest_rows as (
+      select matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+      from matched_ids
+      join lateral (
+        select f2.json, f2.version, f2.modified_at, f2.team_id
+        from public.flows f2
+        where f2.id = matched_ids.id
+          and (
+            ($5 = 'tg' and f2.state_code = 100 and ($7 is null or f2.team_id = $7))
+            or ($5 = 'co' and f2.state_code = 200 and ($7 is null or f2.team_id = $7))
+            or ($5 = 'my' and $6 is not null and f2.user_id = $6 and ($8 is null or f2.state_code = $8))
+            or ($5 = 'te' and $7 is not null and f2.team_id = $7 and ($8 is null or f2.state_code = $8))
+          )
+        order by f2.version desc, f2.modified_at desc
+        limit 1
+      ) latest_row on true
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    ),
+    ranked_rows as (
+      select rank() over (order by counted_rows.search_score desc, counted_rows.modified_at desc, counted_rows.id)::bigint as rank,
+             counted_rows.*
+      from counted_rows
+    )
+    select ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+    from ranked_rows
+    order by ranked_rows.rank, ranked_rows.id
+    limit $3
+    offset ($4 - 1) * $3
+  $sql$, json_filter_clause);
+
+  return query execute v_sql
+    using query_text, filter_condition_jsonb, normalized_page_size, normalized_page_current,
+          data_source, normalized_this_user_id, team_id_filter, state_code_filter,
+          flow_type, flow_type_array, as_input, classification_filter;
+end;
+$$;
+
+alter function public._search_simple_dataset_latest(regclass, text, jsonb, bigint, bigint, text, text, uuid, integer) owner to postgres;
+alter function public.search_processes_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) owner to postgres;
+alter function public.search_flows_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) owner to postgres;
+
+grant all on function public._search_simple_dataset_latest(regclass, text, jsonb, bigint, bigint, text, text, uuid, integer) to anon, authenticated, service_role;
+grant all on function public.search_processes_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) to anon, authenticated, service_role;
+grant all on function public.search_flows_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) to anon, authenticated, service_role;

--- a/supabase/migrations/20260528165000_search_rls_private_helpers.sql
+++ b/supabase/migrations/20260528165000_search_rls_private_helpers.sql
@@ -1,0 +1,607 @@
+-- Move high-volume dataset search scans behind table-specific private
+-- security-definer helpers. The public RPC signatures stay unchanged, but the
+-- table reads no longer pay per-row authenticated RLS policy costs.
+
+create schema if not exists private;
+
+revoke all on schema private from public;
+grant usage on schema private to anon, authenticated, service_role;
+alter default privileges for role postgres in schema private revoke execute on functions from public;
+
+create or replace function private.dataset_search_effective_user_id(p_this_user_id text)
+returns uuid
+language plpgsql
+stable
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  v_actor_id uuid := auth.uid();
+  v_request_role text := nullif(current_setting('request.jwt.claim.role', true), '');
+  v_param_user_id uuid;
+begin
+  if v_actor_id is not null then
+    return v_actor_id;
+  end if;
+
+  if coalesce(v_request_role, '') in ('anon', 'authenticated') then
+    return null::uuid;
+  end if;
+
+  v_param_user_id := case
+    when coalesce(btrim(p_this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      then btrim(p_this_user_id)::uuid
+    else null::uuid
+  end;
+
+  return v_param_user_id;
+end;
+$$;
+
+create or replace function private.dataset_search_can_read_team_filter(
+  p_team_id uuid,
+  p_actor_id uuid
+) returns boolean
+language plpgsql
+stable
+security definer
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  v_request_role text := nullif(current_setting('request.jwt.claim.role', true), '');
+begin
+  if p_team_id is null then
+    return false;
+  end if;
+
+  if coalesce(v_request_role, '') not in ('anon', 'authenticated') then
+    return true;
+  end if;
+
+  if p_actor_id is null then
+    return false;
+  end if;
+
+  return exists (
+    select 1
+    from public.roles r
+    where r.team_id = p_team_id
+      and r.user_id = p_actor_id
+      and r.role::text in ('admin', 'member', 'owner')
+  );
+end;
+$$;
+
+create or replace function private.search_lifecyclemodels_latest_impl(
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer
+) returns table(
+  rank bigint,
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_data_source text;
+  effective_user_id uuid;
+  can_read_team_filter boolean;
+  filter_condition_jsonb jsonb;
+  json_filter_clause text;
+  v_sql text;
+begin
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_data_source := coalesce(nullif(lower(btrim(data_source)), ''), 'tg');
+  effective_user_id := private.dataset_search_effective_user_id(this_user_id);
+  can_read_team_filter := private.dataset_search_can_read_team_filter(team_id_filter, effective_user_id);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+  json_filter_clause := case
+    when filter_condition_jsonb = '{}'::jsonb then ''
+    else 'and l.json @> $2'
+  end;
+
+  v_sql := format($sql$
+    with text_matches as materialized (
+      select l.id,
+             l.json,
+             l.state_code,
+             l.team_id,
+             l.user_id,
+             pgroonga_score(l.tableoid, l.ctid) as search_score
+      from public.lifecyclemodels l
+      where l.extracted_text &@~ $1
+    ),
+    matched_ids as (
+      select l.id, max(l.search_score) as search_score
+      from text_matches l
+      where (
+          ($5 = 'tg' and l.state_code = 100 and ($7 is null or l.team_id = $7))
+          or ($5 = 'co' and l.state_code = 200 and ($7 is null or l.team_id = $7))
+          or ($5 = 'my' and $6 is not null and l.user_id = $6 and ($8 is null or l.state_code = $8))
+          or ($5 = 'te' and $7 is not null and $9 and l.team_id = $7 and ($8 is null or l.state_code = $8))
+        )
+        %s
+      group by l.id
+    ),
+    latest_rows as (
+      select matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+      from matched_ids
+      join lateral (
+        select l2.json, l2.version, l2.modified_at, l2.team_id
+        from public.lifecyclemodels l2
+        where l2.id = matched_ids.id
+          and (
+            ($5 = 'tg' and l2.state_code = 100 and ($7 is null or l2.team_id = $7))
+            or ($5 = 'co' and l2.state_code = 200 and ($7 is null or l2.team_id = $7))
+            or ($5 = 'my' and $6 is not null and l2.user_id = $6 and ($8 is null or l2.state_code = $8))
+            or ($5 = 'te' and $7 is not null and $9 and l2.team_id = $7 and ($8 is null or l2.state_code = $8))
+          )
+        order by l2.version desc, l2.modified_at desc
+        limit 1
+      ) latest_row on true
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    ),
+    ranked_rows as (
+      select rank() over (order by counted_rows.search_score desc, counted_rows.modified_at desc, counted_rows.id)::bigint as rank,
+             counted_rows.*
+      from counted_rows
+    )
+    select ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+    from ranked_rows
+    order by ranked_rows.rank, ranked_rows.id
+    limit $3
+    offset ($4 - 1) * $3
+  $sql$, json_filter_clause);
+
+  return query execute v_sql
+    using query_text, filter_condition_jsonb, normalized_page_size, normalized_page_current,
+          normalized_data_source, effective_user_id, team_id_filter, state_code_filter, can_read_team_filter;
+end;
+$$;
+
+create or replace function private.search_processes_latest_impl(
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer,
+  type_of_data_set_filter text default 'all'::text
+) returns table(
+  rank bigint,
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  model_id uuid,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_data_source text;
+  effective_user_id uuid;
+  can_read_team_filter boolean;
+  filter_condition_jsonb jsonb;
+  json_filter_clause text;
+  v_sql text;
+begin
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_data_source := coalesce(nullif(lower(btrim(data_source)), ''), 'tg');
+  effective_user_id := private.dataset_search_effective_user_id(this_user_id);
+  can_read_team_filter := private.dataset_search_can_read_team_filter(team_id_filter, effective_user_id);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+  json_filter_clause := case
+    when filter_condition_jsonb = '{}'::jsonb then ''
+    else 'and p.json @> $2'
+  end;
+
+  v_sql := format($sql$
+    with text_matches as materialized (
+      select p.id,
+             p.json,
+             p.state_code,
+             p.team_id,
+             p.user_id,
+             p.model_id,
+             pgroonga_score(p.tableoid, p.ctid) as search_score
+      from public.processes p
+      where p.extracted_text &@~ $1
+    ),
+    matched_ids as (
+      select p.id, max(p.search_score) as search_score
+      from text_matches p
+      where (
+          ($5 = 'tg' and p.state_code = 100 and ($7 is null or p.team_id = $7))
+          or ($5 = 'co' and p.state_code = 200 and ($7 is null or p.team_id = $7))
+          or ($5 = 'my' and $6 is not null and p.user_id = $6 and ($8 is null or p.state_code = $8))
+          or ($5 = 'te' and $7 is not null and $9 and p.team_id = $7 and ($8 is null or p.state_code = $8))
+        )
+        %s
+        and (
+          coalesce($10, 'all') = 'all'
+          or p.json #>> '{processDataSet,modellingAndValidation,LCIMethodAndAllocation,typeOfDataSet}' = $10
+        )
+      group by p.id
+    ),
+    latest_rows as (
+      select matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, latest_row.model_id, matched_ids.search_score
+      from matched_ids
+      join lateral (
+        select p2.json, p2.version, p2.modified_at, p2.team_id, p2.model_id
+        from public.processes p2
+        where p2.id = matched_ids.id
+          and (
+            ($5 = 'tg' and p2.state_code = 100 and ($7 is null or p2.team_id = $7))
+            or ($5 = 'co' and p2.state_code = 200 and ($7 is null or p2.team_id = $7))
+            or ($5 = 'my' and $6 is not null and p2.user_id = $6 and ($8 is null or p2.state_code = $8))
+            or ($5 = 'te' and $7 is not null and $9 and p2.team_id = $7 and ($8 is null or p2.state_code = $8))
+          )
+        order by p2.version desc, p2.modified_at desc
+        limit 1
+      ) latest_row on true
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    ),
+    ranked_rows as (
+      select rank() over (order by counted_rows.search_score desc, counted_rows.modified_at desc, counted_rows.id)::bigint as rank,
+             counted_rows.*
+      from counted_rows
+    )
+    select ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.model_id, ranked_rows.total_count
+    from ranked_rows
+    order by ranked_rows.rank, ranked_rows.id
+    limit $3
+    offset ($4 - 1) * $3
+  $sql$, json_filter_clause);
+
+  return query execute v_sql
+    using query_text, filter_condition_jsonb, normalized_page_size, normalized_page_current,
+          normalized_data_source, effective_user_id, team_id_filter, state_code_filter,
+          can_read_team_filter, type_of_data_set_filter;
+end;
+$$;
+
+create or replace function private.search_flows_latest_impl(
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer
+) returns table(
+  rank bigint,
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_data_source text;
+  effective_user_id uuid;
+  can_read_team_filter boolean;
+  filter_condition_jsonb jsonb;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+  classification_filter jsonb;
+  json_filter_clause text;
+  v_sql text;
+begin
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_data_source := coalesce(nullif(lower(btrim(data_source)), ''), 'tg');
+  effective_user_id := private.dataset_search_effective_user_id(this_user_id);
+  can_read_team_filter := private.dataset_search_can_read_team_filter(team_id_filter, effective_user_id);
+  filter_condition_jsonb := coalesce(filter_condition, '{}'::jsonb);
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  if flow_type is not null then
+    flow_type_array := string_to_array(flow_type, ',');
+  else
+    flow_type_array := null;
+  end if;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  if filter_condition_jsonb ? 'asInput' then
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  else
+    as_input := null;
+  end if;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  if jsonb_typeof(filter_condition_jsonb->'classification') = 'array' then
+    classification_filter := filter_condition_jsonb->'classification';
+  else
+    classification_filter := '[]'::jsonb;
+  end if;
+  filter_condition_jsonb := filter_condition_jsonb - 'classification';
+  json_filter_clause := case
+    when filter_condition_jsonb = '{}'::jsonb then ''
+    else 'and f.json @> $2'
+  end;
+
+  v_sql := format($sql$
+    with text_matches as materialized (
+      select f.id,
+             f.json,
+             f.state_code,
+             f.team_id,
+             f.user_id,
+             pgroonga_score(f.tableoid, f.ctid) as search_score
+      from public.flows f
+      where f.extracted_text &@~ $1
+    ),
+    matched_ids as (
+      select f.id, max(f.search_score) as search_score
+      from text_matches f
+      where (
+          ($5 = 'tg' and f.state_code = 100 and ($7 is null or f.team_id = $7))
+          or ($5 = 'co' and f.state_code = 200 and ($7 is null or f.team_id = $7))
+          or ($5 = 'my' and $6 is not null and f.user_id = $6 and ($8 is null or f.state_code = $8))
+          or ($5 = 'te' and $7 is not null and $9 and f.team_id = $7 and ($8 is null or f.state_code = $8))
+        )
+        %s
+        and (
+          $10 is null
+          or (f.json #>> '{flowDataSet,modellingAndValidation,LCIMethod,typeOfDataSet}') = any($11)
+        )
+        and (
+          $12 is null
+          or $12 = false
+          or not (
+            f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+          )
+        )
+        and (
+          jsonb_array_length($13) = 0
+          or exists (
+            select 1
+            from jsonb_array_elements($13) as selected_class(item)
+            where
+              (
+                selected_class.item->>'scope' = 'elementary'
+                and exists (
+                  select 1
+                  from jsonb_array_elements(
+                    case jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      when 'array' then f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}'
+                      when 'object' then jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:elementaryFlowCategorization,common:category}')
+                      else '[]'::jsonb
+                    end
+                  ) as category(item)
+                  where category.item->>'@catId' = selected_class.item->>'code'
+                )
+              )
+              or (
+                selected_class.item->>'scope' = 'classification'
+                and exists (
+                  select 1
+                  from jsonb_array_elements(
+                    case jsonb_typeof(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      when 'array' then f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}'
+                      when 'object' then jsonb_build_array(f.json #> '{flowDataSet,flowInformation,dataSetInformation,classificationInformation,common:classification,common:class}')
+                      else '[]'::jsonb
+                    end
+                  ) as class_item(item)
+                  where class_item.item->>'@classId' = selected_class.item->>'code'
+                )
+              )
+          )
+        )
+      group by f.id
+    ),
+    latest_rows as (
+      select matched_ids.id, latest_row.json, latest_row.version, latest_row.modified_at, latest_row.team_id, matched_ids.search_score
+      from matched_ids
+      join lateral (
+        select f2.json, f2.version, f2.modified_at, f2.team_id
+        from public.flows f2
+        where f2.id = matched_ids.id
+          and (
+            ($5 = 'tg' and f2.state_code = 100 and ($7 is null or f2.team_id = $7))
+            or ($5 = 'co' and f2.state_code = 200 and ($7 is null or f2.team_id = $7))
+            or ($5 = 'my' and $6 is not null and f2.user_id = $6 and ($8 is null or f2.state_code = $8))
+            or ($5 = 'te' and $7 is not null and $9 and f2.team_id = $7 and ($8 is null or f2.state_code = $8))
+          )
+        order by f2.version desc, f2.modified_at desc
+        limit 1
+      ) latest_row on true
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    ),
+    ranked_rows as (
+      select rank() over (order by counted_rows.search_score desc, counted_rows.modified_at desc, counted_rows.id)::bigint as rank,
+             counted_rows.*
+      from counted_rows
+    )
+    select ranked_rows.rank, ranked_rows.id, ranked_rows.json, ranked_rows.version, ranked_rows.modified_at, ranked_rows.team_id, ranked_rows.total_count
+    from ranked_rows
+    order by ranked_rows.rank, ranked_rows.id
+    limit $3
+    offset ($4 - 1) * $3
+  $sql$, json_filter_clause);
+
+  return query execute v_sql
+    using query_text, filter_condition_jsonb, normalized_page_size, normalized_page_current,
+          normalized_data_source, effective_user_id, team_id_filter, state_code_filter,
+          can_read_team_filter, flow_type, flow_type_array, as_input, classification_filter;
+end;
+$$;
+
+create or replace function public.search_lifecyclemodels_latest(
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  order_by jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer
+) returns table(rank bigint, id uuid, "json" jsonb, version character(9), modified_at timestamp with time zone, team_id uuid, total_count bigint)
+language plpgsql
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+begin
+  return query
+    select *
+    from private.search_lifecyclemodels_latest_impl(
+      query_text,
+      filter_condition,
+      page_size,
+      page_current,
+      data_source,
+      this_user_id,
+      team_id_filter,
+      state_code_filter
+    );
+end;
+$$;
+
+create or replace function public.search_processes_latest(
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  order_by jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer,
+  type_of_data_set_filter text default 'all'::text
+) returns table(
+  rank bigint,
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  model_id uuid,
+  total_count bigint
+)
+language plpgsql
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+begin
+  return query
+    select *
+    from private.search_processes_latest_impl(
+      query_text,
+      filter_condition,
+      page_size,
+      page_current,
+      data_source,
+      this_user_id,
+      team_id_filter,
+      state_code_filter,
+      type_of_data_set_filter
+    );
+end;
+$$;
+
+create or replace function public.search_flows_latest(
+  query_text text,
+  filter_condition jsonb default '{}'::jsonb,
+  order_by jsonb default '{}'::jsonb,
+  page_size bigint default 10,
+  page_current bigint default 1,
+  data_source text default 'tg'::text,
+  this_user_id text default ''::text,
+  team_id_filter uuid default null::uuid,
+  state_code_filter integer default null::integer
+) returns table(
+  rank bigint,
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+begin
+  return query
+    select *
+    from private.search_flows_latest_impl(
+      query_text,
+      filter_condition,
+      page_size,
+      page_current,
+      data_source,
+      this_user_id,
+      team_id_filter,
+      state_code_filter
+    );
+end;
+$$;
+
+alter function private.dataset_search_effective_user_id(text) owner to postgres;
+alter function private.dataset_search_can_read_team_filter(uuid, uuid) owner to postgres;
+alter function private.search_lifecyclemodels_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer) owner to postgres;
+alter function private.search_processes_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text) owner to postgres;
+alter function private.search_flows_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer) owner to postgres;
+alter function public.search_lifecyclemodels_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) owner to postgres;
+alter function public.search_processes_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) owner to postgres;
+alter function public.search_flows_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) owner to postgres;
+
+revoke all on function private.dataset_search_effective_user_id(text) from public;
+revoke all on function private.dataset_search_can_read_team_filter(uuid, uuid) from public;
+revoke all on function private.search_lifecyclemodels_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer) from public;
+revoke all on function private.search_processes_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text) from public;
+revoke all on function private.search_flows_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer) from public;
+
+grant execute on function private.search_lifecyclemodels_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer) to anon, authenticated, service_role;
+grant execute on function private.search_processes_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text) to anon, authenticated, service_role;
+grant execute on function private.search_flows_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer) to anon, authenticated, service_role;
+
+grant all on function public.search_lifecyclemodels_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) to anon, authenticated, service_role;
+grant all on function public.search_processes_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text) to anon, authenticated, service_role;
+grant all on function public.search_flows_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer) to anon, authenticated, service_role;

--- a/supabase/migrations/20260528172000_hybrid_search_use_latest_text_candidates.sql
+++ b/supabase/migrations/20260528172000_hybrid_search_use_latest_text_candidates.sql
@@ -1,0 +1,384 @@
+-- Keep hybrid search aligned with ordinary latest search semantics.  The text
+-- side now uses the same extracted_text/latest-version/visibility path as
+-- search_*_latest instead of the legacy JSON PGroonga + text_v1 helpers.
+
+create or replace function public.hybrid_search_flows(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_flows_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from public.semantic_search_flows_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select f.*
+      from public.flows f
+      join fused on fused.id = f.id
+      where (
+        (data_source = 'tg' and f.state_code = 100)
+        or (data_source = 'co' and f.state_code = 200)
+        or (data_source = 'my' and f.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = f.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+create or replace function public.hybrid_search_processes(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  model_id uuid,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_processes_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer,
+        'all'
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from public.semantic_search_processes_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select p.*
+      from public.processes p
+      join fused on fused.id = p.id
+      where (
+        (data_source = 'tg' and p.state_code = 100)
+        or (data_source = 'co' and p.state_code = 200)
+        or (data_source = 'my' and p.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = p.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.model_id,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.model_id,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+create or replace function public.hybrid_search_lifecyclemodels(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_lifecyclemodels_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from public.semantic_search_lifecyclemodels_v1(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select l.*
+      from public.lifecyclemodels l
+      join fused on fused.id = l.id
+      where (
+        (data_source = 'tg' and l.state_code = 100)
+        or (data_source = 'co' and l.state_code = 200)
+        or (data_source = 'my' and l.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = l.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+alter function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+alter function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+alter function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+
+grant all on function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -447,22 +447,22 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
   'flow open-data latest PGroonga search fetches latest versions with lateral index lookups'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.extracted_text &@~ $1') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.extracted_text &@~ $1') > 0,
   'flow latest PGroonga search matches query_text against extracted_text'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'json_filter_clause') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'json_filter_clause') > 0,
   'flow latest PGroonga search branches on empty JSON filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'and f.json @> $2') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'and f.json @> $2') > 0,
   'flow latest PGroonga search only keeps JSON containment for non-empty filters'
 );
 
@@ -482,22 +482,22 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'join lateral') > 0,
   'process latest PGroonga search fetches latest versions with lateral index lookups'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'p.extracted_text &@~ $1') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'p.extracted_text &@~ $1') > 0,
   'process latest PGroonga search matches query_text against extracted_text'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'json_filter_clause') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'json_filter_clause') > 0,
   'process latest PGroonga search branches on empty JSON filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'and p.json @> $2') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'and p.json @> $2') > 0,
   'process latest PGroonga search only keeps JSON containment for non-empty filters'
 );
 
@@ -517,23 +517,23 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
   'lifecyclemodel latest PGroonga search fetches latest versions with lateral index lookups'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'd.extracted_text &@~ $1') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'l.extracted_text &@~ $1') > 0,
   'lifecyclemodel latest PGroonga search matches query_text against extracted_text'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'json_filter_clause') > 0,
-  'simple dataset latest PGroonga search branches on empty JSON filters'
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'json_filter_clause') > 0,
+  'lifecyclemodel latest PGroonga search branches on empty JSON filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'and d.json @> $2') > 0,
-  'simple dataset latest PGroonga search only keeps JSON containment for non-empty filters'
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'and l.json @> $2') > 0,
+  'lifecyclemodel latest PGroonga search only keeps JSON containment for non-empty filters'
 );
 
 select ok(

--- a/supabase/tests/20260528_dataset_search_rls_private_helpers.sql
+++ b/supabase/tests/20260528_dataset_search_rls_private_helpers.sql
@@ -1,0 +1,208 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
+select plan(26);
+
+select ok(to_regnamespace('private') is not null, 'private schema exists for non-exposed search helpers');
+
+select ok(
+  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'private.search_flows_latest_impl') > 0,
+  'flow public search wrapper delegates to private helper'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'private.search_processes_latest_impl') > 0,
+  'process public search wrapper delegates to private helper'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'private.search_lifecyclemodels_latest_impl') > 0,
+  'lifecyclemodel public search wrapper delegates to private helper'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  'flow private helper is security definer'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure),
+  'process private helper is security definer'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  'lifecyclemodel private helper is security definer'
+);
+
+select ok(
+  not (select prosecdef from pg_proc where oid = 'public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  'public search wrapper remains security invoker'
+);
+
+select ok(
+  not (select prosecdef from pg_proc where oid = 'public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  'generic regclass helper remains security invoker'
+);
+
+select ok(
+  not has_function_privilege('authenticated', 'private.dataset_search_effective_user_id(text)', 'EXECUTE'),
+  'authenticated cannot execute private identity helper directly'
+);
+
+select ok(
+  has_function_privilege('authenticated', 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)', 'EXECUTE'),
+  'authenticated can execute the hardcoded flow search helper through the wrapper path'
+);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'a1000000-0000-0000-0000-000000000103',
+    'authenticated',
+    'authenticated',
+    'dataset-search-rls-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"a1000000-0000-0000-0000-000000000103","email":"dataset-search-rls-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'b2000000-0000-0000-0000-000000000103',
+    'authenticated',
+    'authenticated',
+    'dataset-search-rls-outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"b2000000-0000-0000-0000-000000000103","email":"dataset-search-rls-outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('a1000000-0000-0000-0000-000000000103', '{"email":"dataset-search-rls-owner@example.com"}'::jsonb, null),
+  ('b2000000-0000-0000-0000-000000000103', '{"email":"dataset-search-rls-outsider@example.com"}'::jsonb, null);
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('c3000000-0000-0000-0000-000000000103', '{"name":"Dataset Search RLS Team"}'::jsonb, 1, false);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('a1000000-0000-0000-0000-000000000103', 'c3000000-0000-0000-0000-000000000103', 'owner');
+
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flows_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_dataset_extraction_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'zz_flows_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'processes_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'zz_processes_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodel_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'zz_lifecyclemodels_extracted_text_sync_trigger');
+
+insert into public.flows (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('f1000000-0000-0000-0000-000000000103', '01.00.000', '{"search":"rls-public-flow-token"}'::jsonb, '{"search":"rls-public-flow-token"}'::json, 'a1000000-0000-0000-0000-000000000103', 100, null, 'rls-public-flow-token', true, now(), now()),
+  ('f2000000-0000-0000-0000-000000000103', '01.00.000', '{"search":"rls-owner-flow-token"}'::jsonb, '{"search":"rls-owner-flow-token"}'::json, 'a1000000-0000-0000-0000-000000000103', 0, null, 'rls-owner-flow-token', true, now(), now()),
+  ('f3000000-0000-0000-0000-000000000103', '01.00.000', '{"search":"rls-team-flow-token"}'::jsonb, '{"search":"rls-team-flow-token"}'::json, 'b2000000-0000-0000-0000-000000000103', 0, 'c3000000-0000-0000-0000-000000000103', 'rls-team-flow-token', true, now(), now()),
+  ('f4000000-0000-0000-0000-000000000103', '01.00.000', '{"search":"rls-outsider-flow-token"}'::jsonb, '{"search":"rls-outsider-flow-token"}'::json, 'b2000000-0000-0000-0000-000000000103', 0, null, 'rls-outsider-flow-token', true, now(), now());
+
+insert into public.processes (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('e1000000-0000-0000-0000-000000000103', '01.00.000', '{"processDataSet":{"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"rls-public-process-token"}'::jsonb, '{"processDataSet":{"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"rls-public-process-token"}'::json, 'a1000000-0000-0000-0000-000000000103', 100, null, 'rls-public-process-token', true, now(), now()),
+  ('e2000000-0000-0000-0000-000000000103', '01.00.000', '{"processDataSet":{"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"rls-owner-process-token"}'::jsonb, '{"processDataSet":{"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"rls-owner-process-token"}'::json, 'a1000000-0000-0000-0000-000000000103', 0, null, 'rls-owner-process-token', true, now(), now()),
+  ('e3000000-0000-0000-0000-000000000103', '01.00.000', '{"processDataSet":{"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"rls-team-process-token"}'::jsonb, '{"processDataSet":{"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"rls-team-process-token"}'::json, 'b2000000-0000-0000-0000-000000000103', 0, 'c3000000-0000-0000-0000-000000000103', 'rls-team-process-token', true, now(), now()),
+  ('e4000000-0000-0000-0000-000000000103', '01.00.000', '{"processDataSet":{"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"rls-outsider-process-token"}'::jsonb, '{"processDataSet":{"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"search":"rls-outsider-process-token"}'::json, 'b2000000-0000-0000-0000-000000000103', 0, null, 'rls-outsider-process-token', true, now(), now());
+
+insert into public.lifecyclemodels (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('d1000000-0000-0000-0000-000000000103', '01.00.000', '{"search":"rls-public-lifecycle-token"}'::jsonb, '{"search":"rls-public-lifecycle-token"}'::json, 'a1000000-0000-0000-0000-000000000103', 100, null, 'rls-public-lifecycle-token', true, now(), now()),
+  ('d2000000-0000-0000-0000-000000000103', '01.00.000', '{"search":"rls-owner-lifecycle-token"}'::jsonb, '{"search":"rls-owner-lifecycle-token"}'::json, 'a1000000-0000-0000-0000-000000000103', 0, null, 'rls-owner-lifecycle-token', true, now(), now()),
+  ('d3000000-0000-0000-0000-000000000103', '01.00.000', '{"search":"rls-team-lifecycle-token"}'::jsonb, '{"search":"rls-team-lifecycle-token"}'::json, 'b2000000-0000-0000-0000-000000000103', 0, 'c3000000-0000-0000-0000-000000000103', 'rls-team-lifecycle-token', true, now(), now()),
+  ('d4000000-0000-0000-0000-000000000103', '01.00.000', '{"search":"rls-outsider-lifecycle-token"}'::jsonb, '{"search":"rls-outsider-lifecycle-token"}'::json, 'b2000000-0000-0000-0000-000000000103', 0, null, 'rls-outsider-lifecycle-token', true, now(), now());
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', 'a1000000-0000-0000-0000-000000000103', true);
+
+select is((select id::text from public.search_flows_latest('rls-public-flow-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '') limit 1), 'f1000000-0000-0000-0000-000000000103', 'flow tg search returns public data');
+select is((select id::text from public.search_processes_latest('rls-public-process-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '', null, null, 'all') limit 1), 'e1000000-0000-0000-0000-000000000103', 'process tg search returns public data');
+select is((select id::text from public.search_lifecyclemodels_latest('rls-public-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'tg', '') limit 1), 'd1000000-0000-0000-0000-000000000103', 'lifecyclemodel tg search returns public data');
+
+select is((select id::text from public.search_flows_latest('rls-owner-flow-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'my', 'b2000000-0000-0000-0000-000000000103') limit 1), 'f2000000-0000-0000-0000-000000000103', 'flow my search uses auth.uid instead of spoofable this_user_id');
+select is((select id::text from public.search_processes_latest('rls-owner-process-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'my', 'b2000000-0000-0000-0000-000000000103', null, null, 'all') limit 1), 'e2000000-0000-0000-0000-000000000103', 'process my search uses auth.uid instead of spoofable this_user_id');
+select is((select id::text from public.search_lifecyclemodels_latest('rls-owner-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'my', 'b2000000-0000-0000-0000-000000000103') limit 1), 'd2000000-0000-0000-0000-000000000103', 'lifecyclemodel my search uses auth.uid instead of spoofable this_user_id');
+
+select is((select count(*) from public.search_flows_latest('rls-outsider-flow-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'my', 'b2000000-0000-0000-0000-000000000103')), 0::bigint, 'flow my search cannot spoof another user');
+select is((select count(*) from public.search_processes_latest('rls-outsider-process-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'my', 'b2000000-0000-0000-0000-000000000103', null, null, 'all')), 0::bigint, 'process my search cannot spoof another user');
+select is((select count(*) from public.search_lifecyclemodels_latest('rls-outsider-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'my', 'b2000000-0000-0000-0000-000000000103')), 0::bigint, 'lifecyclemodel my search cannot spoof another user');
+
+select is((select id::text from public.search_flows_latest('rls-team-flow-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'te', '', 'c3000000-0000-0000-0000-000000000103') limit 1), 'f3000000-0000-0000-0000-000000000103', 'flow te search returns team data for a team member');
+select is((select id::text from public.search_processes_latest('rls-team-process-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'te', '', 'c3000000-0000-0000-0000-000000000103', null, 'all') limit 1), 'e3000000-0000-0000-0000-000000000103', 'process te search returns team data for a team member');
+select is((select id::text from public.search_lifecyclemodels_latest('rls-team-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'te', '', 'c3000000-0000-0000-0000-000000000103') limit 1), 'd3000000-0000-0000-0000-000000000103', 'lifecyclemodel te search returns team data for a team member');
+
+select set_config('request.jwt.claim.sub', 'b2000000-0000-0000-0000-000000000103', true);
+
+select is((select count(*) from public.search_flows_latest('rls-team-flow-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'te', '', 'c3000000-0000-0000-0000-000000000103')), 0::bigint, 'flow te search rejects a non-member');
+select is((select count(*) from public.search_processes_latest('rls-team-process-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'te', '', 'c3000000-0000-0000-0000-000000000103', null, 'all')), 0::bigint, 'process te search rejects a non-member');
+select is((select count(*) from public.search_lifecyclemodels_latest('rls-team-lifecycle-token', '{}'::jsonb, '{}'::jsonb, 10, 1, 'te', '', 'c3000000-0000-0000-0000-000000000103')), 0::bigint, 'lifecyclemodel te search rejects a non-member');
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260528_dataset_search_text_first_plan.sql
+++ b/supabase/tests/20260528_dataset_search_text_first_plan.sql
@@ -1,0 +1,58 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public;
+
+select plan(9);
+
+select ok(
+  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'with text_matches as materialized') > 0,
+  'flow latest search materializes text matches before non-text filters'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'where f.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'from text_matches f') > 0,
+  'flow latest search separates extracted_text scan from source/filter predicates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  'flow latest search keeps lateral latest-version lookup after candidate matching'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'with text_matches as materialized') > 0,
+  'process latest search materializes text matches before non-text filters'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'where p.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'from text_matches p') > 0,
+  'process latest search separates extracted_text scan from source/filter predicates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'join lateral') > 0,
+  'process latest search keeps lateral latest-version lookup after candidate matching'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'with text_matches as materialized') > 0,
+  'simple dataset latest search materializes text matches before non-text filters'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'where d.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'from text_matches d') > 0,
+  'simple dataset latest search separates extracted_text scan from source/filter predicates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  'simple dataset latest search keeps lateral latest-version lookup after candidate matching'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260528_dataset_search_text_first_plan.sql
+++ b/supabase/tests/20260528_dataset_search_text_first_plan.sql
@@ -3,54 +3,89 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public;
 
-select plan(9);
+select plan(16);
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'with text_matches as materialized') > 0,
+  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'private.search_flows_latest_impl') > 0,
+  'flow public latest search delegates scanning to the private helper'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'with text_matches as materialized') > 0,
   'flow latest search materializes text matches before non-text filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'where f.extracted_text &@~ $1') > 0
-    and strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'from text_matches f') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'where f.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'from text_matches f') > 0,
   'flow latest search separates extracted_text scan from source/filter predicates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
   'flow latest search keeps lateral latest-version lookup after candidate matching'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'with text_matches as materialized') > 0,
+  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'private.search_processes_latest_impl') > 0,
+  'process public latest search delegates scanning to the private helper'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'with text_matches as materialized') > 0,
   'process latest search materializes text matches before non-text filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'where p.extracted_text &@~ $1') > 0
-    and strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'from text_matches p') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'where p.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'from text_matches p') > 0,
   'process latest search separates extracted_text scan from source/filter predicates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'join lateral') > 0,
   'process latest search keeps lateral latest-version lookup after candidate matching'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'with text_matches as materialized') > 0,
-  'simple dataset latest search materializes text matches before non-text filters'
+  strpos(pg_get_functiondef('public.search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'private.search_lifecyclemodels_latest_impl') > 0,
+  'lifecyclemodel public latest search delegates scanning to the private helper'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'where d.extracted_text &@~ $1') > 0
-    and strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'from text_matches d') > 0,
-  'simple dataset latest search separates extracted_text scan from source/filter predicates'
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'with text_matches as materialized') > 0,
+  'lifecyclemodel latest search materializes text matches before non-text filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
-  'simple dataset latest search keeps lateral latest-version lookup after candidate matching'
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'where l.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'from text_matches l') > 0,
+  'lifecyclemodel latest search separates extracted_text scan from source/filter predicates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  'lifecyclemodel latest search keeps lateral latest-version lookup after candidate matching'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  'flow private helper is security definer'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure),
+  'process private helper is security definer'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  'lifecyclemodel private helper is security definer'
+);
+
+select ok(
+  not (select prosecdef from pg_proc where oid = 'public._search_simple_dataset_latest(regclass,text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  'generic regclass search helper remains security invoker'
 );
 
 select * from finish();

--- a/supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
+++ b/supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
@@ -1,0 +1,167 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(12);
+
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger_name text)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger_name
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger_name);
+  end if;
+end;
+$$;
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_flows_latest') > 0,
+  'flow hybrid search uses latest text search for text candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_processes_latest') > 0,
+  'process hybrid search uses latest text search for text candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_lifecyclemodels_latest') > 0,
+  'lifecyclemodel hybrid search uses latest text search for text candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'pgroonga_search_processes_v1') = 0
+    and strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'pgroonga_search_processes_text_v1') = 0,
+  'process hybrid search no longer depends on legacy process PGroonga helpers'
+);
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('a1000000-0000-0000-0000-000000000101', '{"email":"hybrid-search-owner@example.com"}'::jsonb, null),
+  ('b2000000-0000-0000-0000-000000000101', '{"email":"hybrid-search-outsider@example.com"}'::jsonb, null);
+
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flows_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_dataset_extraction_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'zz_flows_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'processes_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'zz_processes_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodel_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'zz_lifecyclemodels_extracted_text_sync_trigger');
+
+insert into public.flows (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('f1000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-public-flow-token"}'::jsonb, '{"search":"hybrid-public-flow-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 100, null, 'hybrid-public-flow-token 电子器件', true, now(), now()),
+  ('f2000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-owner-flow-token"}'::jsonb, '{"search":"hybrid-owner-flow-token"}'::json, 'a1000000-0000-0000-0000-000000000101', 0, null, 'hybrid-owner-flow-token 电子器件', true, now(), now()),
+  ('f3000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-outsider-flow-token"}'::jsonb, '{"search":"hybrid-outsider-flow-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 0, null, 'hybrid-outsider-flow-token 电子器件', true, now(), now());
+
+insert into public.processes (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('e1000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-public-process-token"}'::jsonb, '{"search":"hybrid-public-process-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 100, null, 'hybrid-public-process-token 正极材料 cathode material', true, now(), now()),
+  ('e2000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-owner-process-token"}'::jsonb, '{"search":"hybrid-owner-process-token"}'::json, 'a1000000-0000-0000-0000-000000000101', 0, null, 'hybrid-owner-process-token 正极材料 cathode material', true, now(), now()),
+  ('e3000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-outsider-process-token"}'::jsonb, '{"search":"hybrid-outsider-process-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 0, null, 'hybrid-outsider-process-token 正极材料 cathode material', true, now(), now());
+
+insert into public.lifecyclemodels (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  ('d1000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-public-lifecycle-token"}'::jsonb, '{"search":"hybrid-public-lifecycle-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 100, null, 'hybrid-public-lifecycle-token 交流电', true, now(), now()),
+  ('d2000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-owner-lifecycle-token"}'::jsonb, '{"search":"hybrid-owner-lifecycle-token"}'::json, 'a1000000-0000-0000-0000-000000000101', 0, null, 'hybrid-owner-lifecycle-token 交流电', true, now(), now()),
+  ('d3000000-0000-0000-0000-000000000101', '01.00.000', '{"search":"hybrid-outsider-lifecycle-token"}'::jsonb, '{"search":"hybrid-outsider-lifecycle-token"}'::json, 'b2000000-0000-0000-0000-000000000101', 0, null, 'hybrid-outsider-lifecycle-token 交流电', true, now(), now());
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', 'a1000000-0000-0000-0000-000000000101', true);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_flows('(电子器件) OR (electronic component)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  'f1000000-0000-0000-0000-000000000101',
+  'flow hybrid tg search returns a text candidate through latest search'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_flows('(电子器件) OR (electronic component)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  'f2000000-0000-0000-0000-000000000101',
+  'flow hybrid my search returns the authenticated owner text candidate'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select count(*) from public.hybrid_search_flows('hybrid-outsider-flow-token', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1)),
+  0::bigint,
+  'flow hybrid my search cannot return another user text candidate'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_processes('(正极材料) OR (cathode material)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  'e1000000-0000-0000-0000-000000000101',
+  'process hybrid tg search returns a text candidate through latest search'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_processes('(正极材料) OR (cathode material)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  'e2000000-0000-0000-0000-000000000101',
+  'process hybrid my search returns the authenticated owner text candidate'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select count(*) from public.hybrid_search_processes('hybrid-outsider-process-token', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1)),
+  0::bigint,
+  'process hybrid my search cannot return another user text candidate'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_lifecyclemodels('(交流电) OR (electricity)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  'd1000000-0000-0000-0000-000000000101',
+  'lifecyclemodel hybrid tg search returns a text candidate through latest search'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_lifecyclemodels('(交流电) OR (electricity)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  'd2000000-0000-0000-0000-000000000101',
+  'lifecyclemodel hybrid my search returns the authenticated owner text candidate'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary

Promote `database-engine` `dev` to `main` for the dataset search correctness/performance fixes.

This promote batch includes the merged dev work from:

- #102 `fix: materialize dataset search text matches`
- #104 `fix: bypass dataset search RLS scan overhead`
- #105 `fix: align hybrid search with latest text recall`

It also carries the existing dev backmerge commits already present on `dev` before this promote.

## Key Changes

- Latest dataset search RPCs now materialize text search candidates before applying broad dataset visibility filters.
- Dataset search RLS overhead is reduced through private helper paths used by SECURITY DEFINER search RPCs.
- Hybrid search RPCs now use the latest text recall path instead of the legacy `pgroonga_search_*_text_v1` path, so text-only and hybrid recall stay consistent.
- Regression tests cover Chinese text recall, filter behavior, and hybrid text fallback behavior.

## Validation

- #102 checks passed before merge.
- #104 checks passed before merge.
- #105 checks passed before merge.
- Supabase Dev workflow after #105 merge succeeded: https://github.com/tiangong-lca/database-engine/actions/runs/26559190134
- Local validation during #105:
  - `supabase db reset`
  - full `supabase test db`: 25 files / 420 tests passed
- Dev post-merge smoke checks:
  - migration `20260528172000` is present on dev
  - `hybrid_search_processes` calls `search_processes_latest` and no longer references `pgroonga_search_processes_text_v1`
  - `search_flows_latest('电子器件', tg)` returns results
  - `search_processes_latest('正极材料', my)` and `hybrid_search_processes('正极材料', my)` return results for the tested dev user

## Operational Notes

- No Edge Function code changed in #105.
- After this promote merges, deploy/apply the database migration to the main Supabase environment, then perform root workspace submodule pointer integration.

Refs #101
Refs #103
