### PR TITLE
Promote hybrid semantic candidate optimization to main

### DIFF
--- a/supabase/migrations/20260528193000_semantic_hybrid_candidate_helpers.sql
+++ b/supabase/migrations/20260528193000_semantic_hybrid_candidate_helpers.sql
@@ -1,0 +1,947 @@
+-- Optimize hybrid search's semantic side by making vector candidate
+-- generation table-specific, visibility-aware, and lightweight.
+
+create schema if not exists private;
+
+revoke all on schema private from public;
+grant usage on schema private to anon, authenticated, service_role;
+
+create or replace function private.semantic_flow_candidates(
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  data_source text default 'tg'::text
+) returns table(
+  rank bigint,
+  id uuid,
+  distance double precision
+)
+language plpgsql
+security definer
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  query_embedding_vector vector(1024);
+  filter_condition_jsonb jsonb;
+  normalized_data_source text;
+  normalized_match_count integer;
+  candidate_size integer;
+  threshold_distance double precision;
+  effective_user_id uuid;
+  flow_type text;
+  flow_type_array text[];
+  as_input boolean;
+begin
+  query_embedding_vector := query_embedding::vector(1024);
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  normalized_data_source := coalesce(nullif(lower(btrim(data_source)), ''), 'tg');
+  normalized_match_count := greatest(coalesce(match_count, 20), 1);
+  candidate_size := greatest(normalized_match_count * 10, 200);
+  threshold_distance := 1 - coalesce(match_threshold, 0.5);
+  effective_user_id := private.dataset_search_effective_user_id('');
+
+  flow_type := nullif(btrim(filter_condition_jsonb->>'flowType'), '');
+  if flow_type is not null then
+    flow_type_array := string_to_array(flow_type, ',');
+  else
+    flow_type_array := null;
+  end if;
+  filter_condition_jsonb := filter_condition_jsonb - 'flowType';
+
+  if filter_condition_jsonb ? 'asInput' then
+    as_input := nullif(btrim(filter_condition_jsonb->>'asInput'), '')::boolean;
+  else
+    as_input := null;
+  end if;
+  filter_condition_jsonb := filter_condition_jsonb - 'asInput';
+
+  if normalized_data_source = 'tg' then
+    return query
+      with candidates as materialized (
+        select
+          f.id as candidate_id,
+          (f.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.flows f
+        where f.embedding_ft is not null
+          and f.state_code = 100
+          and f.json @> filter_condition_jsonb
+          and (
+            flow_type is null
+            or flow_type = ''
+            or (f.json->'flowDataSet'->'modellingAndValidation'->'LCIMethod'->>'typeOfDataSet') = any(flow_type_array)
+          )
+          and (
+            as_input is null
+            or as_input = false
+            or not (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+        order by f.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'co' then
+    return query
+      with candidates as materialized (
+        select
+          f.id as candidate_id,
+          (f.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.flows f
+        where f.embedding_ft is not null
+          and f.state_code = 200
+          and f.json @> filter_condition_jsonb
+          and (
+            flow_type is null
+            or flow_type = ''
+            or (f.json->'flowDataSet'->'modellingAndValidation'->'LCIMethod'->>'typeOfDataSet') = any(flow_type_array)
+          )
+          and (
+            as_input is null
+            or as_input = false
+            or not (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+        order by f.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'my' then
+    if effective_user_id is null then
+      return;
+    end if;
+
+    return query
+      with candidates as materialized (
+        select
+          f.id as candidate_id,
+          (f.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.flows f
+        where f.embedding_ft is not null
+          and f.user_id = effective_user_id
+          and f.json @> filter_condition_jsonb
+          and (
+            flow_type is null
+            or flow_type = ''
+            or (f.json->'flowDataSet'->'modellingAndValidation'->'LCIMethod'->>'typeOfDataSet') = any(flow_type_array)
+          )
+          and (
+            as_input is null
+            or as_input = false
+            or not (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+        order by f.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'te' then
+    if effective_user_id is null then
+      return;
+    end if;
+
+    return query
+      with candidates as materialized (
+        select
+          f.id as candidate_id,
+          (f.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.flows f
+        where f.embedding_ft is not null
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = effective_user_id
+              and r.team_id = f.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+          and f.json @> filter_condition_jsonb
+          and (
+            flow_type is null
+            or flow_type = ''
+            or (f.json->'flowDataSet'->'modellingAndValidation'->'LCIMethod'->>'typeOfDataSet') = any(flow_type_array)
+          )
+          and (
+            as_input is null
+            or as_input = false
+            or not (
+              f.json @> '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"classificationInformation":{"common:elementaryFlowCategorization":{"common:category":[{"#text":"Emissions","@level":"0"}]}}}}}}'
+            )
+          )
+        order by f.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+end;
+$$;
+
+create or replace function private.semantic_process_candidates(
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  data_source text default 'tg'::text
+) returns table(
+  rank bigint,
+  id uuid,
+  distance double precision
+)
+language plpgsql
+security definer
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  query_embedding_vector vector(1024);
+  filter_condition_jsonb jsonb;
+  normalized_data_source text;
+  normalized_match_count integer;
+  candidate_size integer;
+  threshold_distance double precision;
+  effective_user_id uuid;
+begin
+  query_embedding_vector := query_embedding::vector(1024);
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  normalized_data_source := coalesce(nullif(lower(btrim(data_source)), ''), 'tg');
+  normalized_match_count := greatest(coalesce(match_count, 20), 1);
+  candidate_size := greatest(normalized_match_count * 10, 200);
+  threshold_distance := 1 - coalesce(match_threshold, 0.5);
+  effective_user_id := private.dataset_search_effective_user_id('');
+
+  if normalized_data_source = 'tg' then
+    return query
+      with candidates as materialized (
+        select
+          p.id as candidate_id,
+          (p.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.processes p
+        where p.embedding_ft is not null
+          and p.state_code = 100
+          and p.json @> filter_condition_jsonb
+        order by p.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'co' then
+    return query
+      with candidates as materialized (
+        select
+          p.id as candidate_id,
+          (p.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.processes p
+        where p.embedding_ft is not null
+          and p.state_code = 200
+          and p.json @> filter_condition_jsonb
+        order by p.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'my' then
+    if effective_user_id is null then
+      return;
+    end if;
+
+    return query
+      with candidates as materialized (
+        select
+          p.id as candidate_id,
+          (p.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.processes p
+        where p.embedding_ft is not null
+          and p.user_id = effective_user_id
+          and p.json @> filter_condition_jsonb
+        order by p.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'te' then
+    if effective_user_id is null then
+      return;
+    end if;
+
+    return query
+      with candidates as materialized (
+        select
+          p.id as candidate_id,
+          (p.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.processes p
+        where p.embedding_ft is not null
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = effective_user_id
+              and r.team_id = p.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+          and p.json @> filter_condition_jsonb
+        order by p.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+end;
+$$;
+
+create or replace function private.semantic_lifecyclemodel_candidates(
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  data_source text default 'tg'::text
+) returns table(
+  rank bigint,
+  id uuid,
+  distance double precision
+)
+language plpgsql
+security definer
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '60s'
+as $$
+declare
+  query_embedding_vector vector(1024);
+  filter_condition_jsonb jsonb;
+  normalized_data_source text;
+  normalized_match_count integer;
+  candidate_size integer;
+  threshold_distance double precision;
+  effective_user_id uuid;
+begin
+  query_embedding_vector := query_embedding::vector(1024);
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  normalized_data_source := coalesce(nullif(lower(btrim(data_source)), ''), 'tg');
+  normalized_match_count := greatest(coalesce(match_count, 20), 1);
+  candidate_size := greatest(normalized_match_count * 10, 200);
+  threshold_distance := 1 - coalesce(match_threshold, 0.5);
+  effective_user_id := private.dataset_search_effective_user_id('');
+
+  if normalized_data_source = 'tg' then
+    return query
+      with candidates as materialized (
+        select
+          l.id as candidate_id,
+          (l.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.lifecyclemodels l
+        where l.embedding_ft is not null
+          and l.state_code = 100
+          and l.json @> filter_condition_jsonb
+        order by l.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'co' then
+    return query
+      with candidates as materialized (
+        select
+          l.id as candidate_id,
+          (l.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.lifecyclemodels l
+        where l.embedding_ft is not null
+          and l.state_code = 200
+          and l.json @> filter_condition_jsonb
+        order by l.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'my' then
+    if effective_user_id is null then
+      return;
+    end if;
+
+    return query
+      with candidates as materialized (
+        select
+          l.id as candidate_id,
+          (l.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.lifecyclemodels l
+        where l.embedding_ft is not null
+          and l.user_id = effective_user_id
+          and l.json @> filter_condition_jsonb
+        order by l.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+
+  if normalized_data_source = 'te' then
+    if effective_user_id is null then
+      return;
+    end if;
+
+    return query
+      with candidates as materialized (
+        select
+          l.id as candidate_id,
+          (l.embedding_ft <=> query_embedding_vector) as candidate_distance
+        from public.lifecyclemodels l
+        where l.embedding_ft is not null
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = effective_user_id
+              and r.team_id = l.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+          and l.json @> filter_condition_jsonb
+        order by l.embedding_ft <=> query_embedding_vector
+        limit candidate_size
+      ),
+      filtered as (
+        select candidates.*
+        from candidates
+        where candidates.candidate_distance < threshold_distance
+      )
+      select
+        rank() over (order by filtered.candidate_distance)::bigint,
+        filtered.candidate_id,
+        filtered.candidate_distance
+      from filtered
+      order by filtered.candidate_distance
+      limit normalized_match_count;
+    return;
+  end if;
+end;
+$$;
+
+create or replace function public.hybrid_search_flows(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_flows_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from private.semantic_flow_candidates(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select f.*
+      from public.flows f
+      join fused on fused.id = f.id
+      where (
+        (data_source = 'tg' and f.state_code = 100)
+        or (data_source = 'co' and f.state_code = 200)
+        or (data_source = 'my' and f.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = f.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+create or replace function public.hybrid_search_processes(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  model_id uuid,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_processes_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer,
+        'all'
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from private.semantic_process_candidates(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select p.*
+      from public.processes p
+      join fused on fused.id = p.id
+      where (
+        (data_source = 'tg' and p.state_code = 100)
+        or (data_source = 'co' and p.state_code = 200)
+        or (data_source = 'my' and p.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = p.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.model_id,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.model_id,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+create or replace function public.hybrid_search_lifecyclemodels(
+  query_text text,
+  query_embedding text,
+  filter_condition text default ''::text,
+  match_threshold double precision default 0.5,
+  match_count integer default 20,
+  full_text_weight double precision default 0.3,
+  extracted_text_weight double precision default 0.2,
+  semantic_weight double precision default 0.5,
+  rrf_k integer default 10,
+  data_source text default 'tg'::text,
+  page_size integer default 10,
+  page_current integer default 1
+) returns table(
+  id uuid,
+  "json" jsonb,
+  version character(9),
+  modified_at timestamp with time zone,
+  team_id uuid,
+  total_count bigint
+)
+language plpgsql
+set statement_timeout to '60s'
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+declare
+  candidate_limit integer;
+  filter_condition_jsonb jsonb;
+  text_weight double precision;
+begin
+  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''), '{}')::jsonb;
+  text_weight := coalesce(full_text_weight, 0) + coalesce(extracted_text_weight, 0);
+
+  return query
+    with text_matches as (
+      select ts.rank as text_rank, ts.id as text_id
+      from public.search_lifecyclemodels_latest(
+        query_text,
+        filter_condition_jsonb,
+        '{}'::jsonb,
+        candidate_limit,
+        1,
+        data_source,
+        '',
+        null::uuid,
+        null::integer
+      ) ts
+    ),
+    semantic as (
+      select ss.rank as ss_rank, ss.id as ss_id
+      from private.semantic_lifecyclemodel_candidates(
+        query_embedding,
+        filter_condition,
+        match_threshold,
+        candidate_limit,
+        data_source
+      ) ss
+    ),
+    fused_raw as (
+      select
+        coalesce(text_matches.text_id, semantic.ss_id) as id,
+        coalesce(1.0 / (rrf_k + text_matches.text_rank), 0.0) * text_weight
+          + coalesce(1.0 / (rrf_k + semantic.ss_rank), 0.0) * semantic_weight as score
+      from text_matches
+      full outer join semantic on text_matches.text_id = semantic.ss_id
+    ),
+    fused as (
+      select fused_raw.id, sum(fused_raw.score) as score
+      from fused_raw
+      where fused_raw.id is not null
+      group by fused_raw.id
+    ),
+    visible_rows as (
+      select l.*
+      from public.lifecyclemodels l
+      join fused on fused.id = l.id
+      where (
+        (data_source = 'tg' and l.state_code = 100)
+        or (data_source = 'co' and l.state_code = 200)
+        or (data_source = 'my' and l.user_id = auth.uid())
+        or (
+          data_source = 'te'
+          and exists (
+            select 1
+            from public.roles r
+            where r.user_id = auth.uid()
+              and r.team_id = l.team_id
+              and r.role::text in ('admin', 'member', 'owner')
+          )
+        )
+      )
+    ),
+    latest_rows as (
+      select distinct on (visible_rows.id)
+        visible_rows.id,
+        visible_rows.json,
+        visible_rows.version,
+        visible_rows.modified_at,
+        visible_rows.team_id,
+        fused.score
+      from visible_rows
+      join fused on fused.id = visible_rows.id
+      order by visible_rows.id, visible_rows.version desc, visible_rows.modified_at desc
+    ),
+    counted_rows as (
+      select latest_rows.*, count(*) over()::bigint as total_count
+      from latest_rows
+    )
+    select
+      counted_rows.id,
+      counted_rows.json,
+      counted_rows.version,
+      counted_rows.modified_at,
+      counted_rows.team_id,
+      counted_rows.total_count
+    from counted_rows
+    order by counted_rows.score desc, counted_rows.modified_at desc, counted_rows.id
+    limit greatest(coalesce(page_size, 10), 1)
+    offset (greatest(coalesce(page_current, 1), 1) - 1) * greatest(coalesce(page_size, 10), 1);
+end;
+$$;
+
+alter function private.semantic_flow_candidates(text, text, double precision, integer, text) owner to postgres;
+alter function private.semantic_process_candidates(text, text, double precision, integer, text) owner to postgres;
+alter function private.semantic_lifecyclemodel_candidates(text, text, double precision, integer, text) owner to postgres;
+alter function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+alter function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+alter function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) owner to postgres;
+
+revoke all on function private.semantic_flow_candidates(text, text, double precision, integer, text) from public;
+revoke all on function private.semantic_process_candidates(text, text, double precision, integer, text) from public;
+revoke all on function private.semantic_lifecyclemodel_candidates(text, text, double precision, integer, text) from public;
+
+grant execute on function private.semantic_flow_candidates(text, text, double precision, integer, text) to anon, authenticated, service_role;
+grant execute on function private.semantic_process_candidates(text, text, double precision, integer, text) to anon, authenticated, service_role;
+grant execute on function private.semantic_lifecyclemodel_candidates(text, text, double precision, integer, text) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer) to anon, authenticated, service_role;

--- a/supabase/tests/20260528_semantic_hybrid_candidate_helpers.sql
+++ b/supabase/tests/20260528_semantic_hybrid_candidate_helpers.sql
@@ -1,0 +1,253 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(15);
+
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger_name text)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger_name
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger_name);
+  end if;
+end;
+$$;
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.semantic_flow_candidates(text,text,double precision,integer,text)'::regprocedure),
+  'flow semantic candidates run as security definer'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.semantic_process_candidates(text,text,double precision,integer,text)'::regprocedure),
+  'process semantic candidates run as security definer'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.semantic_lifecyclemodel_candidates(text,text,double precision,integer,text)'::regprocedure),
+  'lifecyclemodel semantic candidates run as security definer'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'private.semantic_flow_candidates') > 0
+    and strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.semantic_search_flows_v1') = 0,
+  'flow hybrid search uses lightweight private semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'private.semantic_process_candidates') > 0
+    and strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.semantic_search_processes_v1') = 0,
+  'process hybrid search uses lightweight private semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'private.semantic_lifecyclemodel_candidates') > 0
+    and strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.semantic_search_lifecyclemodels_v1') = 0,
+  'lifecyclemodel hybrid search uses lightweight private semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.semantic_process_candidates(text,text,double precision,integer,text)'::regprocedure), 'limit candidate_size') > 0,
+  'process semantic candidates apply a real candidate limit'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.semantic_process_candidates(text,text,double precision,integer,text)'::regprocedure), 'p.user_id = effective_user_id') > 0,
+  'process my semantic candidates are visibility-first'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.semantic_process_candidates(text,text,double precision,integer,text)'::regprocedure), 'r.user_id = effective_user_id') > 0
+    and strpos(pg_get_functiondef('private.semantic_process_candidates(text,text,double precision,integer,text)'::regprocedure), 'r.team_id = p.team_id') > 0,
+  'process team semantic candidates check actor team membership'
+);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'a1000000-0000-0000-0000-000000000111',
+    'authenticated',
+    'authenticated',
+    'semantic-candidate-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"a1000000-0000-0000-0000-000000000111","email":"semantic-candidate-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'b2000000-0000-0000-0000-000000000111',
+    'authenticated',
+    'authenticated',
+    'semantic-candidate-outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"b2000000-0000-0000-0000-000000000111","email":"semantic-candidate-outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('a1000000-0000-0000-0000-000000000111', '{"email":"semantic-candidate-owner@example.com"}'::jsonb, null),
+  ('b2000000-0000-0000-0000-000000000111', '{"email":"semantic-candidate-outsider@example.com"}'::jsonb, null);
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('c3000000-0000-0000-0000-000000000111', '{"name":"Semantic Candidate Team"}'::jsonb, 1, false);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('a1000000-0000-0000-0000-000000000111', 'c3000000-0000-0000-0000-000000000111', 'owner');
+
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flows_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_dataset_extraction_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'zz_flows_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'processes_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'zz_processes_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodel_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'zz_lifecyclemodels_extracted_text_sync_trigger');
+
+with test_vector(value) as (
+  select ('[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']')::vector(1024)
+)
+insert into public.flows (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, embedding_ft, rule_verification, created_at, modified_at
+)
+select *
+from (
+  select 'f1000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-owner-flow"}'::jsonb, '{"search":"semantic-owner-flow"}'::json, 'a1000000-0000-0000-0000-000000000111'::uuid, 0, null::uuid, 'semantic-owner-flow'::text, test_vector.value, true, now(), now() from test_vector
+  union all
+  select 'f2000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-team-flow"}'::jsonb, '{"search":"semantic-team-flow"}'::json, 'b2000000-0000-0000-0000-000000000111'::uuid, 0, 'c3000000-0000-0000-0000-000000000111'::uuid, 'semantic-team-flow'::text, test_vector.value, true, now(), now() from test_vector
+  union all
+  select 'f3000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-outsider-flow"}'::jsonb, '{"search":"semantic-outsider-flow"}'::json, 'b2000000-0000-0000-0000-000000000111'::uuid, 0, null::uuid, 'semantic-outsider-flow'::text, test_vector.value, true, now(), now() from test_vector
+) rows;
+
+with test_vector(value) as (
+  select ('[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']')::vector(1024)
+)
+insert into public.processes (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, embedding_ft, rule_verification, created_at, modified_at
+)
+select *
+from (
+  select 'e1000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-owner-process"}'::jsonb, '{"search":"semantic-owner-process"}'::json, 'a1000000-0000-0000-0000-000000000111'::uuid, 0, null::uuid, 'semantic-owner-process'::text, test_vector.value, true, now(), now() from test_vector
+  union all
+  select 'e2000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-team-process"}'::jsonb, '{"search":"semantic-team-process"}'::json, 'b2000000-0000-0000-0000-000000000111'::uuid, 0, 'c3000000-0000-0000-0000-000000000111'::uuid, 'semantic-team-process'::text, test_vector.value, true, now(), now() from test_vector
+  union all
+  select 'e3000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-outsider-process"}'::jsonb, '{"search":"semantic-outsider-process"}'::json, 'b2000000-0000-0000-0000-000000000111'::uuid, 0, null::uuid, 'semantic-outsider-process'::text, test_vector.value, true, now(), now() from test_vector
+) rows;
+
+with test_vector(value) as (
+  select ('[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']')::vector(1024)
+)
+insert into public.lifecyclemodels (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, embedding_ft, rule_verification, created_at, modified_at
+)
+select *
+from (
+  select 'd1000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-owner-lifecycle"}'::jsonb, '{"search":"semantic-owner-lifecycle"}'::json, 'a1000000-0000-0000-0000-000000000111'::uuid, 0, null::uuid, 'semantic-owner-lifecycle'::text, test_vector.value, true, now(), now() from test_vector
+  union all
+  select 'd2000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-team-lifecycle"}'::jsonb, '{"search":"semantic-team-lifecycle"}'::json, 'b2000000-0000-0000-0000-000000000111'::uuid, 0, 'c3000000-0000-0000-0000-000000000111'::uuid, 'semantic-team-lifecycle'::text, test_vector.value, true, now(), now() from test_vector
+  union all
+  select 'd3000000-0000-0000-0000-000000000111'::uuid, '01.00.000'::character(9), '{"search":"semantic-outsider-lifecycle"}'::jsonb, '{"search":"semantic-outsider-lifecycle"}'::json, 'b2000000-0000-0000-0000-000000000111'::uuid, 0, null::uuid, 'semantic-outsider-lifecycle'::text, test_vector.value, true, now(), now() from test_vector
+) rows;
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', 'a1000000-0000-0000-0000-000000000111', true);
+
+with query_vector(value) as (
+  select '[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']'
+)
+select is(
+  (select array_agg(id::text order by id) from private.semantic_flow_candidates((select value from query_vector), '{}', 0.5, 20, 'my')),
+  array['f1000000-0000-0000-0000-000000000111']::text[],
+  'flow my semantic candidates only include the authenticated owner row'
+);
+
+with query_vector(value) as (
+  select '[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']'
+)
+select is(
+  (select array_agg(id::text order by id) from private.semantic_process_candidates((select value from query_vector), '{}', 0.5, 20, 'my')),
+  array['e1000000-0000-0000-0000-000000000111']::text[],
+  'process my semantic candidates only include the authenticated owner row'
+);
+
+with query_vector(value) as (
+  select '[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']'
+)
+select is(
+  (select array_agg(id::text order by id) from private.semantic_lifecyclemodel_candidates((select value from query_vector), '{}', 0.5, 20, 'my')),
+  array['d1000000-0000-0000-0000-000000000111']::text[],
+  'lifecyclemodel my semantic candidates only include the authenticated owner row'
+);
+
+with query_vector(value) as (
+  select '[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']'
+)
+select is(
+  (select array_agg(id::text order by id) from private.semantic_process_candidates((select value from query_vector), '{}', 0.5, 20, 'te')),
+  array['e2000000-0000-0000-0000-000000000111']::text[],
+  'process team semantic candidates only include actor team rows'
+);
+
+with query_vector(value) as (
+  select '[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_processes('no-text-match-token', (select value from query_vector), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  'e1000000-0000-0000-0000-000000000111',
+  'process hybrid search can return a semantic-only my candidate'
+);
+
+with query_vector(value) as (
+  select '[1,' || array_to_string(array_fill('0'::text, array[1023]), ',') || ']'
+)
+select is(
+  (select id::text from public.hybrid_search_processes('semantic-outsider-process', (select value from query_vector), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  'e1000000-0000-0000-0000-000000000111',
+  'process hybrid my search does not leak outsider semantic candidates even when text query names outsider row'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes #111

## Summary
- promote the hybrid semantic candidate optimization from `dev` to `main`
- add private `semantic_*_candidates` helpers for flows, processes, and lifecyclemodels
- rewire `hybrid_search_*` semantic-side recall to use bounded, visibility-aware candidate helpers
- keep public `semantic_search_*_v1` functions and public hybrid RPC signatures compatible

## Promote Diff
- `supabase/migrations/20260528193000_semantic_hybrid_candidate_helpers.sql`
- `supabase/tests/20260528_semantic_hybrid_candidate_helpers.sql`

## Validation already completed on #112
- `supabase db reset`
- targeted SQL tests: 4 files / 69 tests passed
- full `supabase test db`: 26 files / 435 tests passed
- Gitleaks Security Scan passed
- Supabase Preview passed

## Deployment / Follow-up
- After merge to `main`, Supabase GitHub integration should apply the migration automatically.
- Re-test production hybrid search latency after main migration deployment.
- This PR optimizes the DB-side semantic branch; Edge embedding and query rewrite latency are outside this change.