### PR TITLE
fix: govern webhook hooks

### DIFF
--- a/supabase/migrations/20260528212000_govern_webhook_hooks.sql
+++ b/supabase/migrations/20260528212000_govern_webhook_hooks.sql
@@ -1,0 +1,93 @@
+-- Keep markdown extraction webhooks in migration-managed form and remove the
+-- retired webhook_jobs path that used to be driven by embedding_flag updates.
+
+drop trigger if exists flow_extract_md_trigger_update on public.flows;
+drop trigger if exists lifecyclemodel_extract_md_trigger_insert on public.lifecyclemodels;
+drop trigger if exists lifecyclemodel_extract_md_trigger_update on public.lifecyclemodels;
+drop trigger if exists process_extract_md_trigger_insert on public.processes;
+drop trigger if exists process_extract_md_trigger_update on public.processes;
+
+create trigger flow_extract_md_trigger_update
+after update of json on public.flows
+for each row
+when (new.json is distinct from old.json)
+execute function util.invoke_edge_webhook('webhook_flow_embedding_ft', '1000');
+
+create trigger lifecyclemodel_extract_md_trigger_insert
+after insert on public.lifecyclemodels
+for each row
+execute function util.invoke_edge_webhook('webhook_model_embedding_ft', '1000');
+
+create trigger lifecyclemodel_extract_md_trigger_update
+after update of json on public.lifecyclemodels
+for each row
+when (new.json is distinct from old.json)
+execute function util.invoke_edge_webhook('webhook_model_embedding_ft', '1000');
+
+create trigger process_extract_md_trigger_insert
+after insert on public.processes
+for each row
+execute function util.invoke_edge_webhook('webhook_process_embedding_ft', '1000');
+
+create trigger process_extract_md_trigger_update
+after update of json on public.processes
+for each row
+when (new.json is distinct from old.json)
+execute function util.invoke_edge_webhook('webhook_process_embedding_ft', '1000');
+
+-- Text extraction is now database-side extracted_text sync. Keep the old
+-- non-*_ft Edge webhook path explicitly removed.
+drop trigger if exists flow_extract_text_trigger_insert on public.flows;
+drop trigger if exists flow_extract_text_trigger_update on public.flows;
+drop trigger if exists process_extract_text_trigger_insert on public.processes;
+drop trigger if exists process_extract_text_trigger_update on public.processes;
+drop trigger if exists lifecyclemodels_extract_text_trigger_insert on public.lifecyclemodels;
+drop trigger if exists lifecyclemodels_extract_text_trigger_update on public.lifecyclemodels;
+
+-- The old embedding_flag path wrote to pgmq.webhook_jobs. The worker cron is
+-- retired, and markdown/embedding updates now use dataset_extraction_jobs and
+-- embedding_jobs instead.
+drop trigger if exists flow_extract_md_trigger_update_flag on public.flows;
+drop trigger if exists lifecyclemodel_extract_md_trigger_update_flag on public.lifecyclemodels;
+drop trigger if exists process_extract_md_trigger_update_flag on public.processes;
+
+drop function if exists util.queue_embedding_webhook();
+drop function if exists util.process_webhook_jobs(integer, integer, integer);
+
+do $$
+begin
+  if to_regclass('pgmq.q_webhook_jobs') is not null
+      or to_regclass('pgmq.a_webhook_jobs') is not null then
+    if to_regprocedure('pgmq.drop_queue(text)') is not null then
+      perform pgmq.drop_queue('webhook_jobs');
+    elsif to_regprocedure('pgmq.drop_queue(text, boolean)') is not null then
+      perform pgmq.drop_queue('webhook_jobs', true);
+    end if;
+  end if;
+end
+$$;
+
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    begin
+      perform cron.unschedule('process-dataset-extraction-jobs');
+    exception when others then
+      null;
+    end;
+
+    perform cron.schedule(
+      'process-dataset-extraction-jobs',
+      '10 seconds',
+      $cron$
+        select util.process_dataset_extraction_jobs(
+          batch_size => 5,
+          visibility_timeout_seconds => 300,
+          max_read_count => 5,
+          timeout_milliseconds => 300000
+        );
+      $cron$
+    );
+  end if;
+end
+$$;

