### PR TITLE
Add controlled team invite email lookup RPC

### DIFF
--- a/supabase/migrations/20260528203000_team_invitable_user_lookup.sql
+++ b/supabase/migrations/20260528203000_team_invitable_user_lookup.sql
@@ -1,0 +1,162 @@
+create or replace function public.qry_team_find_invitable_user_by_email(
+  p_team_id uuid,
+  p_email text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_email text := lower(btrim(coalesce(p_email, '')));
+  v_user_id uuid;
+  v_user_email text;
+  v_user_meta jsonb := '{}'::jsonb;
+  v_requested_team_role text;
+  v_other_team_role text;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_team_id is null or v_email = '' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_PAYLOAD',
+      'status', 400,
+      'message', 'teamId and email are required'
+    );
+  end if;
+
+  if p_team_id = '00000000-0000-0000-0000-000000000000'::uuid then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_TEAM_SCOPE',
+      'status', 400,
+      'message', 'Use system or review member commands for the zero team scope'
+    );
+  end if;
+
+  if not public.cmd_membership_is_team_manager(v_actor, p_team_id) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'FORBIDDEN',
+      'status', 403,
+      'message', 'Only team owners and admins can look up invitees'
+    );
+  end if;
+
+  select
+    au.id,
+    coalesce(nullif(btrim(au.email), ''), nullif(btrim(u.raw_user_meta_data ->> 'email'), '')),
+    coalesce(u.raw_user_meta_data, '{}'::jsonb)
+  into v_user_id, v_user_email, v_user_meta
+  from auth.users as au
+  left join public.users as u
+    on u.id = au.id
+  where lower(btrim(coalesce(au.email, u.raw_user_meta_data ->> 'email', ''))) = v_email
+  order by au.created_at desc, au.id
+  limit 1;
+
+  if v_user_id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'USER_NOT_FOUND',
+      'status', 404,
+      'message', 'No registered user was found for this email'
+    );
+  end if;
+
+  select role
+    into v_requested_team_role
+  from public.roles
+  where user_id = v_user_id
+    and team_id = p_team_id;
+
+  if v_requested_team_role = 'rejected' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REINVITE_REQUIRED',
+      'status', 409,
+      'message', 'Use the reinvite command for rejected members',
+      'data', jsonb_build_object(
+        'id', v_user_id,
+        'user_id', v_user_id,
+        'email', coalesce(v_user_email, v_email)
+      )
+    );
+  end if;
+
+  if v_requested_team_role is not null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'TEAM_MEMBER_ALREADY_EXISTS',
+      'status', 409,
+      'message', 'The team membership already exists',
+      'data', jsonb_build_object(
+        'id', v_user_id,
+        'user_id', v_user_id,
+        'email', coalesce(v_user_email, v_email)
+      )
+    );
+  end if;
+
+  select role
+    into v_other_team_role
+  from public.roles
+  where user_id = v_user_id
+    and team_id <> '00000000-0000-0000-0000-000000000000'::uuid
+    and team_id <> p_team_id
+    and role <> 'rejected'
+  order by
+    case when role = 'is_invited' then 0 else 1 end,
+    modified_at desc nulls last,
+    created_at desc nulls last
+  limit 1;
+
+  if v_other_team_role = 'is_invited' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'USER_ALREADY_INVITED_TO_TEAM',
+      'status', 409,
+      'message', 'This user already has a pending invitation to another team'
+    );
+  end if;
+
+  if v_other_team_role is not null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'USER_ALREADY_IN_TEAM',
+      'status', 409,
+      'message', 'This user already belongs to another team'
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'id', v_user_id,
+      'user_id', v_user_id,
+      'email', coalesce(v_user_email, v_email),
+      'display_name', coalesce(
+        nullif(btrim(v_user_meta ->> 'display_name'), ''),
+        nullif(btrim(v_user_meta ->> 'name'), ''),
+        nullif(btrim(v_user_email), ''),
+        v_email
+      )
+    )
+  );
+end;
+$$;
+
+alter function public.qry_team_find_invitable_user_by_email(uuid, text) owner to postgres;
+
+revoke all on function public.qry_team_find_invitable_user_by_email(uuid, text) from public;
+
+grant execute on function public.qry_team_find_invitable_user_by_email(uuid, text) to authenticated;
+grant execute on function public.qry_team_find_invitable_user_by_email(uuid, text) to service_role;

