### PR TITLE
feat: add dataset JSON UUID mention search

### DIFF
--- a/supabase/migrations/20260529120000_dataset_json_uuid_deep_search.sql
+++ b/supabase/migrations/20260529120000_dataset_json_uuid_deep_search.sql
@@ -1,0 +1,450 @@
+-- Add a deliberately bounded, low-frequency UUID deep search path. This is
+-- separate from search_*_latest: exact UUID search still returns the object
+-- itself, while this RPC finds visible latest dataset rows whose JSON contains
+-- the UUID text.
+
+create or replace function private.dataset_json_first_text(p_value jsonb)
+returns text
+language sql
+immutable
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+  select nullif(
+    btrim(
+      case
+        when p_value is null or p_value = 'null'::jsonb then null
+        when jsonb_typeof(p_value) = 'string' then p_value #>> '{}'
+        when jsonb_typeof(p_value) = 'object' then p_value ->> '#text'
+        when jsonb_typeof(p_value) = 'array' then (
+          select coalesce(item ->> '#text', item #>> '{}')
+          from jsonb_array_elements(p_value) as value(item)
+          where nullif(btrim(coalesce(item ->> '#text', item #>> '{}')), '') is not null
+          limit 1
+        )
+        else null
+      end
+    ),
+    ''
+  );
+$$;
+
+create or replace function private.dataset_json_display_name(
+  p_entity_kind text,
+  p_json jsonb
+) returns text
+language sql
+immutable
+set search_path to 'public', 'extensions', 'pg_temp'
+as $$
+  select coalesce(
+    case p_entity_kind
+      when 'flow' then coalesce(
+        private.dataset_json_first_text(p_json #> '{flowDataSet,flowInformation,dataSetInformation,name,baseName}'),
+        private.dataset_json_first_text(p_json #> '{flowDataSet,flowInformation,dataSetInformation,common:name}')
+      )
+      when 'process' then coalesce(
+        private.dataset_json_first_text(p_json #> '{processDataSet,processInformation,dataSetInformation,name,baseName}'),
+        private.dataset_json_first_text(p_json #> '{processDataSet,processInformation,dataSetInformation,common:name}')
+      )
+      when 'lifecyclemodel' then coalesce(
+        private.dataset_json_first_text(p_json #> '{lifeCycleModelDataSet,lifeCycleModelInformation,dataSetInformation,name,baseName}'),
+        private.dataset_json_first_text(p_json #> '{lifeCycleModelDataSet,lifeCycleModelInformation,dataSetInformation,common:name}')
+      )
+      when 'source' then coalesce(
+        private.dataset_json_first_text(p_json #> '{sourceDataSet,sourceInformation,dataSetInformation,common:shortName}'),
+        private.dataset_json_first_text(p_json #> '{sourceDataSet,sourceInformation,dataSetInformation,common:name}')
+      )
+      when 'contact' then coalesce(
+        private.dataset_json_first_text(p_json #> '{contactDataSet,contactInformation,dataSetInformation,common:shortName}'),
+        private.dataset_json_first_text(p_json #> '{contactDataSet,contactInformation,dataSetInformation,common:name}')
+      )
+      when 'unitgroup' then private.dataset_json_first_text(
+        p_json #> '{unitGroupDataSet,unitGroupInformation,dataSetInformation,common:name}'
+      )
+      when 'flowproperty' then private.dataset_json_first_text(
+        p_json #> '{flowPropertyDataSet,flowPropertiesInformation,dataSetInformation,common:name}'
+      )
+      else null
+    end,
+    nullif(btrim(p_json ->> 'name'), ''),
+    nullif(btrim(p_json ->> 'title'), '')
+  );
+$$;
+
+create or replace function private.search_dataset_json_uuid_mentions_impl(
+  p_uuid uuid,
+  p_source_entity_kinds text[] default null::text[],
+  p_data_source text default 'tg'::text,
+  p_this_user_id text default ''::text,
+  p_team_id_filter uuid default null::uuid,
+  p_state_code_filter integer default null::integer,
+  p_limit integer default 20
+) returns table(
+  rank bigint,
+  source_entity_kind text,
+  source_id uuid,
+  source_version character(9),
+  source_name text,
+  source_modified_at timestamp with time zone,
+  source_team_id uuid,
+  source_json jsonb,
+  matched_by text,
+  matched_entity_table text
+)
+language plpgsql
+security definer
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '8s'
+as $$
+declare
+  normalized_data_source text;
+  effective_user_id uuid;
+  can_read_team_filter boolean;
+  normalized_limit integer;
+  per_entity_limit integer;
+  uuid_pattern text;
+  normalized_source_entity_kinds text[];
+  branches text[] := array[]::text[];
+  v_sql text;
+begin
+  normalized_data_source := coalesce(nullif(lower(btrim(p_data_source)), ''), 'tg');
+  effective_user_id := private.dataset_search_effective_user_id(p_this_user_id);
+  can_read_team_filter := private.dataset_search_can_read_team_filter(p_team_id_filter, effective_user_id);
+  normalized_limit := least(greatest(coalesce(p_limit, 20), 1), 50);
+  per_entity_limit := normalized_limit;
+  uuid_pattern := '%' || p_uuid::text || '%';
+
+  if p_source_entity_kinds is not null then
+    select array_agg(distinct normalized_kind order by normalized_kind)
+    into normalized_source_entity_kinds
+    from (
+      select case lower(btrim(kind))
+        when 'flow' then 'flow'
+        when 'flows' then 'flow'
+        when 'process' then 'process'
+        when 'processes' then 'process'
+        when 'lifecyclemodel' then 'lifecyclemodel'
+        when 'lifecyclemodels' then 'lifecyclemodel'
+        when 'model' then 'lifecyclemodel'
+        when 'models' then 'lifecyclemodel'
+        when 'source' then 'source'
+        when 'sources' then 'source'
+        when 'contact' then 'contact'
+        when 'contacts' then 'contact'
+        when 'unitgroup' then 'unitgroup'
+        when 'unitgroups' then 'unitgroup'
+        when 'flowproperty' then 'flowproperty'
+        when 'flowproperties' then 'flowproperty'
+        else null
+      end as normalized_kind
+      from unnest(p_source_entity_kinds) as requested(kind)
+    ) normalized
+    where normalized_kind is not null;
+
+    if coalesce(array_length(normalized_source_entity_kinds, 1), 0) = 0 then
+      return;
+    end if;
+  end if;
+
+  if normalized_source_entity_kinds is null or 'process' = any(normalized_source_entity_kinds) then
+    branches := branches || array[$branch$
+      (select *
+      from (
+        select distinct on (d.id)
+          10::integer as entity_rank,
+          'process'::text as source_entity_kind,
+          d.id as source_id,
+          d.version as source_version,
+          private.dataset_json_display_name('process', d.json) as source_name,
+          d.modified_at as source_modified_at,
+          d.team_id as source_team_id,
+          d.json as source_json,
+          'json_uuid_scan'::text as matched_by,
+          'public.processes'::text as matched_entity_table
+        from public.processes d
+        where (
+            ($1 = 'tg' and d.state_code = 100 and ($3 is null or d.team_id = $3))
+            or ($1 = 'co' and d.state_code = 200 and ($3 is null or d.team_id = $3))
+            or ($1 = 'my' and $2 is not null and d.user_id = $2 and ($4 is null or d.state_code = $4))
+            or ($1 = 'te' and $3 is not null and $5 and d.team_id = $3 and ($4 is null or d.state_code = $4))
+          )
+        order by d.id, d.version desc, d.modified_at desc
+      ) latest
+      where latest.source_json::text like $6
+      order by latest.source_modified_at desc nulls last, latest.source_id
+      limit $8
+      )
+    $branch$];
+  end if;
+
+  if normalized_source_entity_kinds is null or 'flow' = any(normalized_source_entity_kinds) then
+    branches := branches || array[$branch$
+      (select *
+      from (
+        select distinct on (d.id)
+          20::integer as entity_rank,
+          'flow'::text as source_entity_kind,
+          d.id as source_id,
+          d.version as source_version,
+          private.dataset_json_display_name('flow', d.json) as source_name,
+          d.modified_at as source_modified_at,
+          d.team_id as source_team_id,
+          d.json as source_json,
+          'json_uuid_scan'::text as matched_by,
+          'public.flows'::text as matched_entity_table
+        from public.flows d
+        where (
+            ($1 = 'tg' and d.state_code = 100 and ($3 is null or d.team_id = $3))
+            or ($1 = 'co' and d.state_code = 200 and ($3 is null or d.team_id = $3))
+            or ($1 = 'my' and $2 is not null and d.user_id = $2 and ($4 is null or d.state_code = $4))
+            or ($1 = 'te' and $3 is not null and $5 and d.team_id = $3 and ($4 is null or d.state_code = $4))
+          )
+        order by d.id, d.version desc, d.modified_at desc
+      ) latest
+      where latest.source_json::text like $6
+      order by latest.source_modified_at desc nulls last, latest.source_id
+      limit $8
+      )
+    $branch$];
+  end if;
+
+  if normalized_source_entity_kinds is null or 'lifecyclemodel' = any(normalized_source_entity_kinds) then
+    branches := branches || array[$branch$
+      (select *
+      from (
+        select distinct on (d.id)
+          30::integer as entity_rank,
+          'lifecyclemodel'::text as source_entity_kind,
+          d.id as source_id,
+          d.version as source_version,
+          private.dataset_json_display_name('lifecyclemodel', d.json) as source_name,
+          d.modified_at as source_modified_at,
+          d.team_id as source_team_id,
+          d.json as source_json,
+          'json_uuid_scan'::text as matched_by,
+          'public.lifecyclemodels'::text as matched_entity_table
+        from public.lifecyclemodels d
+        where (
+            ($1 = 'tg' and d.state_code = 100 and ($3 is null or d.team_id = $3))
+            or ($1 = 'co' and d.state_code = 200 and ($3 is null or d.team_id = $3))
+            or ($1 = 'my' and $2 is not null and d.user_id = $2 and ($4 is null or d.state_code = $4))
+            or ($1 = 'te' and $3 is not null and $5 and d.team_id = $3 and ($4 is null or d.state_code = $4))
+          )
+        order by d.id, d.version desc, d.modified_at desc
+      ) latest
+      where latest.source_json::text like $6
+      order by latest.source_modified_at desc nulls last, latest.source_id
+      limit $8
+      )
+    $branch$];
+  end if;
+
+  if normalized_source_entity_kinds is null or 'source' = any(normalized_source_entity_kinds) then
+    branches := branches || array[$branch$
+      (select *
+      from (
+        select distinct on (d.id)
+          40::integer as entity_rank,
+          'source'::text as source_entity_kind,
+          d.id as source_id,
+          d.version as source_version,
+          private.dataset_json_display_name('source', d.json) as source_name,
+          d.modified_at as source_modified_at,
+          d.team_id as source_team_id,
+          d.json as source_json,
+          'json_uuid_scan'::text as matched_by,
+          'public.sources'::text as matched_entity_table
+        from public.sources d
+        where (
+            ($1 = 'tg' and d.state_code = 100 and ($3 is null or d.team_id = $3))
+            or ($1 = 'co' and d.state_code = 200 and ($3 is null or d.team_id = $3))
+            or ($1 = 'my' and $2 is not null and d.user_id = $2 and ($4 is null or d.state_code = $4))
+            or ($1 = 'te' and $3 is not null and $5 and d.team_id = $3 and ($4 is null or d.state_code = $4))
+          )
+        order by d.id, d.version desc, d.modified_at desc
+      ) latest
+      where latest.source_json::text like $6
+      order by latest.source_modified_at desc nulls last, latest.source_id
+      limit $8
+      )
+    $branch$];
+  end if;
+
+  if normalized_source_entity_kinds is null or 'contact' = any(normalized_source_entity_kinds) then
+    branches := branches || array[$branch$
+      (select *
+      from (
+        select distinct on (d.id)
+          50::integer as entity_rank,
+          'contact'::text as source_entity_kind,
+          d.id as source_id,
+          d.version as source_version,
+          private.dataset_json_display_name('contact', d.json) as source_name,
+          d.modified_at as source_modified_at,
+          d.team_id as source_team_id,
+          d.json as source_json,
+          'json_uuid_scan'::text as matched_by,
+          'public.contacts'::text as matched_entity_table
+        from public.contacts d
+        where (
+            ($1 = 'tg' and d.state_code = 100 and ($3 is null or d.team_id = $3))
+            or ($1 = 'co' and d.state_code = 200 and ($3 is null or d.team_id = $3))
+            or ($1 = 'my' and $2 is not null and d.user_id = $2 and ($4 is null or d.state_code = $4))
+            or ($1 = 'te' and $3 is not null and $5 and d.team_id = $3 and ($4 is null or d.state_code = $4))
+          )
+        order by d.id, d.version desc, d.modified_at desc
+      ) latest
+      where latest.source_json::text like $6
+      order by latest.source_modified_at desc nulls last, latest.source_id
+      limit $8
+      )
+    $branch$];
+  end if;
+
+  if normalized_source_entity_kinds is null or 'unitgroup' = any(normalized_source_entity_kinds) then
+    branches := branches || array[$branch$
+      (select *
+      from (
+        select distinct on (d.id)
+          60::integer as entity_rank,
+          'unitgroup'::text as source_entity_kind,
+          d.id as source_id,
+          d.version as source_version,
+          private.dataset_json_display_name('unitgroup', d.json) as source_name,
+          d.modified_at as source_modified_at,
+          d.team_id as source_team_id,
+          d.json as source_json,
+          'json_uuid_scan'::text as matched_by,
+          'public.unitgroups'::text as matched_entity_table
+        from public.unitgroups d
+        where (
+            ($1 = 'tg' and d.state_code = 100 and ($3 is null or d.team_id = $3))
+            or ($1 = 'co' and d.state_code = 200 and ($3 is null or d.team_id = $3))
+            or ($1 = 'my' and $2 is not null and d.user_id = $2 and ($4 is null or d.state_code = $4))
+            or ($1 = 'te' and $3 is not null and $5 and d.team_id = $3 and ($4 is null or d.state_code = $4))
+          )
+        order by d.id, d.version desc, d.modified_at desc
+      ) latest
+      where latest.source_json::text like $6
+      order by latest.source_modified_at desc nulls last, latest.source_id
+      limit $8
+      )
+    $branch$];
+  end if;
+
+  if normalized_source_entity_kinds is null or 'flowproperty' = any(normalized_source_entity_kinds) then
+    branches := branches || array[$branch$
+      (select *
+      from (
+        select distinct on (d.id)
+          70::integer as entity_rank,
+          'flowproperty'::text as source_entity_kind,
+          d.id as source_id,
+          d.version as source_version,
+          private.dataset_json_display_name('flowproperty', d.json) as source_name,
+          d.modified_at as source_modified_at,
+          d.team_id as source_team_id,
+          d.json as source_json,
+          'json_uuid_scan'::text as matched_by,
+          'public.flowproperties'::text as matched_entity_table
+        from public.flowproperties d
+        where (
+            ($1 = 'tg' and d.state_code = 100 and ($3 is null or d.team_id = $3))
+            or ($1 = 'co' and d.state_code = 200 and ($3 is null or d.team_id = $3))
+            or ($1 = 'my' and $2 is not null and d.user_id = $2 and ($4 is null or d.state_code = $4))
+            or ($1 = 'te' and $3 is not null and $5 and d.team_id = $3 and ($4 is null or d.state_code = $4))
+          )
+        order by d.id, d.version desc, d.modified_at desc
+      ) latest
+      where latest.source_json::text like $6
+      order by latest.source_modified_at desc nulls last, latest.source_id
+      limit $8
+      )
+    $branch$];
+  end if;
+
+  if coalesce(array_length(branches, 1), 0) = 0 then
+    return;
+  end if;
+
+  v_sql := format($sql$
+    with matched_rows as (
+      %s
+    )
+    select
+      row_number() over (
+        order by entity_rank, source_modified_at desc nulls last, source_entity_kind, source_id
+      )::bigint as rank,
+      source_entity_kind,
+      source_id,
+      source_version,
+      source_name,
+      source_modified_at,
+      source_team_id,
+      source_json,
+      matched_by,
+      matched_entity_table
+    from matched_rows
+    order by entity_rank, source_modified_at desc nulls last, source_entity_kind, source_id
+    limit $7
+  $sql$, array_to_string(branches, E'\nunion all\n'));
+
+  return query execute v_sql
+    using normalized_data_source, effective_user_id, p_team_id_filter, p_state_code_filter,
+          can_read_team_filter, uuid_pattern, normalized_limit, per_entity_limit;
+end;
+$$;
+
+create or replace function public.search_dataset_json_uuid_mentions(
+  p_uuid uuid,
+  p_source_entity_kinds text[] default null::text[],
+  p_data_source text default 'tg'::text,
+  p_this_user_id text default ''::text,
+  p_team_id_filter uuid default null::uuid,
+  p_state_code_filter integer default null::integer,
+  p_limit integer default 20
+) returns table(
+  rank bigint,
+  source_entity_kind text,
+  source_id uuid,
+  source_version character(9),
+  source_name text,
+  source_modified_at timestamp with time zone,
+  source_team_id uuid,
+  source_json jsonb,
+  matched_by text,
+  matched_entity_table text
+)
+language plpgsql
+set search_path to 'public', 'extensions', 'pg_temp'
+set statement_timeout to '8s'
+as $$
+begin
+  return query
+    select *
+    from private.search_dataset_json_uuid_mentions_impl(
+      p_uuid,
+      p_source_entity_kinds,
+      p_data_source,
+      p_this_user_id,
+      p_team_id_filter,
+      p_state_code_filter,
+      p_limit
+    );
+end;
+$$;
+
+alter function private.dataset_json_first_text(jsonb) owner to postgres;
+alter function private.dataset_json_display_name(text, jsonb) owner to postgres;
+alter function private.search_dataset_json_uuid_mentions_impl(uuid, text[], text, text, uuid, integer, integer) owner to postgres;
+alter function public.search_dataset_json_uuid_mentions(uuid, text[], text, text, uuid, integer, integer) owner to postgres;
+
+revoke all on function private.dataset_json_first_text(jsonb) from public;
+revoke all on function private.dataset_json_display_name(text, jsonb) from public;
+revoke all on function private.search_dataset_json_uuid_mentions_impl(uuid, text[], text, text, uuid, integer, integer) from public;
+
+grant execute on function private.search_dataset_json_uuid_mentions_impl(uuid, text[], text, text, uuid, integer, integer) to anon, authenticated, service_role;
+grant all on function public.search_dataset_json_uuid_mentions(uuid, text[], text, text, uuid, integer, integer) to anon, authenticated, service_role;
+
+grant execute on function util.dataset_json_search_text_allowed_prefixes(text) to service_role;
+grant execute on function util.dataset_json_search_text_is_noise(text, text) to service_role;

--- a/supabase/tests/20260529_dataset_json_uuid_deep_search.sql
+++ b/supabase/tests/20260529_dataset_json_uuid_deep_search.sql
@@ -1,0 +1,471 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(17);
+
+alter table public.flows disable trigger user;
+alter table public.processes disable trigger user;
+alter table public.lifecyclemodels disable trigger user;
+alter table public.sources disable trigger user;
+alter table public.contacts disable trigger user;
+alter table public.unitgroups disable trigger user;
+alter table public.flowproperties disable trigger user;
+
+select ok(
+  strpos(pg_get_functiondef('public.search_dataset_json_uuid_mentions(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), 'private.search_dataset_json_uuid_mentions_impl') > 0,
+  'public JSON UUID mention wrapper delegates to private helper'
+);
+
+select ok(
+  (select prosecdef from pg_proc where oid = 'private.search_dataset_json_uuid_mentions_impl(uuid,text[],text,text,uuid,integer,integer)'::regprocedure),
+  'private JSON UUID mention helper is security definer'
+);
+
+select ok(
+  not (select prosecdef from pg_proc where oid = 'public.search_dataset_json_uuid_mentions(uuid,text[],text,text,uuid,integer,integer)'::regprocedure),
+  'public JSON UUID mention wrapper remains security invoker'
+);
+
+select ok(
+  strpos(pg_get_function_result('public.search_dataset_json_uuid_mentions(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), 'total_count') = 0,
+  'JSON UUID mention RPC does not expose total_count'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.search_dataset_json_uuid_mentions_impl(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), 'least(greatest(coalesce(p_limit, 20), 1), 50)') > 0,
+  'JSON UUID mention RPC hard-caps limit at 50'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.search_dataset_json_uuid_mentions_impl(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), 'statement_timeout') > 0
+    and strpos(pg_get_functiondef('private.search_dataset_json_uuid_mentions_impl(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), '8s') > 0,
+  'JSON UUID mention RPC has bounded statement timeout'
+);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'a1380000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'json-uuid-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"a1380000-0000-0000-0000-000000000001","email":"json-uuid-owner@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'b1380000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'json-uuid-outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"b1380000-0000-0000-0000-000000000001","email":"json-uuid-outsider@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('a1380000-0000-0000-0000-000000000001', '{"email":"json-uuid-owner@example.com"}'::jsonb, null),
+  ('b1380000-0000-0000-0000-000000000001', '{"email":"json-uuid-outsider@example.com"}'::jsonb, null);
+
+insert into public.teams (id, json, rank, is_public)
+values
+  ('c1380000-0000-0000-0000-000000000001', '{"name":"JSON UUID Mention Team"}'::jsonb, 1, false);
+
+insert into public.roles (user_id, team_id, role)
+values
+  ('a1380000-0000-0000-0000-000000000001', 'c1380000-0000-0000-0000-000000000001', 'owner');
+
+insert into public.flows (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  (
+    'f1380000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Old UUID flow"}]}}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::jsonb,
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Old UUID flow"}]}}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::json,
+    'a1380000-0000-0000-0000-000000000001',
+    100,
+    null,
+    'old uuid flow',
+    true,
+    now() - interval '2 days',
+    now() - interval '2 days'
+  ),
+  (
+    'f1380000-0000-0000-0000-000000000001',
+    '01.01.000',
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Latest UUID flow"}]}}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::jsonb,
+    '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Latest UUID flow"}]}}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::json,
+    'a1380000-0000-0000-0000-000000000001',
+    100,
+    null,
+    'latest uuid flow',
+    true,
+    now() - interval '1 day',
+    now() - interval '1 day'
+  );
+
+insert into public.processes (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  (
+    'e1380000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Public UUID process"}]}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"nested":{"uuid":"d1380000-0000-0000-0000-000000000001"}}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Public UUID process"}]}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"nested":{"uuid":"d1380000-0000-0000-0000-000000000001"}}'::json,
+    'a1380000-0000-0000-0000-000000000001',
+    100,
+    null,
+    'public uuid process',
+    true,
+    now(),
+    now()
+  ),
+  (
+    'e1380000-0000-0000-0000-000000000002',
+    '01.00.000',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Owner UUID process"}]}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"nested":{"uuid":"d1380000-0000-0000-0000-000000000002"}}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Owner UUID process"}]}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"nested":{"uuid":"d1380000-0000-0000-0000-000000000002"}}'::json,
+    'a1380000-0000-0000-0000-000000000001',
+    0,
+    null,
+    'owner uuid process',
+    true,
+    now(),
+    now()
+  ),
+  (
+    'e1380000-0000-0000-0000-000000000003',
+    '01.00.000',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Outsider UUID process"}]}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"nested":{"uuid":"d1380000-0000-0000-0000-000000000002"}}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Outsider UUID process"}]}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"nested":{"uuid":"d1380000-0000-0000-0000-000000000002"}}'::json,
+    'b1380000-0000-0000-0000-000000000001',
+    0,
+    null,
+    'outsider uuid process',
+    true,
+    now(),
+    now()
+  ),
+  (
+    'e1380000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Team UUID process"}]}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"nested":{"uuid":"d1380000-0000-0000-0000-000000000003"}}'::jsonb,
+    '{"processDataSet":{"processInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"Team UUID process"}]}}},"modellingAndValidation":{"LCIMethodAndAllocation":{"typeOfDataSet":"Unit process"}}},"nested":{"uuid":"d1380000-0000-0000-0000-000000000003"}}'::json,
+    'b1380000-0000-0000-0000-000000000001',
+    0,
+    'c1380000-0000-0000-0000-000000000001',
+    'team uuid process',
+    true,
+    now(),
+    now()
+  );
+
+insert into public.lifecyclemodels (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values (
+  'd1380000-0000-0000-0000-000000000010',
+  '01.00.000',
+  '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"UUID model"}]}}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::jsonb,
+  '{"lifeCycleModelDataSet":{"lifeCycleModelInformation":{"dataSetInformation":{"name":{"baseName":[{"#text":"UUID model"}]}}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::json,
+  'a1380000-0000-0000-0000-000000000001',
+  100,
+  null,
+  'uuid model',
+  true,
+  now(),
+  now()
+);
+
+insert into public.sources (id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at)
+values (
+  '51380000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"#text":"UUID source"}]}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::jsonb,
+  '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"#text":"UUID source"}]}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::json,
+  'a1380000-0000-0000-0000-000000000001',
+  100,
+  null,
+  'uuid source',
+  true,
+  now(),
+  now()
+);
+
+insert into public.contacts (id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at)
+values (
+  'c1380000-0000-0000-0000-000000000010',
+  '01.00.000',
+  '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"#text":"UUID contact"}]}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::jsonb,
+  '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"#text":"UUID contact"}]}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::json,
+  'a1380000-0000-0000-0000-000000000001',
+  100,
+  null,
+  'uuid contact',
+  true,
+  now(),
+  now()
+);
+
+insert into public.unitgroups (id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at)
+values (
+  '71380000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"#text":"UUID unitgroup"}]}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::jsonb,
+  '{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"#text":"UUID unitgroup"}]}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::json,
+  'a1380000-0000-0000-0000-000000000001',
+  100,
+  null,
+  'uuid unitgroup',
+  true,
+  now(),
+  now()
+);
+
+insert into public.flowproperties (id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at)
+values (
+  '81380000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"#text":"UUID flowproperty"}]}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::jsonb,
+  '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"#text":"UUID flowproperty"}]}}},"contains":"d1380000-0000-0000-0000-000000000001"}'::json,
+  'a1380000-0000-0000-0000-000000000001',
+  100,
+  null,
+  'uuid flowproperty',
+  true,
+  now(),
+  now()
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', 'a1380000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select source_version::text
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000001',
+      array['flow'],
+      'tg',
+      '',
+      null,
+      null,
+      20
+    )
+    where source_id = 'f1380000-0000-0000-0000-000000000001'
+  ),
+  '01.01.000',
+  'flow JSON UUID mention search returns latest visible row'
+);
+
+select is(
+  (
+    select source_name
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000001',
+      array['flow'],
+      'tg',
+      '',
+      null,
+      null,
+      20
+    )
+    where source_id = 'f1380000-0000-0000-0000-000000000001'
+  ),
+  'Latest UUID flow',
+  'flow JSON UUID mention search exposes display name'
+);
+
+select set_eq(
+  $$
+    select source_entity_kind
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000001',
+      array['process'],
+      'tg',
+      '',
+      null,
+      null,
+      20
+    )
+  $$,
+  $$ values ('process'::text) $$,
+  'source entity kind filter restricts JSON UUID deep search'
+);
+
+select is(
+  (
+    select count(*)
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000001',
+      array['flow','process','lifecyclemodel','source','contact','unitgroup','flowproperty'],
+      'tg',
+      '',
+      null,
+      null,
+      2
+    )
+  ),
+  2::bigint,
+  'JSON UUID deep search respects caller limit'
+);
+
+select is(
+  (
+    select count(*)
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000001',
+      array['flow','process','lifecyclemodel','source','contact','unitgroup','flowproperty'],
+      'tg',
+      '',
+      null,
+      null,
+      20
+    )
+  ),
+  7::bigint,
+  'JSON UUID deep search covers all supported entity branches'
+);
+
+select is(
+  (
+    select matched_by
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000001',
+      array['source'],
+      'tg',
+      '',
+      null,
+      null,
+      20
+    )
+    limit 1
+  ),
+  'json_uuid_scan',
+  'JSON UUID deep search marks match source'
+);
+
+select is(
+  (
+    select source_id::text
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000002',
+      array['process'],
+      'my',
+      'b1380000-0000-0000-0000-000000000001',
+      null,
+      null,
+      20
+    )
+  ),
+  'e1380000-0000-0000-0000-000000000002',
+  'my JSON UUID deep search uses auth.uid instead of spoofable this_user_id'
+);
+
+select is(
+  (
+    select count(*)
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000002',
+      array['process'],
+      'my',
+      'b1380000-0000-0000-0000-000000000001',
+      null,
+      null,
+      20
+    )
+    where source_id = 'e1380000-0000-0000-0000-000000000003'
+  ),
+  0::bigint,
+  'my JSON UUID deep search does not return outsider data'
+);
+
+select is(
+  (
+    select source_id::text
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000003',
+      array['process'],
+      'te',
+      '',
+      'c1380000-0000-0000-0000-000000000001',
+      null,
+      20
+    )
+  ),
+  'e1380000-0000-0000-0000-000000000004',
+  'team JSON UUID deep search returns team data for a member'
+);
+
+select set_config('request.jwt.claim.sub', 'b1380000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select count(*)
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000003',
+      array['process'],
+      'te',
+      '',
+      'c1380000-0000-0000-0000-000000000001',
+      null,
+      20
+    )
+  ),
+  0::bigint,
+  'team JSON UUID deep search rejects a non-member'
+);
+
+select is(
+  (
+    select count(*)
+    from public.search_dataset_json_uuid_mentions(
+      'd1380000-0000-0000-0000-000000000001',
+      array['unsupported-kind'],
+      'tg',
+      '',
+      null,
+      null,
+      20
+    )
+  ),
+  0::bigint,
+  'unsupported entity kind returns no JSON UUID deep search rows'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary

- add a bounded `search_dataset_json_uuid_mentions` RPC for low-frequency UUID deep search across supported dataset JSON tables
- preserve visibility/latest-version semantics for `tg`, `co`, `my`, and `te` data scopes
- add pgTAP coverage for entity filters, latest-row behavior, limit capping, RLS boundary handling, and unsupported kind handling
- grant `service_role` execute permission on existing extracted-text helper functions used by service-role trigger paths

Closes #138

## Validation

- `supabase db reset`
- `supabase test db supabase/tests/20260529_dataset_json_uuid_deep_search.sql`
- `supabase test db supabase/tests/20260520_contacts_latest_version_query_rpcs.sql supabase/tests/20260529_dataset_json_uuid_deep_search.sql`
- `supabase test db` (35 files, 548 tests)
