### PR TITLE
promote: RLS advisor cleanup to main

### DIFF
--- a/supabase/migrations/20260528214000_optimize_rls_advisor_policies.sql
+++ b/supabase/migrations/20260528214000_optimize_rls_advisor_policies.sql
@@ -1,0 +1,227 @@
+-- Normalize RLS policies flagged by Supabase Performance Advisor.
+--
+-- This migration preserves the existing authorization semantics while:
+-- - wrapping row-independent auth.uid() calls as (select auth.uid())
+-- - merging duplicate permissive comments UPDATE policies
+-- - removing production-only teams helper-function drift in favor of the
+--   checked-in inline policy definitions.
+
+drop policy if exists "comments select by review participants" on public.comments;
+create policy "comments select by review participants"
+on public.comments
+for select
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and public.policy_review_can_read(review_id, (select auth.uid()))
+  and (
+    public.cmd_review_is_review_admin((select auth.uid()))
+    or exists (
+      select 1
+      from public.reviews r
+      where r.id = comments.review_id
+        and (((r.json -> 'user'::text) ->> 'id'::text)::uuid = (select auth.uid()))
+    )
+    or reviewer_id = (select auth.uid())
+  )
+);
+
+drop policy if exists "comments update by review-admin" on public.comments;
+drop policy if exists "comments update by reviewer self" on public.comments;
+drop policy if exists "comments update by reviewer or review-admin" on public.comments;
+create policy "comments update by reviewer or review-admin"
+on public.comments
+for update
+to authenticated
+using (
+  public.policy_is_current_user_in_roles(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    array['review-admin'::text]
+  )
+  or reviewer_id = (select auth.uid())
+)
+with check (
+  public.policy_is_current_user_in_roles(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    array['review-admin'::text]
+  )
+  or reviewer_id = (select auth.uid())
+);
+
+do $$
+declare
+  dataset_table text;
+begin
+  foreach dataset_table in array array[
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes',
+    'lifecyclemodels'
+  ]
+  loop
+    execute format(
+      'drop policy if exists transitional_update_owner_draft_only on public.%I',
+      dataset_table
+    );
+    execute format(
+      $policy$
+      create policy transitional_update_owner_draft_only
+      on public.%I
+      for update
+      to authenticated
+      using ((state_code = 0) and (user_id = (select auth.uid())))
+      with check ((state_code = 0) and (user_id = (select auth.uid())))
+      $policy$,
+      dataset_table
+    );
+  end loop;
+end
+$$;
+
+drop policy if exists lca_package_artifacts_select_own on public.lca_package_artifacts;
+create policy lca_package_artifacts_select_own
+on public.lca_package_artifacts
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.lca_package_jobs j
+    where j.id = lca_package_artifacts.job_id
+      and j.requested_by = (select auth.uid())
+  )
+);
+
+drop policy if exists lca_package_jobs_select_own on public.lca_package_jobs;
+create policy lca_package_jobs_select_own
+on public.lca_package_jobs
+for select
+to authenticated
+using (requested_by = (select auth.uid()));
+
+drop policy if exists lca_package_request_cache_select_own on public.lca_package_request_cache;
+create policy lca_package_request_cache_select_own
+on public.lca_package_request_cache
+for select
+to authenticated
+using (requested_by = (select auth.uid()));
+
+drop policy if exists notifications_insert_sender on public.notifications;
+create policy notifications_insert_sender
+on public.notifications
+for insert
+to authenticated
+with check ((select auth.uid()) = sender_user_id);
+
+drop policy if exists notifications_select_sender_or_recipient on public.notifications;
+create policy notifications_select_sender_or_recipient
+on public.notifications
+for select
+to authenticated
+using (
+  (select auth.uid()) = sender_user_id
+  or (select auth.uid()) = recipient_user_id
+);
+
+drop policy if exists notifications_update_sender on public.notifications;
+create policy notifications_update_sender
+on public.notifications
+for update
+to authenticated
+using ((select auth.uid()) = sender_user_id)
+with check ((select auth.uid()) = sender_user_id);
+
+drop policy if exists notifications_delete_recipient_only on public.notifications;
+create policy notifications_delete_recipient_only
+on public.notifications
+for delete
+to authenticated
+using ((select auth.uid()) = recipient_user_id);
+
+drop policy if exists "reviews select by review participants" on public.reviews;
+create policy "reviews select by review participants"
+on public.reviews
+for select
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and public.policy_review_can_read(id, (select auth.uid()))
+);
+
+drop policy if exists transitional_reviews_update_submitter_only on public.reviews;
+create policy transitional_reviews_update_submitter_only
+on public.reviews
+for update
+to authenticated
+using (
+  (select auth.uid()) is not null
+  and (((json -> 'user'::text) ->> 'id'::text)::uuid = (select auth.uid()))
+)
+with check (
+  (select auth.uid()) is not null
+  and (((json -> 'user'::text) ->> 'id'::text)::uuid = (select auth.uid()))
+);
+
+drop policy if exists "insert by authenticated" on public.teams;
+drop policy if exists "select by owner or public teams" on public.teams;
+drop policy if exists "update by owner and admin" on public.teams;
+
+create policy "insert by authenticated"
+on public.teams
+for insert
+to authenticated
+with check (
+  (
+    select count(1)
+    from public.roles
+    where roles.user_id = (select auth.uid())
+      and roles.role <> 'rejected'::text
+      and roles.team_id <> '00000000-0000-0000-0000-000000000000'::uuid
+  ) = 0
+);
+
+create policy "select by owner or public teams"
+on public.teams
+for select
+to authenticated
+using (
+  is_public
+  or rank > 0
+  or exists (
+    select 1
+    from public.roles
+    where (roles.team_id = teams.id or roles.team_id = '00000000-0000-0000-0000-000000000000'::uuid)
+      and roles.user_id = (select auth.uid())
+      and roles.role <> 'rejected'::text
+  )
+);
+
+create policy "update by owner and admin"
+on public.teams
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.roles r
+    where r.user_id = (select auth.uid())
+      and r.team_id = teams.id
+      and r.role::text = any (array['owner'::text, 'admin'::text])
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.roles r
+    where r.user_id = (select auth.uid())
+      and r.team_id = teams.id
+      and r.role::text = any (array['owner'::text, 'admin'::text])
+  )
+);
+
+drop function if exists public.policy_teams_insert();
+drop function if exists public.policy_teams_select(uuid, integer, boolean);
+drop function if exists public.policy_teams_update(uuid);

