### PR TITLE
Backmerge main after Supabase auto migration docs hotfix

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "983a9085ea04a6babc978fd45d82d7d32921171d"
+lastReviewedCommit: "afb4c43d17dd2d085d896edcf1dddd3600efb715"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ related:
 
 ## Repo Contract
 
-`database-engine` owns the checked-in Supabase database contract for the TianGong LCA workspace: schema truth, migration history, operator branch bindings, database-side tests, and the automation that deploys committed migrations to the persistent Supabase `dev` branch.
+`database-engine` owns the checked-in Supabase database contract for the TianGong LCA workspace: schema truth, migration history, operator branch bindings, database-side tests, the automation that deploys committed migrations to the persistent Supabase `dev` branch, and the production Supabase GitHub integration contract that applies Git `main` migrations.
 
 Start here when the task may change schema truth, branch bindings, generated schema-workspace tooling, repo validation rules, or documentation ownership inside this repo.
 
@@ -112,6 +112,7 @@ Keep these entry-level facts in `AGENTS.md`. Use `docs/agents/repo-validation.md
 - migration authoring starts from Git `dev`, not GitHub default-branch UI
 - preview-branch proof belongs to the repo PR
 - persistent `dev` proof belongs after merge into Git `dev`
+- production `main` proof belongs after `dev -> main` promote and should confirm Supabase GitHub integration applied migrations automatically
 - root workspace proof belongs later in `lca-workspace`
 - generated workspace helpers are low-risk to inspect with `python scripts/<name>.py --help`
 
@@ -129,6 +130,7 @@ At a human-readable level, this repo owns:
 - database-side review-submit gate state and final submit-review assertion RPCs
 - `scripts/**` for schema export, workspace refresh, change copying, and migration generation
 - `.github/workflows/supabase-dev.yml`
+- production Supabase GitHub integration contract for Git `main`
 - `.env.supabase.dev.local.example`
 - `.env.supabase.main.local.example`
 - repo-local governance and branching docs

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It owns the checked-in database source of truth:
 - `.env.supabase.main.local.example`
 - Supabase branching and operations docs
 - the GitHub Actions flow that pushes committed migrations to the persistent Supabase `dev` branch
+- the production Supabase GitHub integration contract that applies Git `main` migrations automatically
 
 It does **not** own:
 
@@ -52,7 +53,7 @@ Those stay in consumer repos such as:
 5. Open the PR into `dev`.
 6. Validate the Supabase preview branch created for the PR.
 7. After merge, validate the persistent `dev` branch.
-8. Promote `dev` to `main` when ready to release.
+8. Promote `dev` to `main` when ready to release, then validate the production Supabase auto migration.
 
 ## Maintenance env files
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,6 +41,7 @@ related:
 - `.env.supabase.main.local.example`
 - Supabase 分支与运维文档
 - 将已提交 migration 推送到持久化 Supabase `dev` 分支的 GitHub Actions 流程
+- 自动应用 Git `main` migrations 的生产 Supabase GitHub integration 契约
 
 它**不**负责以下内容：
 
@@ -70,7 +71,7 @@ related:
 5. 向 `dev` 发起 PR。
 6. 验证 PR 对应创建的 Supabase 预览分支。
 7. 合并后，验证持久化的 `dev` 分支。
-8. 准备发布时，将 `dev` 提升到 `main`。
+8. 准备发布时，将 `dev` 提升到 `main`，随后验证生产 Supabase 自动迁移。
 
 ## 运维环境文件
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -51,7 +51,7 @@ This repo is organized around one checked-in Supabase project plus a generated s
 | `supabase/tests/**` | PGTAP-style regression and access-control assertions |
 | `.env.supabase.dev.local.example`, `.env.supabase.main.local.example` | operator branch-binding templates |
 | `scripts/**` | export, refresh, change-copy, and migration-generation helpers |
-| `.github/workflows/supabase-dev.yml` | only checked-in automation for pushing committed migrations to the persistent remote `dev` branch |
+| `.github/workflows/supabase-dev.yml` | only checked-in GitHub Actions automation for pushing committed migrations to the persistent remote `dev` branch |
 | `supabase/workspace/changes/**` | manual overlay area used when generating migrations from workspace files |
 | `supabase/workspace/remote_schema.sql` | generated full raw dump from the remote database |
 | `supabase/workspace/global/**` | generated split-out global objects rebuilt on workspace refresh |
@@ -65,6 +65,7 @@ This repo is organized around one checked-in Supabase project plus a generated s
 - Git `main` is the promoted release line
 - PR branches map to Supabase preview branches
 - `.github/workflows/supabase-dev.yml` pushes committed migrations to the persistent remote `dev` branch on Git `dev`
+- the production Supabase project is migrated automatically by the Supabase GitHub integration when Git `main` advances
 
 This means branch behavior is part of the repo architecture, not just delivery process.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -110,9 +110,10 @@ For branch-oriented changes:
 
 - preview-branch proof usually happens on the repo PR
 - persistent remote `dev` proof happens after merge into Git `dev`
+- production `main` proof happens after `dev -> main` promote and should confirm the Supabase GitHub integration applied migrations automatically
 - root workspace proof happens later in `lca-workspace`
 
-Do not collapse those three phases into one validation note.
+Do not collapse those phases into one validation note.
 
 ## Minimum PR Validation Note
 
@@ -120,7 +121,7 @@ Every PR note for this repo should state:
 
 1. exact commands run
 2. exact SQL assertion files or migration paths exercised
-3. whether any proof is deferred to preview branch, persistent `dev`, or root integration
+3. whether any proof is deferred to preview branch, persistent `dev`, production `main`, or root integration
 
 ## Local Docpact Push Gate
 

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -56,8 +56,8 @@ Those stay in consumer repositories such as `tiangong-lca-next` and `tiangong-lc
 
 ## Branch contract
 
-- Git `main` -> production baseline
-- Git `dev` -> persistent Supabase `dev` branch
+- Git `main` -> production baseline migrated automatically by the Supabase GitHub integration
+- Git `dev` -> persistent Supabase `dev` branch migrated by `.github/workflows/supabase-dev.yml`
 - PR / feature branches -> preview branches created by the Supabase GitHub integration
 
 Rules:
@@ -75,6 +75,7 @@ Rules:
 - Keep branch-specific overrides in `[remotes.<branch>]` inside `supabase/config.toml`.
 - Do not create a separate `supabase/` directory per Git branch.
 - Keep `.github/workflows/supabase-dev.yml` as the only GitHub Actions flow in this repo that runs `supabase db push` for the persistent Supabase `dev` branch.
+- Do not add a checked-in GitHub Actions production deploy for Git `main`; the production project is migrated by the Supabase GitHub integration bound to this repository.
 - Do not author normal schema changes by editing the remote database first and reconstructing migrations later.
 
 ## Files to maintain
@@ -113,6 +114,10 @@ Supabase GitHub integration for the production project must point to:
 - repository: `tiangong-lca/database-engine`
 - relative path: `supabase`
 
+This integration applies committed migrations to the production project automatically
+when Git `main` advances. Absence of a checked-in GitHub Actions workflow for
+`main` does not mean production migration is manual-only.
+
 Repository configuration expected by `.github/workflows/supabase-dev.yml`:
 
 - variable `SUPABASE_DEV_PROJECT_ID`
@@ -138,10 +143,21 @@ Normal PR path:
 7. Pending checked-in migrations are then applied to the persistent Supabase
    `dev` branch.
 
-This repository currently has no checked-in manual `workflow_dispatch` deploy
-for Supabase. An operator can still run `supabase link` and `supabase db push`
-locally, but that is a deliberate manual deployment path and must be recorded
-as such in validation or incident notes.
+Promote path:
+
+1. A `dev -> main` promote PR merges into Git `main`.
+2. The production project's Supabase GitHub integration reads the checked-in
+   `supabase/` directory from Git `main`.
+3. Pending checked-in migrations are applied automatically to the production
+   project.
+4. Operators validate production migration state and application behavior after
+   the promote merge.
+
+This repository currently has no checked-in `workflow_dispatch` production
+deploy for Supabase. That is intentional: Git `main` is handled by the Supabase
+GitHub integration. An operator can still run `supabase link` and
+`supabase db push` locally as an explicit fallback or recovery path, but that
+manual action must be recorded in validation or incident notes.
 
 ## Vault secret contract
 
@@ -174,12 +190,22 @@ Rules:
 9. Let Supabase create or update the preview branch for that PR.
 10. After merge, validate the persistent remote `dev` branch.
 11. Promote `dev` to `main` when ready to release.
+12. Validate that the production Supabase project was migrated automatically by
+    the Supabase GitHub integration.
 
 ### Persistent `dev` branch deployment
 
 - Pushes to Git `dev` trigger `.github/workflows/supabase-dev.yml`.
 - That workflow links to the persistent Supabase `dev` branch and runs `supabase db push`.
 - Do not add a second automation path that pushes the same target.
+
+### Production `main` deployment
+
+- Pushes to Git `main` are handled by the production project's Supabase GitHub integration.
+- The integration watches repository `tiangong-lca/database-engine` with relative path `supabase`.
+- Checked-in pending migrations are applied automatically to the production project when `main` advances.
+- Do not treat the missing checked-in GitHub Actions workflow for `main` as a manual-deploy requirement.
+- Use local `supabase db push` only as an explicit fallback or recovery path, and record that action.
 
 ### Hotfix flow
 

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -56,8 +56,8 @@ related:
 
 ## 分支契约
 
-- Git `main` -> 生产基线
-- Git `dev` -> 持久化 Supabase `dev` 分支
+- Git `main` -> 生产基线，由 Supabase GitHub integration 自动迁移
+- Git `dev` -> 持久化 Supabase `dev` 分支，由 `.github/workflows/supabase-dev.yml` 迁移
 - PR / feature 分支 -> 由 Supabase GitHub integration 自动创建的 preview branch
 
 规则：
@@ -75,6 +75,7 @@ related:
 - 分支差异放在 `supabase/config.toml` 的 `[remotes.<branch>]` 中。
 - 不要为不同 Git 分支复制多套 `supabase/` 目录。
 - 把 `.github/workflows/supabase-dev.yml` 作为本仓唯一会对持久化 Supabase `dev` 分支执行 `supabase db push` 的 GitHub Actions 流程。
+- 不要为 Git `main` 增加 checked-in 的 GitHub Actions 生产部署流程；生产项目由绑定到本仓的 Supabase GitHub integration 自动迁移。
 - 不要先手改远端数据库再回头补 migration。
 
 ## 需要维护的文件
@@ -113,6 +114,9 @@ related:
 - repository: `tiangong-lca/database-engine`
 - relative path: `supabase`
 
+当 Git `main` 前进时，该 integration 会自动把已提交的 migration 应用到生产项目。
+仓库中没有针对 `main` 的 checked-in GitHub Actions workflow，并不表示生产迁移只能手动执行。
+
 `.github/workflows/supabase-dev.yml` 依赖以下仓库配置：
 
 - variable `SUPABASE_DEV_PROJECT_ID`
@@ -133,8 +137,17 @@ related:
 6. 该 workflow 会连接 `SUPABASE_DEV_PROJECT_ID` 并执行 `supabase db push`。
 7. 尚未应用的已提交 migrations 随后才会应用到持久化 Supabase `dev` 分支。
 
-本仓目前没有 checked-in 的手动 `workflow_dispatch` Supabase 部署流程。运维人员仍可在本地执行
-`supabase link` 和 `supabase db push`，但这是明确的人工部署路径，必须在验证记录或事故记录中说明。
+Promote 路径：
+
+1. `dev -> main` promote PR 合并到 Git `main`。
+2. 生产项目的 Supabase GitHub integration 会读取 Git `main` 中已提交的 `supabase/` 目录。
+3. 尚未应用的已提交 migrations 会自动应用到生产项目。
+4. 运维人员在 promote merge 后验证生产 migration 状态和应用行为。
+
+本仓目前没有 checked-in 的 `workflow_dispatch` 生产 Supabase 部署流程。这是有意设计：
+Git `main` 由 Supabase GitHub integration 处理。运维人员仍可在本地执行
+`supabase link` 和 `supabase db push`，但这只能作为明确的兜底或恢复路径，
+并且必须在验证记录或事故记录中说明。
 
 ## Vault secret 契约
 
@@ -167,12 +180,21 @@ related:
 9. 让 Supabase 为该 PR 自动创建或更新 preview branch。
 10. 合并后，在持久化远端 `dev` 分支验证结果。
 11. 准备发布时，再把 `dev` 晋升到 `main`。
+12. 验证生产 Supabase 项目已经由 Supabase GitHub integration 自动完成迁移。
 
 ### 持久化 `dev` 分支部署
 
 - 对 Git `dev` 的 push 会触发 `.github/workflows/supabase-dev.yml`。
 - 该 workflow 会连接持久化 Supabase `dev` 分支并执行 `supabase db push`。
 - 不要再增加第二条会对同一目标执行 push 的自动化链路。
+
+### 生产 `main` 部署
+
+- 对 Git `main` 的 push 由生产项目的 Supabase GitHub integration 处理。
+- 该 integration 监听 repository `tiangong-lca/database-engine`，relative path 为 `supabase`。
+- 当 `main` 前进时，已提交且尚未应用的 migrations 会自动应用到生产项目。
+- 不要把缺少 checked-in 的 `main` GitHub Actions workflow 理解为需要手动部署。
+- 本地 `supabase db push` 仅作为明确的兜底或恢复路径使用，并需要记录该动作。
 
 ### Hotfix 流程
 


### PR DESCRIPTION
## Summary

Back-merge `main` into `dev` after docs hotfix #109.

This keeps the M2 long-lived branches aligned after clarifying that Git `main` production migrations are applied automatically by the Supabase GitHub integration, while local `supabase db push` is only a fallback/recovery path.

## Validation

- `scripts/docpact lint --root . --base origin/dev --head HEAD --output /tmp/database-engine-backmerge-docpact-lint.json`
- `scripts/docpact validate-config --root . --strict`

No schema, migration, or runtime behavior changed.

Refs #109
Refs tiangong-lca/workspace#186
