### PR TITLE
fix: add cron run details retention job

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "b76dd051c931f5310d2346ff8548a8a3519c88d3"
+lastReviewedCommit: "58213cd9f2ffa77a533090f6da469d724292fcd2"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: b76dd051c931f5310d2346ff8548a8a3519c88d3
+lastReviewedCommit: 58213cd9f2ffa77a533090f6da469d724292fcd2
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: b76dd051c931f5310d2346ff8548a8a3519c88d3
+lastReviewedCommit: 58213cd9f2ffa77a533090f6da469d724292fcd2
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: b76dd051c931f5310d2346ff8548a8a3519c88d3
+lastReviewedCommit: 58213cd9f2ffa77a533090f6da469d724292fcd2
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260529121000_cron_job_run_details_retention.sql
+++ b/supabase/migrations/20260529121000_cron_job_run_details_retention.sql
@@ -1,0 +1,110 @@
+create or replace function util.preview_cron_job_run_details_retention(
+  p_retention_window interval default interval '14 days'
+) returns table (
+  retention_window interval,
+  cutoff_time timestamp with time zone,
+  eligible_rows bigint,
+  protected_open_or_running_rows bigint,
+  oldest_eligible_end_time timestamp with time zone,
+  newest_eligible_end_time timestamp with time zone
+)
+language plpgsql
+stable
+set search_path to ''
+as $$
+begin
+  if p_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'cron job run details retention window must be at least 1 day';
+  end if;
+
+  return query
+  select
+    p_retention_window as retention_window,
+    pg_catalog.now() - p_retention_window as cutoff_time,
+    count(*) filter (
+      where details.end_time is not null
+        and details.end_time < pg_catalog.now() - p_retention_window
+        and coalesce(details.status, '') <> 'running'
+    )::bigint as eligible_rows,
+    count(*) filter (
+      where details.end_time is null
+        or coalesce(details.status, '') = 'running'
+    )::bigint as protected_open_or_running_rows,
+    min(details.end_time) filter (
+      where details.end_time is not null
+        and details.end_time < pg_catalog.now() - p_retention_window
+        and coalesce(details.status, '') <> 'running'
+    ) as oldest_eligible_end_time,
+    max(details.end_time) filter (
+      where details.end_time is not null
+        and details.end_time < pg_catalog.now() - p_retention_window
+        and coalesce(details.status, '') <> 'running'
+    ) as newest_eligible_end_time
+  from cron.job_run_details as details;
+end;
+$$;
+
+alter function util.preview_cron_job_run_details_retention(interval) owner to postgres;
+revoke all on function util.preview_cron_job_run_details_retention(interval) from public;
+
+create or replace function util.purge_cron_job_run_details(
+  p_retention_window interval default interval '14 days'
+) returns bigint
+language plpgsql
+set search_path to ''
+as $$
+declare
+  deleted_count bigint;
+begin
+  if p_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'cron job run details retention window must be at least 1 day';
+  end if;
+
+  if not pg_catalog.pg_try_advisory_xact_lock(
+    pg_catalog.hashtext('util.purge_cron_job_run_details')
+  ) then
+    return 0;
+  end if;
+
+  delete from cron.job_run_details as details
+   where details.end_time is not null
+     and details.end_time < pg_catalog.now() - p_retention_window
+     and coalesce(details.status, '') <> 'running';
+
+  get diagnostics deleted_count = row_count;
+  return deleted_count;
+end;
+$$;
+
+alter function util.purge_cron_job_run_details(interval) owner to postgres;
+revoke all on function util.purge_cron_job_run_details(interval) from public;
+
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    begin
+      perform cron.unschedule('purge-cron-job-run-details');
+    exception when others then
+      null;
+    end;
+
+    perform cron.schedule(
+      'purge-cron-job-run-details',
+      '17 3 * * *',
+      $cron$
+        select util.purge_cron_job_run_details(interval '14 days');
+      $cron$
+    );
+  end if;
+end
+$$;
+
+comment on function util.preview_cron_job_run_details_retention(interval) is
+  'Operator dry-run helper for pg_cron run-detail retention; reports rows older than the retention window while protecting open or running records.';
+
+comment on function util.purge_cron_job_run_details(interval) is
+  'Deletes completed pg_cron run details older than the retention window; open rows and status=running rows are protected.';

