### PR TITLE
promote: function search path governance to main

### DIFF
--- a/supabase/migrations/20260528213000_pin_function_search_paths.sql
+++ b/supabase/migrations/20260528213000_pin_function_search_paths.sql
@@ -1,0 +1,19 @@
+-- Pin search_path for the remaining functions flagged by the Supabase
+-- function_search_path_mutable advisor. The function bodies already qualify
+-- non-catalog references, so an empty path preserves behavior while removing
+-- caller-dependent name resolution.
+
+alter function public.update_modified_at()
+  set search_path to '';
+
+alter function util.dataset_json_search_text(jsonb)
+  set search_path to '';
+
+alter function util.dataset_json_search_text(text, jsonb)
+  set search_path to '';
+
+alter function util.dataset_json_search_text_allowed_prefixes(text)
+  set search_path to '';
+
+alter function util.dataset_json_search_text_is_noise(text, text)
+  set search_path to '';

--- a/supabase/tests/20260528_function_search_path_governance.sql
+++ b/supabase/tests/20260528_function_search_path_governance.sql
@@ -1,0 +1,49 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create or replace function pg_temp.has_empty_search_path(p_signature text)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from pg_proc p
+    cross join lateral unnest(coalesce(p.proconfig, array[]::text[])) as config(setting)
+    where p.oid = p_signature::regprocedure
+      and config.setting in ('search_path=', 'search_path=""')
+  );
+$$;
+
+select plan(5);
+
+select ok(
+  pg_temp.has_empty_search_path('public.update_modified_at()'),
+  'public.update_modified_at() pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.dataset_json_search_text(jsonb)'),
+  'util.dataset_json_search_text(jsonb) pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.dataset_json_search_text(text,jsonb)'),
+  'util.dataset_json_search_text(text,jsonb) pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.dataset_json_search_text_allowed_prefixes(text)'),
+  'util.dataset_json_search_text_allowed_prefixes(text) pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.dataset_json_search_text_is_noise(text,text)'),
+  'util.dataset_json_search_text_is_noise(text,text) pins an empty search_path'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#125

## Summary
- Promote the function search_path advisor cleanup from dev to main.
- Carries migration 20260528213000 and its pgTAP governance assertion into the production migration line.

## Key Decisions
- Promote only after local validation and persistent dev db push both showed function_search_path_mutable at 0.

## Validation
- dev PR #127 merged into dev.
- Supabase Dev workflow rerun passed after an initial Supabase API 502 during link.
- Persistent dev schema_migrations contains 20260528213000.
- Persistent dev advisors: function_search_path_mutable count is 0; remaining WARN are the RLS items tracked by #126.

## Risks / Rollback
- Low risk: this promotes only function configuration changes already validated on local and persistent dev.

## Follow-ups
- After merge, confirm production main migration state and advisor grouping.

## Workspace Integration
- After this promote PR merges, lca-workspace must bump database-engine to the promoted main commit.