### PR TITLE
Hotfix hybrid semantic candidate expansion

### DIFF
--- a/supabase/migrations/20260528194000_hybrid_semantic_candidate_limit_hotfix.sql
+++ b/supabase/migrations/20260528194000_hybrid_semantic_candidate_limit_hotfix.sql
@@ -1,0 +1,52 @@
+do $$
+declare
+  flow_signature constant text := 'public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)';
+  process_signature constant text := 'public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)';
+  lifecyclemodel_signature constant text := 'public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)';
+  fn text;
+begin
+  foreach fn in array array[
+    pg_get_functiondef(flow_signature::regprocedure),
+    pg_get_functiondef(process_signature::regprocedure),
+    pg_get_functiondef(lifecyclemodel_signature::regprocedure)
+  ]
+  loop
+    fn := replace(
+      fn,
+      '  candidate_limit integer;
+  filter_condition_jsonb jsonb;',
+      '  candidate_limit integer;
+  semantic_match_count integer;
+  filter_condition_jsonb jsonb;'
+    );
+
+    fn := replace(
+      fn,
+      '  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''''), ''{}'')::jsonb;',
+      '  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  semantic_match_count := greatest(coalesce(match_count, 20), coalesce(page_size, 10));
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''''), ''{}'')::jsonb;'
+    );
+
+    fn := replace(
+      fn,
+      '        match_threshold,
+        candidate_limit,
+        data_source',
+      '        match_threshold,
+        semantic_match_count,
+        data_source'
+    );
+
+    execute fn;
+  end loop;
+
+  if strpos(pg_get_functiondef(flow_signature::regprocedure), 'semantic_match_count') = 0
+    or strpos(pg_get_functiondef(process_signature::regprocedure), 'semantic_match_count') = 0
+    or strpos(pg_get_functiondef(lifecyclemodel_signature::regprocedure), 'semantic_match_count') = 0
+  then
+    raise exception 'hybrid semantic candidate limit hotfix did not apply';
+  end if;
+end;
+$$;

--- a/supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql
+++ b/supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql
@@ -1,0 +1,67 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(9);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  'flow hybrid declares a separate semantic match count'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        semantic_match_count,
+        data_source') > 0,
+  'flow hybrid passes the unexpanded semantic match count to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        candidate_limit,
+        data_source') = 0,
+  'flow hybrid no longer passes the 10x text candidate limit to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  'process hybrid declares a separate semantic match count'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        semantic_match_count,
+        data_source') > 0,
+  'process hybrid passes the unexpanded semantic match count to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        candidate_limit,
+        data_source') = 0,
+  'process hybrid no longer passes the 10x text candidate limit to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  'lifecyclemodel hybrid declares a separate semantic match count'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        semantic_match_count,
+        data_source') > 0,
+  'lifecyclemodel hybrid passes the unexpanded semantic match count to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        candidate_limit,
+        data_source') = 0,
+  'lifecyclemodel hybrid no longer passes the 10x text candidate limit to semantic candidates'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Refs #111

## Summary
- hotfix `hybrid_search_flows/processes/lifecyclemodels` so the semantic branch receives the unexpanded `semantic_match_count` instead of the 10x text candidate limit
- keep the text-side candidate oversampling unchanged
- add SQL tests to prevent passing `candidate_limit` into `private.semantic_*_candidates` again

## Why
Production validation after #114 showed the migration was applied and the hybrid functions were wired to private helpers, but `hybrid_search_flows(电子器件, tg)` still spent about 2.0-2.2s in the semantic branch. The root cause was double expansion: hybrid computed `candidate_limit = 200`, then the helper multiplied that by 10 and scanned 2000 vector candidates. Calling the same helper with the intended `match_count = 20` measured about 2.9ms on production.

## Validation
- `supabase db reset`
- `supabase test db supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql supabase/tests/20260528_semantic_hybrid_candidate_helpers.sql supabase/tests/20260528_hybrid_search_latest_text_candidates.sql supabase/tests/20260528_dataset_search_rls_private_helpers.sql supabase/tests/20260528_dataset_search_text_first_plan.sql` PASS, 5 files / 78 tests
- production read-only check before this PR: migration `20260528193000` applied; public hybrid RPCs use private semantic helpers; flow helper `match_count=200` ~2202ms vs `match_count=20` ~2.9ms for the same zero-vector smoke

## Rollout
- Hotfix targets `main` first because #114 already reached main.
- After merge, backmerge `main` into `dev`.
- Re-run production hybrid DB smoke and full Edge latency checks after Supabase main migration applies.