### PR TITLE
Backmerge main after hybrid semantic hotfix

### DIFF
--- a/supabase/migrations/20260528194000_hybrid_semantic_candidate_limit_hotfix.sql
+++ b/supabase/migrations/20260528194000_hybrid_semantic_candidate_limit_hotfix.sql
@@ -1,0 +1,52 @@
+do $$
+declare
+  flow_signature constant text := 'public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)';
+  process_signature constant text := 'public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)';
+  lifecyclemodel_signature constant text := 'public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)';
+  fn text;
+begin
+  foreach fn in array array[
+    pg_get_functiondef(flow_signature::regprocedure),
+    pg_get_functiondef(process_signature::regprocedure),
+    pg_get_functiondef(lifecyclemodel_signature::regprocedure)
+  ]
+  loop
+    fn := replace(
+      fn,
+      '  candidate_limit integer;
+  filter_condition_jsonb jsonb;',
+      '  candidate_limit integer;
+  semantic_match_count integer;
+  filter_condition_jsonb jsonb;'
+    );
+
+    fn := replace(
+      fn,
+      '  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''''), ''{}'')::jsonb;',
+      '  candidate_limit := greatest(coalesce(match_count, 20), coalesce(page_size, 10)) * 10;
+  semantic_match_count := greatest(coalesce(match_count, 20), coalesce(page_size, 10));
+  filter_condition_jsonb := coalesce(nullif(btrim(filter_condition), ''''), ''{}'')::jsonb;'
+    );
+
+    fn := replace(
+      fn,
+      '        match_threshold,
+        candidate_limit,
+        data_source',
+      '        match_threshold,
+        semantic_match_count,
+        data_source'
+    );
+
+    execute fn;
+  end loop;
+
+  if strpos(pg_get_functiondef(flow_signature::regprocedure), 'semantic_match_count') = 0
+    or strpos(pg_get_functiondef(process_signature::regprocedure), 'semantic_match_count') = 0
+    or strpos(pg_get_functiondef(lifecyclemodel_signature::regprocedure), 'semantic_match_count') = 0
+  then
+    raise exception 'hybrid semantic candidate limit hotfix did not apply';
+  end if;
+end;
+$$;

--- a/supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql
+++ b/supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql
@@ -1,0 +1,67 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(9);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  'flow hybrid declares a separate semantic match count'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        semantic_match_count,
+        data_source') > 0,
+  'flow hybrid passes the unexpanded semantic match count to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        candidate_limit,
+        data_source') = 0,
+  'flow hybrid no longer passes the 10x text candidate limit to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  'process hybrid declares a separate semantic match count'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        semantic_match_count,
+        data_source') > 0,
+  'process hybrid passes the unexpanded semantic match count to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        candidate_limit,
+        data_source') = 0,
+  'process hybrid no longer passes the 10x text candidate limit to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  'lifecyclemodel hybrid declares a separate semantic match count'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        semantic_match_count,
+        data_source') > 0,
+  'lifecyclemodel hybrid passes the unexpanded semantic match count to semantic candidates'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+        candidate_limit,
+        data_source') = 0,
+  'lifecyclemodel hybrid no longer passes the 10x text candidate limit to semantic candidates'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary
- backmerge `main` into `dev` after hotfix #115
- keeps M2 long-lived branches aligned after the production hybrid semantic candidate limit fix

## Diff
- `supabase/migrations/20260528194000_hybrid_semantic_candidate_limit_hotfix.sql`
- `supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql`

## Validation
- Backmerge was clean with no conflicts.
- #115 validation: `supabase db reset` passed.
- #115 validation: targeted SQL tests passed, 5 files / 78 tests.
- #115 checks: Gitleaks and Supabase Preview passed.

Refs #115
Refs #111