### PR TITLE
fix: govern embedding cron jobs

### DIFF
--- a/supabase/migrations/20260528201145_govern_embedding_cron_jobs.sql
+++ b/supabase/migrations/20260528201145_govern_embedding_cron_jobs.sql
@@ -1,0 +1,29 @@
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    begin
+      perform cron.unschedule('process-webhook-jobs');
+    exception when others then
+      null;
+    end;
+
+    begin
+      perform cron.unschedule('process-embeddings');
+    exception when others then
+      null;
+    end;
+
+    perform cron.schedule(
+      'process-embeddings',
+      '10 seconds',
+      $cron$
+        select util.process_embeddings(
+          batch_size => 3,
+          max_requests => 3,
+          timeout_milliseconds => 300000
+        );
+      $cron$
+    );
+  end if;
+end
+$$;

--- a/supabase/tests/20260528_embedding_cron_governance.sql
+++ b/supabase/tests/20260528_embedding_cron_governance.sql
@@ -1,0 +1,66 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(6);
+
+select ok(
+  exists (select 1 from pg_extension where extname = 'pg_cron'),
+  'pg_cron extension is available for cron governance assertions'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job
+    where jobname = 'process-embeddings'
+  ),
+  1,
+  'process-embeddings is scheduled exactly once'
+);
+
+select is(
+  (
+    select schedule
+    from cron.job
+    where jobname = 'process-embeddings'
+  ),
+  '10 seconds',
+  'process-embeddings keeps the intended sub-minute schedule'
+);
+
+select is(
+  (
+    select active
+    from cron.job
+    where jobname = 'process-embeddings'
+  ),
+  true,
+  'process-embeddings is active'
+);
+
+select ok(
+  (
+    select command like '%util.process_embeddings(%'
+      and command like '%batch_size => 3%'
+      and command like '%max_requests => 3%'
+    from cron.job
+    where jobname = 'process-embeddings'
+  ),
+  'process-embeddings uses explicit conservative dispatcher arguments'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job
+    where jobname = 'process-webhook-jobs'
+  ),
+  0,
+  'legacy process-webhook-jobs cron is not scheduled'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#119

## Summary
- Add a migration that makes embedding cron behavior durable: process-embeddings is scheduled idempotently and legacy process-webhook-jobs is unscheduled.
- Add PGTAP coverage for the expected cron state.

## Key Decisions
- Keep process-embeddings because it is the active embedding queue dispatcher and persistent dev already had queued embedding jobs without a scheduler.
- Remove process-webhook-jobs from scheduled execution because the legacy webhook queue is not used by current migrations and was only production drift.

## Validation
- supabase db reset
- psql 'postgresql://postgres:postgres@127.0.0.1:55322/postgres' -X -v ON_ERROR_STOP=1 -f supabase/tests/20260528_embedding_cron_governance.sql
- supabase migration list --local
- supabase db advisors --local --fail-on error (completed with existing WARN-level findings only)
- Applied the same idempotent SQL to remote dev and main as operator remediation; verified process-webhook-jobs absent and process-embeddings active with explicit args.

## Risks / Rollback
- Low operational risk: migration only touches pg_cron schedules and is idempotent; process_embeddings already has backpressure limits from the existing migration history.
- Remote dev/main were remediated directly before this PR; the migration is still required so future branches converge to the same state.

## Follow-ups
- Separately track production webhook trigger wrapper drift and secret rotation; this PR only governs the cron jobs.
- Separately investigate the dataset_extraction_jobs backlog/failure table.

## Workspace Integration
- Requires workspace submodule pointer integration after database-engine dev/main promotion.