--- a/supabase/tests/20260528_rls_advisor_policy_governance.sql
+++ b/supabase/tests/20260528_rls_advisor_policy_governance.sql
@@ -1,0 +1,160 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(7);
+
+with affected(table_name, policy_name) as (
+  values
+    ('comments', 'comments select by review participants'),
+    ('comments', 'comments update by reviewer or review-admin'),
+    ('contacts', 'transitional_update_owner_draft_only'),
+    ('sources', 'transitional_update_owner_draft_only'),
+    ('unitgroups', 'transitional_update_owner_draft_only'),
+    ('flowproperties', 'transitional_update_owner_draft_only'),
+    ('flows', 'transitional_update_owner_draft_only'),
+    ('processes', 'transitional_update_owner_draft_only'),
+    ('lifecyclemodels', 'transitional_update_owner_draft_only'),
+    ('lca_package_artifacts', 'lca_package_artifacts_select_own'),
+    ('lca_package_jobs', 'lca_package_jobs_select_own'),
+    ('lca_package_request_cache', 'lca_package_request_cache_select_own'),
+    ('notifications', 'notifications_insert_sender'),
+    ('notifications', 'notifications_select_sender_or_recipient'),
+    ('notifications', 'notifications_update_sender'),
+    ('notifications', 'notifications_delete_recipient_only'),
+    ('reviews', 'reviews select by review participants'),
+    ('reviews', 'transitional_reviews_update_submitter_only'),
+    ('teams', 'update by owner and admin')
+)
+select is(
+  (
+    select count(*)::integer
+    from affected a
+    join pg_class c on c.relname = a.table_name
+    join pg_namespace n on n.oid = c.relnamespace and n.nspname = 'public'
+    join pg_policy p on p.polrelid = c.oid and p.polname = a.policy_name
+  ),
+  19,
+  'all advisor-targeted RLS policies exist after rewrite'
+);
+
+with affected(table_name, policy_name) as (
+  values
+    ('comments', 'comments select by review participants'),
+    ('comments', 'comments update by reviewer or review-admin'),
+    ('contacts', 'transitional_update_owner_draft_only'),
+    ('sources', 'transitional_update_owner_draft_only'),
+    ('unitgroups', 'transitional_update_owner_draft_only'),
+    ('flowproperties', 'transitional_update_owner_draft_only'),
+    ('flows', 'transitional_update_owner_draft_only'),
+    ('processes', 'transitional_update_owner_draft_only'),
+    ('lifecyclemodels', 'transitional_update_owner_draft_only'),
+    ('lca_package_artifacts', 'lca_package_artifacts_select_own'),
+    ('lca_package_jobs', 'lca_package_jobs_select_own'),
+    ('lca_package_request_cache', 'lca_package_request_cache_select_own'),
+    ('notifications', 'notifications_insert_sender'),
+    ('notifications', 'notifications_select_sender_or_recipient'),
+    ('notifications', 'notifications_update_sender'),
+    ('notifications', 'notifications_delete_recipient_only'),
+    ('reviews', 'reviews select by review participants'),
+    ('reviews', 'transitional_reviews_update_submitter_only'),
+    ('teams', 'update by owner and admin')
+),
+policy_exprs as (
+  select
+    replace(
+      coalesce(pg_get_expr(p.polqual, p.polrelid), '')
+      || ' '
+      || coalesce(pg_get_expr(p.polwithcheck, p.polrelid), ''),
+      '( SELECT auth.uid() AS uid)',
+      ''
+    ) as stripped_expr
+  from affected a
+  join pg_class c on c.relname = a.table_name
+  join pg_namespace n on n.oid = c.relnamespace and n.nspname = 'public'
+  join pg_policy p on p.polrelid = c.oid and p.polname = a.policy_name
+)
+select is(
+  (
+    select count(*)::integer
+    from policy_exprs
+    where stripped_expr like '%auth.uid()%'
+  ),
+  0,
+  'advisor-targeted policies wrap auth.uid() as select initplans'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_policy p
+    join pg_class c on c.oid = p.polrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    join pg_roles r on r.oid = any (p.polroles)
+    where n.nspname = 'public'
+      and c.relname = 'comments'
+      and p.polpermissive
+      and p.polcmd = 'w'
+      and r.rolname = 'authenticated'
+  ),
+  1,
+  'comments has one permissive authenticated UPDATE policy'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_policy p
+    join pg_class c on c.oid = p.polrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = 'comments'
+      and p.polname in ('comments update by review-admin', 'comments update by reviewer self')
+  ),
+  0,
+  'old split comments UPDATE policies are removed'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_policy p
+    join pg_class c on c.oid = p.polrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = 'teams'
+      and p.polname in ('insert by authenticated', 'select by owner or public teams', 'update by owner and admin')
+  ),
+  3,
+  'teams keeps the three migration-managed policies'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_policy p
+    join pg_class c on c.oid = p.polrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = 'teams'
+      and (
+        coalesce(pg_get_expr(p.polqual, p.polrelid), '')
+        || ' '
+        || coalesce(pg_get_expr(p.polwithcheck, p.polrelid), '')
+      ) like '%policy_teams_%'
+  ),
+  0,
+  'teams policies do not reference production-only policy_teams helper drift'
+);
+
+select ok(
+  to_regprocedure('public.policy_teams_insert()') is null
+  and to_regprocedure('public.policy_teams_select(uuid,integer,boolean)') is null
+  and to_regprocedure('public.policy_teams_update(uuid)') is null,
+  'production-only policy_teams helper functions are absent'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#126

## Summary
- Promote the RLS advisor cleanup from dev to main.
- Carries migration 20260528214000 and pgTAP governance coverage into the production migration line.

## Key Decisions
- Promote after local and persistent dev advisors both returned no issues.

## Validation
- dev PR #129 merged into dev.
- Supabase Dev workflow passed.
- Persistent dev schema_migrations contains 20260528214000.
- Persistent dev advisors: No issues found.

## Risks / Rollback
- Medium risk: RLS policy rewrites are already covered by local access-control regression tests and persistent dev advisor validation.

## Follow-ups
- After merge, confirm production main migration state and advisors.

## Workspace Integration
- After this promote PR merges, lca-workspace must bump database-engine to the promoted main commit.