--- a/supabase/tests/20260528_webhook_hook_governance.sql
+++ b/supabase/tests/20260528_webhook_hook_governance.sql
@@ -1,0 +1,197 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(16);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger t
+    join pg_proc p on p.oid = t.tgfoid
+    join pg_namespace n on n.oid = p.pronamespace
+    where not t.tgisinternal
+      and n.nspname = 'supabase_functions'
+      and p.proname = 'http_request'
+  ),
+  0,
+  'no active database webhook trigger uses Dashboard-managed supabase_functions.http_request'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where not tgisinternal
+      and pg_get_triggerdef(oid, true) like '%sb_secret_%'
+  ),
+  0,
+  'database webhook triggers do not embed Supabase secret keys'
+);
+
+select is(
+  (
+    with expected(table_name, trigger_name, edge_function_name) as (
+      values
+        ('flows', 'flow_extract_md_trigger_update', 'webhook_flow_embedding_ft'),
+        ('lifecyclemodels', 'lifecyclemodel_extract_md_trigger_insert', 'webhook_model_embedding_ft'),
+        ('lifecyclemodels', 'lifecyclemodel_extract_md_trigger_update', 'webhook_model_embedding_ft'),
+        ('processes', 'process_extract_md_trigger_insert', 'webhook_process_embedding_ft'),
+        ('processes', 'process_extract_md_trigger_update', 'webhook_process_embedding_ft')
+    )
+    select count(*)::integer
+    from expected e
+    join pg_class c on c.relname = e.table_name
+    join pg_namespace cn on cn.oid = c.relnamespace and cn.nspname = 'public'
+    join pg_trigger t on t.tgrelid = c.oid and t.tgname = e.trigger_name
+    join pg_proc p on p.oid = t.tgfoid
+    join pg_namespace pn on pn.oid = p.pronamespace
+    where not t.tgisinternal
+      and pn.nspname = 'util'
+      and p.proname = 'invoke_edge_webhook'
+      and pg_get_triggerdef(t.oid, true) like '%' || e.edge_function_name || '%'
+  ),
+  5,
+  'required markdown extraction webhooks are migration-managed util.invoke_edge_webhook triggers'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where not tgisinternal
+      and tgname = 'flow_extract_md_trigger_insert'
+  ),
+  0,
+  'flow inserts do not use the old full-row markdown webhook trigger'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_trigger t
+    join pg_proc p on p.oid = t.tgfoid
+    join pg_namespace pn on pn.oid = p.pronamespace
+    where t.tgrelid = 'public.flows'::regclass
+      and t.tgname = 'flow_dataset_extraction_trigger_insert'
+      and not t.tgisinternal
+      and pn.nspname = 'util'
+      and p.proname = 'queue_dataset_extraction_jobs'
+  ),
+  'flow inserts keep the compact dataset extraction queue trigger'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where not tgisinternal
+      and tgname in (
+        'flow_extract_text_trigger_insert',
+        'flow_extract_text_trigger_update',
+        'process_extract_text_trigger_insert',
+        'process_extract_text_trigger_update',
+        'lifecyclemodels_extract_text_trigger_insert',
+        'lifecyclemodels_extract_text_trigger_update'
+      )
+  ),
+  0,
+  'legacy text extraction Edge webhook triggers remain removed'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger
+    where not tgisinternal
+      and tgname in (
+        'flow_extract_md_trigger_update_flag',
+        'lifecyclemodel_extract_md_trigger_update_flag',
+        'process_extract_md_trigger_update_flag'
+      )
+  ),
+  0,
+  'embedding_flag no longer enqueues legacy webhook_jobs work'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger t
+    join pg_proc p on p.oid = t.tgfoid
+    join pg_namespace n on n.oid = p.pronamespace
+    where not t.tgisinternal
+      and n.nspname = 'util'
+      and p.proname = 'queue_embedding_webhook'
+  ),
+  0,
+  'no trigger references util.queue_embedding_webhook'
+);
+
+select ok(
+  to_regprocedure('util.queue_embedding_webhook()') is null,
+  'legacy util.queue_embedding_webhook function is removed'
+);
+
+select ok(
+  to_regprocedure('util.process_webhook_jobs(integer, integer, integer)') is null,
+  'legacy util.process_webhook_jobs function is removed'
+);
+
+select ok(
+  to_regclass('pgmq.q_webhook_jobs') is null
+    and to_regclass('pgmq.a_webhook_jobs') is null,
+  'legacy webhook_jobs queue tables are removed'
+);
+
+select ok(
+  exists (select 1 from pg_extension where extname = 'pg_cron'),
+  'pg_cron extension is available for dataset extraction cron governance assertions'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job
+    where jobname = 'process-dataset-extraction-jobs'
+  ),
+  1,
+  'process-dataset-extraction-jobs is scheduled exactly once'
+);
+
+select is(
+  (
+    select schedule
+    from cron.job
+    where jobname = 'process-dataset-extraction-jobs'
+  ),
+  '10 seconds',
+  'process-dataset-extraction-jobs uses the intended catch-up cadence'
+);
+
+select is(
+  (
+    select active
+    from cron.job
+    where jobname = 'process-dataset-extraction-jobs'
+  ),
+  true,
+  'process-dataset-extraction-jobs is active'
+);
+
+select ok(
+  (
+    select command like '%batch_size => 5%'
+      and command like '%visibility_timeout_seconds => 300%'
+      and command like '%max_read_count => 5%'
+      and command like '%timeout_milliseconds => 300000%'
+    from cron.job
+    where jobname = 'process-dataset-extraction-jobs'
+  ),
+  'process-dataset-extraction-jobs uses explicit conservative worker arguments'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#122

## Summary
- Recreate required markdown extraction database hooks through migration-managed util.invoke_edge_webhook.
- Remove legacy embedding_flag webhook queue triggers, obsolete webhook_jobs functions, and stale webhook_jobs queue tables.
- Reschedule dataset extraction worker cron to a 10-second conservative catch-up cadence with explicit arguments.

## Key Decisions
- Keep flow inserts on the compact dataset_extraction_jobs path; only flow json updates and process/lifecyclemodel insert/update paths retain markdown extraction webhooks.
- Do not restore legacy non-*_ft text extraction webhooks because extracted_text is database-side.

## Validation
- supabase db reset
- psql -f supabase/tests/20260528_webhook_hook_governance.sql
- psql -f supabase/tests/20260528_embedding_cron_governance.sql
- psql -f supabase/tests/20260526_dataset_extraction_jobs.sql
- supabase db advisors --local --fail-on error (exited 0; only pre-existing WARN findings)
- Operator-applied SQL to persistent dev and production main; both now show 0 Dashboard http_request triggers, 5 util.invoke_edge_webhook md hooks, no update_flag triggers, no q_webhook_jobs, and 10-second dataset extraction cron.
- Production dataset queue observed draining after remediation: 5913 -> 5888 pending jobs over about 35 seconds; latest worker response HTTP 200 with claimed=5 and acked=5.

## Risks / Rollback
- Low schema risk: migration drops only retired webhook queue objects and recreates already-required markdown hooks in the repo-managed form. Rollback is to restore the prior trigger definitions and previous dataset cron schedule.

## Follow-ups
- After this merges to dev, promote database-engine dev to main and then update the lca-workspace submodule pointer.

## Workspace Integration
- Workspace integration remains pending until the promoted database-engine main commit is pinned in lca-workspace.