--- a/supabase/tests/20260529_cron_job_run_details_retention.sql
+++ b/supabase/tests/20260529_cron_job_run_details_retention.sql
@@ -1,0 +1,232 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create or replace function pg_temp.has_empty_search_path(p_signature text)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from pg_proc p
+    cross join lateral unnest(coalesce(p.proconfig, array[]::text[])) as config(setting)
+    where p.oid = p_signature::regprocedure
+      and config.setting in ('search_path=', 'search_path=""')
+  );
+$$;
+
+select plan(17);
+
+select ok(
+  exists (select 1 from pg_extension where extname = 'pg_cron'),
+  'pg_cron extension is available for retention assertions'
+);
+
+select ok(
+  to_regprocedure('util.preview_cron_job_run_details_retention(interval)') is not null,
+  'cron job run-detail retention preview function exists'
+);
+
+select ok(
+  to_regprocedure('util.purge_cron_job_run_details(interval)') is not null,
+  'cron job run-detail retention purge function exists'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job
+    where jobname = 'purge-cron-job-run-details'
+  ),
+  1,
+  'purge-cron-job-run-details is scheduled exactly once'
+);
+
+select is(
+  (
+    select schedule
+    from cron.job
+    where jobname = 'purge-cron-job-run-details'
+  ),
+  '17 3 * * *',
+  'purge-cron-job-run-details uses the daily low-frequency cadence'
+);
+
+select is(
+  (
+    select active
+    from cron.job
+    where jobname = 'purge-cron-job-run-details'
+  ),
+  true,
+  'purge-cron-job-run-details is active'
+);
+
+select ok(
+  (
+    select command like '%util.purge_cron_job_run_details%'
+      and command like '%14 days%'
+    from cron.job
+    where jobname = 'purge-cron-job-run-details'
+  ),
+  'purge-cron-job-run-details uses the 14 day first-rollout retention window'
+);
+
+delete from cron.job_run_details
+where jobid between 9141001 and 9141004
+   or runid between -9141004 and -9141001;
+
+insert into cron.job_run_details (
+  jobid,
+  runid,
+  database,
+  username,
+  command,
+  status,
+  return_message,
+  start_time,
+  end_time
+) values
+  (
+    9141001,
+    -9141001,
+    current_database(),
+    current_user,
+    'select 1 -- pgtap old completed retention candidate',
+    'succeeded',
+    'SELECT 1',
+    pg_catalog.now() - interval '20 days',
+    pg_catalog.now() - interval '20 days'
+  ),
+  (
+    9141002,
+    -9141002,
+    current_database(),
+    current_user,
+    'select 1 -- pgtap recent completed retention protected',
+    'succeeded',
+    'SELECT 1',
+    pg_catalog.now() - interval '1 day',
+    pg_catalog.now() - interval '1 day'
+  ),
+  (
+    9141003,
+    -9141003,
+    current_database(),
+    current_user,
+    'select 1 -- pgtap old open retention protected',
+    'running',
+    null,
+    pg_catalog.now() - interval '20 days',
+    null
+  ),
+  (
+    9141004,
+    -9141004,
+    current_database(),
+    current_user,
+    'select 1 -- pgtap old running retention protected',
+    'running',
+    null,
+    pg_catalog.now() - interval '20 days',
+    pg_catalog.now() - interval '20 days'
+  );
+
+select ok(
+  (
+    select eligible_rows >= 1
+    from util.preview_cron_job_run_details_retention(interval '14 days')
+  ),
+  'preview reports at least the inserted old completed run as eligible'
+);
+
+select ok(
+  (
+    select protected_open_or_running_rows >= 2
+    from util.preview_cron_job_run_details_retention(interval '14 days')
+  ),
+  'preview reports open or running rows as protected'
+);
+
+create temporary table pg_temp.cron_retention_purge_result as
+select util.purge_cron_job_run_details(interval '14 days') as deleted_rows;
+
+select ok(
+  (select deleted_rows >= 1 from pg_temp.cron_retention_purge_result),
+  'purge deletes at least the inserted old completed run'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job_run_details
+    where jobid = 9141001
+  ),
+  0,
+  'purge deletes completed rows older than the retention window'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job_run_details
+    where jobid = 9141002
+  ),
+  1,
+  'purge keeps completed rows inside the retention window'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job_run_details
+    where jobid = 9141003
+  ),
+  1,
+  'purge keeps open rows with null end_time'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job_run_details
+    where jobid = 9141004
+  ),
+  1,
+  'purge keeps status=running rows even when end_time is populated'
+);
+
+create temporary table pg_temp.cron_retention_error_check (
+  raised boolean not null
+);
+
+do $$
+begin
+  perform util.purge_cron_job_run_details(interval '12 hours');
+  insert into pg_temp.cron_retention_error_check values (false);
+exception when invalid_parameter_value then
+  insert into pg_temp.cron_retention_error_check values (true);
+end
+$$;
+
+select is(
+  (select raised from pg_temp.cron_retention_error_check),
+  true,
+  'purge rejects retention windows shorter than one day'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.preview_cron_job_run_details_retention(interval)'),
+  'cron retention preview function pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.purge_cron_job_run_details(interval)'),
+  'cron retention purge function pins an empty search_path'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes #142

## Summary
- Adds operator preview SQL for cron.job_run_details retention with a 14 day first-rollout window.
- Adds a daily purge-cron-job-run-details pg_cron job that deletes only completed old run details.
- Adds pgTAP coverage for scheduling, dry-run shape, running/null-end protection, and retention guardrails.

## Key Decisions
- This PR is intentionally limited to pg_cron diagnostic retention and does not delete business artifact metadata or Storage objects.
- The new migration is ordered after existing 20260529120000 migrations to avoid out-of-order remote migration risk.

## Validation
- supabase db reset
- supabase test db supabase/tests/20260529_cron_job_run_details_retention.sql
- supabase migration list --local
- scripts/docpact lint --root . --files 'supabase/migrations/20260529121000_cron_job_run_details_retention.sql,supabase/tests/20260529_cron_job_run_details_retention.sql,AGENTS.md,.docpact/config.yaml,docs/agents/repo-validation.md,docs/agents/repo-architecture.md' --mode enforce
- scripts/docpact validate-config --root . --strict

## Risks / Rollback
- Low runtime risk: one daily delete against cron.job_run_details using end_time/status predicates; running and open rows are protected.
- Rollback: unschedule purge-cron-job-run-details and revert the migration in a follow-up migration if unexpected behavior appears.

## Follow-ups
- Remaining database-engine retention work stays in #141: package/job/artifact/request-cache dry-run contracts, supabase_functions.hooks policy, and pgmq archive handling.

## Workspace Integration
- Refs tiangong-lca/database-engine#141 and tiangong-lca/workspace#201. database-engine is M2; this routine PR targets dev, with root workspace integration pending after promote to main.