--- a/supabase/tests/20260528_team_invitable_user_lookup_rpc.sql
+++ b/supabase/tests/20260528_team_invitable_user_lookup_rpc.sql
@@ -1,0 +1,303 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(12);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'invite-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"invite-owner@example.com","display_name":"Invite Owner"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'invite-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"invite-admin@example.com","display_name":"Invite Admin"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'invite-member@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"invite-member@example.com","display_name":"Invite Member"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    'fresh-invitee@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"fresh-invitee@example.com","display_name":"Fresh Invitee"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000005',
+    'authenticated',
+    'authenticated',
+    'other-member@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"other-member@example.com","display_name":"Other Member"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000006',
+    'authenticated',
+    'authenticated',
+    'other-invited@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"other-invited@example.com","display_name":"Other Invited"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000007',
+    'authenticated',
+    'authenticated',
+    'other-rejected@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"other-rejected@example.com","display_name":"Other Rejected"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000008',
+    'authenticated',
+    'authenticated',
+    'same-invited@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"same-invited@example.com","display_name":"Same Invited"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '81000000-0000-0000-0000-000000000009',
+    'authenticated',
+    'authenticated',
+    'same-rejected@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"email":"same-rejected@example.com","display_name":"Same Rejected"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.teams (id, json, rank, is_public, modified_at)
+values
+  ('82000000-0000-0000-0000-000000000001', '{"title":[{"@xml:lang":"en","#text":"Invite Team"}]}'::jsonb, 1, false, now()),
+  ('82000000-0000-0000-0000-000000000002', '{"title":[{"@xml:lang":"en","#text":"Other Team"}]}'::jsonb, 2, false, now());
+
+insert into public.roles (user_id, team_id, role, modified_at)
+values
+  ('81000000-0000-0000-0000-000000000001', '82000000-0000-0000-0000-000000000001', 'owner', now()),
+  ('81000000-0000-0000-0000-000000000002', '82000000-0000-0000-0000-000000000001', 'admin', now()),
+  ('81000000-0000-0000-0000-000000000003', '82000000-0000-0000-0000-000000000001', 'member', now()),
+  ('81000000-0000-0000-0000-000000000005', '82000000-0000-0000-0000-000000000002', 'member', now()),
+  ('81000000-0000-0000-0000-000000000006', '82000000-0000-0000-0000-000000000002', 'is_invited', now()),
+  ('81000000-0000-0000-0000-000000000007', '82000000-0000-0000-0000-000000000002', 'rejected', now()),
+  ('81000000-0000-0000-0000-000000000008', '82000000-0000-0000-0000-000000000001', 'is_invited', now()),
+  ('81000000-0000-0000-0000-000000000009', '82000000-0000-0000-0000-000000000001', 'rejected', now());
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'fresh-invitee@example.com'
+  ) #>> '{data,id}',
+  '81000000-0000-0000-0000-000000000004',
+  'team owner can resolve a fresh invitee by exact email'
+);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    '  FRESH-INVITEE@EXAMPLE.COM  '
+  )->>'ok',
+  'true',
+  'invitee lookup normalizes email case and whitespace'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000002', true);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'fresh-invitee@example.com'
+  )->>'ok',
+  'true',
+  'team admin can resolve a fresh invitee'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000003', true);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'fresh-invitee@example.com'
+  )->>'code',
+  'FORBIDDEN',
+  'non-manager team members cannot use the invite lookup'
+);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'missing@example.com'
+  )->>'code',
+  'FORBIDDEN',
+  'unauthorized actors cannot learn whether an email exists'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000001', true);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'missing@example.com'
+  )->>'code',
+  'USER_NOT_FOUND',
+  'authorized team managers receive USER_NOT_FOUND for missing email'
+);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'other-member@example.com'
+  )->>'code',
+  'USER_ALREADY_IN_TEAM',
+  'authorized lookup reports users already active in another team'
+);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'other-invited@example.com'
+  )->>'code',
+  'USER_ALREADY_INVITED_TO_TEAM',
+  'authorized lookup reports users already invited to another team'
+);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'other-rejected@example.com'
+  )->>'ok',
+  'true',
+  'rejected membership in another team does not block a fresh invite'
+);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'same-invited@example.com'
+  )->>'code',
+  'TEAM_MEMBER_ALREADY_EXISTS',
+  'same-team pending invitations are reported as existing membership'
+);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    'same-rejected@example.com'
+  )->>'code',
+  'REINVITE_REQUIRED',
+  'same-team rejected members require the reinvite command'
+);
+
+select is(
+  public.qry_team_find_invitable_user_by_email(
+    '82000000-0000-0000-0000-000000000001',
+    '  '
+  )->>'code',
+  'INVALID_PAYLOAD',
+  'blank email is rejected as an invalid payload'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- add `qry_team_find_invitable_user_by_email` as a manager-gated SECURITY DEFINER RPC for team invite email lookup
- return controlled invite states for not found, same-team membership, other-team membership, and other-team pending invitations
- add PGTAP assertions for owner/admin access, forbidden non-managers, inviteable users, and blocking states

## Validation
- `git diff --check`
- Not run locally: `supabase db reset` / SQL assertion execution because this environment does not have `supabase` or `psql` installed

Closes #117
Refs tiangong-lca/workspace#190