### PR TITLE
fix: pin function search paths

### DIFF
--- a/supabase/migrations/20260528213000_pin_function_search_paths.sql
+++ b/supabase/migrations/20260528213000_pin_function_search_paths.sql
@@ -1,0 +1,19 @@
+-- Pin search_path for the remaining functions flagged by the Supabase
+-- function_search_path_mutable advisor. The function bodies already qualify
+-- non-catalog references, so an empty path preserves behavior while removing
+-- caller-dependent name resolution.
+
+alter function public.update_modified_at()
+  set search_path to '';
+
+alter function util.dataset_json_search_text(jsonb)
+  set search_path to '';
+
+alter function util.dataset_json_search_text(text, jsonb)
+  set search_path to '';
+
+alter function util.dataset_json_search_text_allowed_prefixes(text)
+  set search_path to '';
+
+alter function util.dataset_json_search_text_is_noise(text, text)
+  set search_path to '';

--- a/supabase/tests/20260528_function_search_path_governance.sql
+++ b/supabase/tests/20260528_function_search_path_governance.sql
@@ -1,0 +1,49 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create or replace function pg_temp.has_empty_search_path(p_signature text)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from pg_proc p
+    cross join lateral unnest(coalesce(p.proconfig, array[]::text[])) as config(setting)
+    where p.oid = p_signature::regprocedure
+      and config.setting in ('search_path=', 'search_path=""')
+  );
+$$;
+
+select plan(5);
+
+select ok(
+  pg_temp.has_empty_search_path('public.update_modified_at()'),
+  'public.update_modified_at() pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.dataset_json_search_text(jsonb)'),
+  'util.dataset_json_search_text(jsonb) pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.dataset_json_search_text(text,jsonb)'),
+  'util.dataset_json_search_text(text,jsonb) pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.dataset_json_search_text_allowed_prefixes(text)'),
+  'util.dataset_json_search_text_allowed_prefixes(text) pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.dataset_json_search_text_is_noise(text,text)'),
+  'util.dataset_json_search_text_is_noise(text,text) pins an empty search_path'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#125

## Summary
- Pin empty search_path settings on the five functions still flagged by the Supabase function_search_path_mutable advisor.
- Add a pgTAP governance test that asserts the expected function-level search_path settings.

## Key Decisions
- Use ALTER FUNCTION SET search_path instead of recreating function bodies so behavior, owners, comments, and grants remain unchanged.
- Use an empty search_path because the affected function bodies already qualify non-catalog references and only need pg_catalog built-ins.

## Validation
- supabase db reset
- psql "" -v ON_ERROR_STOP=1 -f supabase/tests/20260528_function_search_path_governance.sql
- psql "" -v ON_ERROR_STOP=1 -f supabase/tests/20260527_dataset_extracted_text_contract.sql
- supabase db advisors --local --output json: function_search_path_mutable count is 0; remaining WARN are the RLS items tracked by #126
- supabase db advisors --local --fail-on error

## Risks / Rollback
- Low risk: the migration only sets function configuration and does not rewrite function bodies or policy logic.

## Follow-ups
- Handle auth_rls_initplan and multiple_permissive_policies in #126.

## Workspace Integration
- After this lands in database-engine dev and is promoted to main, lca-workspace must bump the database-engine submodule pointer to the promoted main commit.