### PR TITLE
promote: embedding cron governance to main

### DIFF
--- a/supabase/migrations/20260528201145_govern_embedding_cron_jobs.sql
+++ b/supabase/migrations/20260528201145_govern_embedding_cron_jobs.sql
@@ -1,0 +1,29 @@
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    begin
+      perform cron.unschedule('process-webhook-jobs');
+    exception when others then
+      null;
+    end;
+
+    begin
+      perform cron.unschedule('process-embeddings');
+    exception when others then
+      null;
+    end;
+
+    perform cron.schedule(
+      'process-embeddings',
+      '10 seconds',
+      $cron$
+        select util.process_embeddings(
+          batch_size => 3,
+          max_requests => 3,
+          timeout_milliseconds => 300000
+        );
+      $cron$
+    );
+  end if;
+end
+$$;

--- a/supabase/tests/20260528_embedding_cron_governance.sql
+++ b/supabase/tests/20260528_embedding_cron_governance.sql
@@ -1,0 +1,66 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(6);
+
+select ok(
+  exists (select 1 from pg_extension where extname = 'pg_cron'),
+  'pg_cron extension is available for cron governance assertions'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job
+    where jobname = 'process-embeddings'
+  ),
+  1,
+  'process-embeddings is scheduled exactly once'
+);
+
+select is(
+  (
+    select schedule
+    from cron.job
+    where jobname = 'process-embeddings'
+  ),
+  '10 seconds',
+  'process-embeddings keeps the intended sub-minute schedule'
+);
+
+select is(
+  (
+    select active
+    from cron.job
+    where jobname = 'process-embeddings'
+  ),
+  true,
+  'process-embeddings is active'
+);
+
+select ok(
+  (
+    select command like '%util.process_embeddings(%'
+      and command like '%batch_size => 3%'
+      and command like '%max_requests => 3%'
+    from cron.job
+    where jobname = 'process-embeddings'
+  ),
+  'process-embeddings uses explicit conservative dispatcher arguments'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job
+    where jobname = 'process-webhook-jobs'
+  ),
+  0,
+  'legacy process-webhook-jobs cron is not scheduled'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#119

## Summary
- Promote the embedding cron governance migration from dev to main so production migration history converges with the manually remediated production cron state.
- The diff contains only the cron governance migration and its PGTAP assertion file from PR #120.

## Key Decisions
- Use the standard database-engine M2 promote path dev -> main instead of leaving production fixed only by operator SQL.

## Validation
- PR #120 merged into dev.
- Supabase Dev workflow succeeded for merge commit 561d2df93e0e7725ecc43b8fbf45f3534599082a.
- Persistent dev has migration 20260528201145 recorded, process-embeddings active, process-webhook-jobs absent, and pgmq.q_embedding_jobs drained to 0.

## Risks / Rollback
- Low risk: production cron state was already remediated with the same idempotent SQL; main promotion should record the migration and preserve the same schedule state.

## Follow-ups
- After this PR merges and production migration is verified, root lca-workspace may bump database-engine to the promoted main commit.

## Workspace Integration
- Required for root workspace integration eligibility; root main should only point at database-engine main for M2 repos.