### PR TITLE
promote: package retention dry-run to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "58213cd9f2ffa77a533090f6da469d724292fcd2"
+lastReviewedCommit: "7fedf008e4417a7e0ff7e18f5b24fb098f88cb47"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 58213cd9f2ffa77a533090f6da469d724292fcd2
+lastReviewedCommit: 7fedf008e4417a7e0ff7e18f5b24fb098f88cb47
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 58213cd9f2ffa77a533090f6da469d724292fcd2
+lastReviewedCommit: 7fedf008e4417a7e0ff7e18f5b24fb098f88cb47
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-29
-lastReviewedCommit: 58213cd9f2ffa77a533090f6da469d724292fcd2
+lastReviewedCommit: 7fedf008e4417a7e0ff7e18f5b24fb098f88cb47
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260529123000_lca_package_retention_dry_run.sql
+++ b/supabase/migrations/20260529123000_lca_package_retention_dry_run.sql
@@ -1,0 +1,244 @@
+create schema if not exists util;
+
+create or replace function util.preview_lca_package_retention(
+  p_job_retention_window interval default interval '30 days',
+  p_request_cache_retention_window interval default interval '30 days',
+  p_as_of timestamp with time zone default pg_catalog.now()
+) returns table (
+  retention_area text,
+  retention_action text,
+  is_eligible boolean,
+  reason text,
+  retention_window interval,
+  cutoff_time timestamp with time zone,
+  row_count bigint,
+  total_artifact_bytes bigint,
+  total_hit_count bigint,
+  oldest_observed_at timestamp with time zone,
+  newest_observed_at timestamp with time zone
+)
+language plpgsql
+stable
+set search_path to ''
+as $$
+begin
+  if p_as_of is null then
+    raise exception using
+      errcode = '22023',
+      message = 'package retention dry-run as_of timestamp must not be null';
+  end if;
+
+  if p_job_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'package job retention window must be at least 1 day';
+  end if;
+
+  if p_request_cache_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'package request-cache retention window must be at least 1 day';
+  end if;
+
+  return query
+  with job_rollup as (
+    select
+      jobs.id,
+      jobs.status,
+      coalesce(jobs.finished_at, jobs.updated_at, jobs.created_at) as lifecycle_at,
+      coalesce(bool_or(artifacts.is_pinned) filter (where artifacts.id is not null), false) as has_pinned_artifact,
+      coalesce(
+        bool_or(
+          artifacts.id is not null
+          and artifacts.status <> 'deleted'
+          and (
+            artifacts.expires_at is null
+            or artifacts.expires_at > p_as_of
+          )
+        ),
+        false
+      ) as has_unexpired_artifact,
+      exists (
+        select 1
+        from public.lca_package_artifacts as recent_artifact
+        join public.lca_package_request_cache as recent_cache
+          on recent_cache.export_artifact_id = recent_artifact.id
+          or recent_cache.report_artifact_id = recent_artifact.id
+        where recent_artifact.job_id = jobs.id
+          and recent_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window
+      ) as has_recent_artifact_cache,
+      coalesce(sum(coalesce(artifacts.artifact_byte_size, 0)), 0)::bigint as artifact_bytes
+    from public.lca_package_jobs as jobs
+    left join public.lca_package_artifacts as artifacts
+      on artifacts.job_id = jobs.id
+    group by jobs.id
+  ),
+  job_classified as (
+    select
+      'lca_package_jobs'::text as retention_area,
+      'delete_job_metadata_cascade_after_artifact_gc'::text as retention_action,
+      (classified.reason = 'eligible_terminal_job_older_than_window') as is_eligible,
+      classified.reason,
+      p_job_retention_window as retention_window,
+      p_as_of - p_job_retention_window as cutoff_time,
+      1::bigint as row_count,
+      classified.artifact_bytes as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      classified.lifecycle_at as observed_at
+    from (
+      select
+        job_rollup.*,
+        case
+          when job_rollup.status in ('queued', 'running') then 'protected_active_job'
+          when job_rollup.status not in ('ready', 'completed', 'failed', 'stale') then 'protected_unknown_job_status'
+          when job_rollup.lifecycle_at >= p_as_of - p_job_retention_window then 'protected_inside_job_retention_window'
+          when job_rollup.has_pinned_artifact then 'protected_pinned_artifact'
+          when job_rollup.has_unexpired_artifact then 'protected_artifact_not_expired'
+          when job_rollup.has_recent_artifact_cache then 'protected_recent_request_cache_reference'
+          else 'eligible_terminal_job_older_than_window'
+        end as reason
+      from job_rollup
+    ) as classified
+  ),
+  artifact_classified as (
+    select
+      'lca_package_artifacts'::text as retention_area,
+      'delete_object_then_mark_deleted'::text as retention_action,
+      (classified.reason = 'eligible_expired_unpinned_artifact') as is_eligible,
+      classified.reason,
+      null::interval as retention_window,
+      p_as_of as cutoff_time,
+      1::bigint as row_count,
+      coalesce(classified.artifact_byte_size, 0)::bigint as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      coalesce(classified.expires_at, classified.updated_at, classified.created_at) as observed_at
+    from (
+      select
+        artifacts.*,
+        jobs.status as parent_job_status,
+        coalesce(recent_cache.recent_cache_rows, 0) as recent_cache_rows,
+        case
+          when jobs.id is null then 'protected_missing_parent_job'
+          when artifacts.is_pinned then 'protected_pinned_artifact'
+          when artifacts.status = 'deleted' then 'protected_already_deleted'
+          when artifacts.status = 'pending' then 'protected_artifact_not_ready'
+          when jobs.status in ('queued', 'running') then 'protected_active_parent_job'
+          when artifacts.expires_at is null then 'protected_missing_expires_at'
+          when artifacts.expires_at > p_as_of then 'protected_expires_at_in_future'
+          when coalesce(recent_cache.recent_cache_rows, 0) > 0 then 'protected_recent_request_cache_reference'
+          else 'eligible_expired_unpinned_artifact'
+        end as reason
+      from public.lca_package_artifacts as artifacts
+      left join public.lca_package_jobs as jobs
+        on jobs.id = artifacts.job_id
+      left join lateral (
+        select count(*)::bigint as recent_cache_rows
+        from public.lca_package_request_cache as request_cache
+        where (
+            request_cache.export_artifact_id = artifacts.id
+            or request_cache.report_artifact_id = artifacts.id
+          )
+          and request_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window
+      ) as recent_cache on true
+    ) as classified
+  ),
+  request_cache_classified as (
+    select
+      'lca_package_request_cache'::text as retention_area,
+      'delete_stale_request_cache_row'::text as retention_action,
+      (classified.reason = 'eligible_stale_request_cache') as is_eligible,
+      classified.reason,
+      p_request_cache_retention_window as retention_window,
+      p_as_of - p_request_cache_retention_window as cutoff_time,
+      1::bigint as row_count,
+      0::bigint as total_artifact_bytes,
+      classified.hit_count::bigint as total_hit_count,
+      classified.last_accessed_at as observed_at
+    from (
+      select
+        request_cache.*,
+        jobs.status as parent_job_status,
+        case
+          when request_cache.status in ('pending', 'running') then 'protected_active_request_cache'
+          when request_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window then 'protected_recent_request_cache_access'
+          when jobs.status in ('queued', 'running') then 'protected_active_parent_job'
+          else 'eligible_stale_request_cache'
+        end as reason
+      from public.lca_package_request_cache as request_cache
+      left join public.lca_package_jobs as jobs
+        on jobs.id = request_cache.job_id
+    ) as classified
+  ),
+  export_item_classified as (
+    select
+      'lca_package_export_items'::text as retention_area,
+      'delete_export_items_with_parent_job'::text as retention_action,
+      (classified.reason = 'eligible_parent_job_cascade') as is_eligible,
+      classified.reason,
+      p_job_retention_window as retention_window,
+      p_as_of - p_job_retention_window as cutoff_time,
+      1::bigint as row_count,
+      0::bigint as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      classified.created_at as observed_at
+    from (
+      select
+        export_items.*,
+        case
+          when job_rollup.id is null then 'protected_missing_parent_job'
+          when job_rollup.status in ('queued', 'running') then 'protected_active_parent_job'
+          when job_rollup.status not in ('ready', 'completed', 'failed', 'stale') then 'protected_unknown_parent_job_status'
+          when job_rollup.lifecycle_at >= p_as_of - p_job_retention_window then 'protected_parent_inside_job_retention_window'
+          when job_rollup.has_pinned_artifact then 'protected_pinned_artifact'
+          when job_rollup.has_unexpired_artifact then 'protected_artifact_not_expired'
+          when job_rollup.has_recent_artifact_cache then 'protected_recent_request_cache_reference'
+          else 'eligible_parent_job_cascade'
+        end as reason
+      from public.lca_package_export_items as export_items
+      left join job_rollup
+        on job_rollup.id = export_items.job_id
+    ) as classified
+  ),
+  classified as (
+    select * from job_classified
+    union all
+    select * from artifact_classified
+    union all
+    select * from request_cache_classified
+    union all
+    select * from export_item_classified
+  )
+  select
+    classified.retention_area,
+    classified.retention_action,
+    classified.is_eligible,
+    classified.reason,
+    classified.retention_window,
+    classified.cutoff_time,
+    sum(classified.row_count)::bigint as row_count,
+    coalesce(sum(classified.total_artifact_bytes), 0)::bigint as total_artifact_bytes,
+    coalesce(sum(classified.total_hit_count), 0)::bigint as total_hit_count,
+    min(classified.observed_at) as oldest_observed_at,
+    max(classified.observed_at) as newest_observed_at
+  from classified
+  group by
+    classified.retention_area,
+    classified.retention_action,
+    classified.is_eligible,
+    classified.reason,
+    classified.retention_window,
+    classified.cutoff_time
+  order by
+    classified.retention_area,
+    classified.is_eligible desc,
+    classified.reason;
+end;
+$$;
+
+alter function util.preview_lca_package_retention(interval, interval, timestamp with time zone) owner to postgres;
+revoke all on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) from public;
+grant usage on schema util to service_role;
+grant execute on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) to service_role;
+
+comment on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) is
+  'Operator dry-run helper for package metadata retention; reports aggregate eligible/protected counts for package jobs, artifacts, request cache, and export items without deleting or updating business rows.';

--- a/supabase/tests/20260529_lca_package_retention_dry_run.sql
+++ b/supabase/tests/20260529_lca_package_retention_dry_run.sql
@@ -1,0 +1,472 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create or replace function pg_temp.has_empty_search_path(p_signature text)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from pg_proc p
+    cross join lateral unnest(coalesce(p.proconfig, array[]::text[])) as config(setting)
+    where p.oid = p_signature::regprocedure
+      and config.setting in ('search_path=', 'search_path=""')
+  );
+$$;
+
+select plan(16);
+
+select ok(
+  to_regprocedure('util.preview_lca_package_retention(interval,interval,timestamp with time zone)') is not null,
+  'package retention dry-run function exists'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'util.preview_lca_package_retention(interval,interval,timestamp with time zone)',
+    'EXECUTE'
+  ),
+  'service_role can execute package retention dry-run function'
+);
+
+insert into public.lca_package_jobs (
+  id,
+  job_type,
+  status,
+  payload,
+  diagnostics,
+  requested_by,
+  created_at,
+  updated_at,
+  finished_at
+) values
+  (
+    '91460000-0000-4000-8000-000000000001',
+    'export_package',
+    'ready',
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '91460000-0000-4000-8000-000000000100',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000002',
+    'export_package',
+    'queued',
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '91460000-0000-4000-8000-000000000100',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    null
+  ),
+  (
+    '91460000-0000-4000-8000-000000000003',
+    'export_package',
+    'ready',
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '91460000-0000-4000-8000-000000000100',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000004',
+    'export_package',
+    'ready',
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '91460000-0000-4000-8000-000000000100',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000005',
+    'export_package',
+    'ready',
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '91460000-0000-4000-8000-000000000100',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  );
+
+insert into public.lca_package_artifacts (
+  id,
+  job_id,
+  artifact_kind,
+  status,
+  artifact_url,
+  artifact_sha256,
+  artifact_byte_size,
+  artifact_format,
+  content_type,
+  metadata,
+  expires_at,
+  is_pinned,
+  created_at,
+  updated_at
+) values
+  (
+    '91460000-0000-4000-8000-000000000103',
+    '91460000-0000-4000-8000-000000000003',
+    'export_zip',
+    'ready',
+    'storage://package/missing-expiry.zip',
+    null,
+    10,
+    'tidas-package-zip:v1',
+    'application/zip',
+    '{}'::jsonb,
+    null,
+    false,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000104',
+    '91460000-0000-4000-8000-000000000004',
+    'export_zip',
+    'ready',
+    'storage://package/expired.zip',
+    null,
+    20,
+    'tidas-package-zip:v1',
+    'application/zip',
+    '{}'::jsonb,
+    '2025-12-15 00:00:00+00',
+    false,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000105',
+    '91460000-0000-4000-8000-000000000005',
+    'export_zip',
+    'ready',
+    'storage://package/recent-cache.zip',
+    null,
+    30,
+    'tidas-package-zip:v1',
+    'application/zip',
+    '{}'::jsonb,
+    '2025-12-15 00:00:00+00',
+    false,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  );
+
+insert into public.lca_package_export_items (
+  id,
+  job_id,
+  table_name,
+  dataset_id,
+  version,
+  is_seed,
+  refs_done,
+  created_at,
+  updated_at
+) values
+  (
+    '91460000-0000-4000-8000-000000000201',
+    '91460000-0000-4000-8000-000000000001',
+    'processes',
+    '91460000-0000-4000-8000-000000000301',
+    '000000001',
+    false,
+    true,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000202',
+    '91460000-0000-4000-8000-000000000002',
+    'processes',
+    '91460000-0000-4000-8000-000000000302',
+    '000000001',
+    false,
+    false,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000203',
+    '91460000-0000-4000-8000-000000000003',
+    'processes',
+    '91460000-0000-4000-8000-000000000303',
+    '000000001',
+    false,
+    true,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000204',
+    '91460000-0000-4000-8000-000000000004',
+    'processes',
+    '91460000-0000-4000-8000-000000000304',
+    '000000001',
+    false,
+    true,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  );
+
+insert into public.lca_package_request_cache (
+  id,
+  requested_by,
+  operation,
+  request_key,
+  request_payload,
+  status,
+  job_id,
+  export_artifact_id,
+  report_artifact_id,
+  hit_count,
+  last_accessed_at,
+  created_at,
+  updated_at
+) values
+  (
+    '91460000-0000-4000-8000-000000000401',
+    '91460000-0000-4000-8000-000000000100',
+    'export_package',
+    'old-ready-cache',
+    '{}'::jsonb,
+    'ready',
+    null,
+    null,
+    null,
+    2,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000402',
+    '91460000-0000-4000-8000-000000000100',
+    'export_package',
+    'recent-ready-cache',
+    '{}'::jsonb,
+    'ready',
+    null,
+    null,
+    null,
+    3,
+    '2026-01-30 00:00:00+00',
+    '2026-01-30 00:00:00+00',
+    '2026-01-30 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000403',
+    '91460000-0000-4000-8000-000000000100',
+    'export_package',
+    'old-pending-cache',
+    '{}'::jsonb,
+    'pending',
+    null,
+    null,
+    null,
+    0,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000404',
+    '91460000-0000-4000-8000-000000000100',
+    'export_package',
+    'recent-artifact-cache',
+    '{}'::jsonb,
+    'ready',
+    '91460000-0000-4000-8000-000000000005',
+    '91460000-0000-4000-8000-000000000105',
+    null,
+    1,
+    '2026-01-30 00:00:00+00',
+    '2026-01-30 00:00:00+00',
+    '2026-01-30 00:00:00+00'
+  );
+
+create temporary table pg_temp.package_retention_preview as
+select *
+from util.preview_lca_package_retention(
+  interval '30 days',
+  interval '7 days',
+  '2026-02-01 00:00:00+00'::timestamp with time zone
+);
+
+select is(
+  (select count(distinct retention_area)::integer from pg_temp.package_retention_preview),
+  4,
+  'dry-run reports all package retention areas'
+);
+
+select ok(
+  (
+    select row_count >= 2
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_jobs'
+      and is_eligible
+      and reason = 'eligible_terminal_job_older_than_window'
+  ),
+  'old terminal jobs without protected artifacts are eligible'
+);
+
+select ok(
+  (
+    select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_jobs'
+      and not is_eligible
+      and reason = 'protected_artifact_not_expired'
+  ),
+  'jobs with attached missing-expiry artifacts are protected'
+);
+
+select ok(
+  (
+    select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_jobs'
+      and not is_eligible
+      and reason = 'protected_recent_request_cache_reference'
+  ),
+  'jobs with recently referenced artifacts are protected'
+);
+
+select ok(
+  (
+    select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_artifacts'
+      and not is_eligible
+      and reason = 'protected_missing_expires_at'
+  ),
+  'artifacts without expires_at are protected'
+);
+
+select ok(
+  (
+    select row_count >= 1
+      and total_artifact_bytes >= 20
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_artifacts'
+      and is_eligible
+      and reason = 'eligible_expired_unpinned_artifact'
+  ),
+  'expired unpinned artifacts are eligible and report bytes'
+);
+
+select ok(
+  (
+    select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_artifacts'
+      and not is_eligible
+      and reason = 'protected_recent_request_cache_reference'
+  ),
+  'expired artifacts with recent request-cache references are protected'
+);
+
+select ok(
+  (
+    select row_count >= 1
+      and total_hit_count >= 3
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_request_cache'
+      and not is_eligible
+      and reason = 'protected_recent_request_cache_access'
+  ),
+  'recent request-cache rows are protected and report hit counts'
+);
+
+select ok(
+  (
+    select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_request_cache'
+      and is_eligible
+      and reason = 'eligible_stale_request_cache'
+  ),
+  'old terminal request-cache rows are eligible'
+);
+
+select ok(
+  (
+    select row_count >= 2
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_export_items'
+      and is_eligible
+      and reason = 'eligible_parent_job_cascade'
+  ),
+  'export items follow eligible parent job lifecycle'
+);
+
+create temporary table pg_temp.package_retention_error_check (
+  case_name text primary key,
+  raised boolean not null
+);
+
+do $$
+begin
+  perform util.preview_lca_package_retention(
+    interval '12 hours',
+    interval '7 days',
+    '2026-02-01 00:00:00+00'::timestamp with time zone
+  );
+  insert into pg_temp.package_retention_error_check values ('job-window', false);
+exception when invalid_parameter_value then
+  insert into pg_temp.package_retention_error_check values ('job-window', true);
+end
+$$;
+
+do $$
+begin
+  perform util.preview_lca_package_retention(
+    interval '30 days',
+    interval '12 hours',
+    '2026-02-01 00:00:00+00'::timestamp with time zone
+  );
+  insert into pg_temp.package_retention_error_check values ('cache-window', false);
+exception when invalid_parameter_value then
+  insert into pg_temp.package_retention_error_check values ('cache-window', true);
+end
+$$;
+
+select is(
+  (select raised from pg_temp.package_retention_error_check where case_name = 'job-window'),
+  true,
+  'dry-run rejects package job retention windows shorter than one day'
+);
+
+select is(
+  (select raised from pg_temp.package_retention_error_check where case_name = 'cache-window'),
+  true,
+  'dry-run rejects request-cache retention windows shorter than one day'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.preview_lca_package_retention(interval,interval,timestamp with time zone)'),
+  'package retention dry-run function pins an empty search_path'
+);
+
+select ok(
+  lower(pg_get_functiondef('util.preview_lca_package_retention(interval,interval,timestamp with time zone)'::regprocedure)) not like '%delete from public.lca_package%'
+  and lower(pg_get_functiondef('util.preview_lca_package_retention(interval,interval,timestamp with time zone)'::regprocedure)) not like '%update public.lca_package%'
+  and lower(pg_get_functiondef('util.preview_lca_package_retention(interval,interval,timestamp with time zone)'::regprocedure)) not like '%insert into public.lca_package%',
+  'dry-run function does not contain destructive package DML'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes #148

## Summary
- Promote the dev merge for #147 into main so the package retention dry-run migration can reach the production/main Supabase integration path.

## Key Decisions
- This promote PR contains no new schema edits beyond the already merged dev PR #147.
- Keep root workspace integration separate until database-engine main and production/main Supabase verification are complete.

## Validation
- Persistent dev Supabase workflow succeeded for merge commit c2c8ec753a262695e97656d8620e6771c99d96e3.
- Persistent dev read-only verification: migration 20260529123000 exists; util.preview_lca_package_retention(...) exists and executes.
- Promote PR checks will be inspected before merge.

## Risks / Rollback
- Low: promote-only PR. Rollback would be a follow-up revert/promotion if production main validation found an issue.

## Follow-ups
- After merge, verify production/main Supabase migration state and dry-run output, then update #141/#146/#148.
- After production/main validation, perform lca-workspace submodule pointer integration.

## Workspace Integration
- Root workspace integration remains pending until database-engine main contains this promote merge.