### PR TITLE
promote: supabase_functions hooks retention to main

### DIFF
--- a/supabase/migrations/20260529124000_supabase_functions_hooks_retention.sql
+++ b/supabase/migrations/20260529124000_supabase_functions_hooks_retention.sql
@@ -1,0 +1,154 @@
+create index if not exists supabase_functions_hooks_created_at_idx
+  on supabase_functions.hooks (created_at);
+
+create or replace function util.preview_supabase_functions_hooks_retention(
+  p_retention_window interval default interval '14 days',
+  p_as_of timestamp with time zone default pg_catalog.now()
+) returns table (
+  retention_window interval,
+  cutoff_time timestamp with time zone,
+  total_rows bigint,
+  eligible_rows bigint,
+  protected_recent_rows bigint,
+  protected_live_response_rows bigint,
+  oldest_eligible_created_at timestamp with time zone,
+  newest_eligible_created_at timestamp with time zone
+)
+language plpgsql
+stable
+set search_path to ''
+as $$
+begin
+  if p_as_of is null then
+    raise exception using
+      errcode = '22023',
+      message = 'supabase functions hooks retention as_of timestamp must not be null';
+  end if;
+
+  if p_retention_window is null or p_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'supabase functions hooks retention window must be at least 1 day';
+  end if;
+
+  return query
+  with live_responses as materialized (
+    select response.id
+    from net._http_response as response
+  ), classified as (
+    select
+      hooks.created_at,
+      hooks.created_at < p_as_of - p_retention_window as is_older_than_cutoff,
+      live_responses.id is not null as has_live_pg_net_response
+    from supabase_functions.hooks as hooks
+    left join live_responses on live_responses.id = hooks.request_id
+  )
+  select
+    p_retention_window as retention_window,
+    p_as_of - p_retention_window as cutoff_time,
+    count(*)::bigint as total_rows,
+    count(*) filter (
+      where classified.is_older_than_cutoff
+        and not classified.has_live_pg_net_response
+    )::bigint as eligible_rows,
+    count(*) filter (
+      where not classified.is_older_than_cutoff
+    )::bigint as protected_recent_rows,
+    count(*) filter (
+      where classified.is_older_than_cutoff
+        and classified.has_live_pg_net_response
+    )::bigint as protected_live_response_rows,
+    min(classified.created_at) filter (
+      where classified.is_older_than_cutoff
+        and not classified.has_live_pg_net_response
+    ) as oldest_eligible_created_at,
+    max(classified.created_at) filter (
+      where classified.is_older_than_cutoff
+        and not classified.has_live_pg_net_response
+    ) as newest_eligible_created_at
+  from classified;
+end;
+$$;
+
+alter function util.preview_supabase_functions_hooks_retention(interval, timestamp with time zone) owner to postgres;
+revoke all on function util.preview_supabase_functions_hooks_retention(interval, timestamp with time zone) from public;
+grant execute on function util.preview_supabase_functions_hooks_retention(interval, timestamp with time zone) to service_role;
+
+create or replace function util.purge_supabase_functions_hooks(
+  p_retention_window interval default interval '14 days',
+  p_batch_size integer default 50000
+) returns bigint
+language plpgsql
+set search_path to ''
+as $$
+declare
+  deleted_count bigint;
+begin
+  if p_retention_window is null or p_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'supabase functions hooks retention window must be at least 1 day';
+  end if;
+
+  if p_batch_size is null or p_batch_size < 1 or p_batch_size > 100000 then
+    raise exception using
+      errcode = '22023',
+      message = 'supabase functions hooks purge batch size must be between 1 and 100000';
+  end if;
+
+  if not pg_catalog.pg_try_advisory_xact_lock(
+    pg_catalog.hashtext('util.purge_supabase_functions_hooks')
+  ) then
+    return 0;
+  end if;
+
+  with live_responses as materialized (
+    select response.id
+    from net._http_response as response
+  ), candidates as (
+    select hooks.id
+    from supabase_functions.hooks as hooks
+    left join live_responses on live_responses.id = hooks.request_id
+    where hooks.created_at < pg_catalog.now() - p_retention_window
+      and live_responses.id is null
+    order by hooks.created_at, hooks.id
+    limit p_batch_size
+    for update of hooks skip locked
+  )
+  delete from supabase_functions.hooks as hooks
+  using candidates
+  where hooks.id = candidates.id;
+
+  get diagnostics deleted_count = row_count;
+  return deleted_count;
+end;
+$$;
+
+alter function util.purge_supabase_functions_hooks(interval, integer) owner to postgres;
+revoke all on function util.purge_supabase_functions_hooks(interval, integer) from public;
+
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    begin
+      perform cron.unschedule('purge-supabase-functions-hooks');
+    exception when others then
+      null;
+    end;
+
+    perform cron.schedule(
+      'purge-supabase-functions-hooks',
+      '47 3 * * *',
+      $cron$
+        select util.purge_supabase_functions_hooks(interval '14 days', 50000);
+      $cron$
+    );
+  end if;
+end
+$$;
+
+comment on function util.preview_supabase_functions_hooks_retention(interval, timestamp with time zone) is
+  'Operator dry-run helper for Supabase Functions webhook audit retention; reports rows older than the retention window while protecting recent rows and rows still linked to live pg_net responses.';
+
+comment on function util.purge_supabase_functions_hooks(interval, integer) is
+  'Deletes Supabase Functions webhook audit rows older than the retention window in bounded batches while protecting rows still linked to live pg_net responses.';

--- a/supabase/tests/20260529_supabase_functions_hooks_retention.sql
+++ b/supabase/tests/20260529_supabase_functions_hooks_retention.sql
@@ -1,0 +1,301 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create or replace function pg_temp.has_empty_search_path(p_signature text)
+returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from pg_proc p
+    cross join lateral unnest(coalesce(p.proconfig, array[]::text[])) as config(setting)
+    where p.oid = p_signature::regprocedure
+      and config.setting in ('search_path=', 'search_path=""')
+  );
+$$;
+
+select plan(24);
+
+select ok(
+  to_regclass('supabase_functions.hooks') is not null,
+  'supabase_functions.hooks audit table exists'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_indexes
+    where schemaname = 'supabase_functions'
+      and tablename = 'hooks'
+      and indexname = 'supabase_functions_hooks_created_at_idx'
+  ),
+  'supabase_functions hooks retention has a created_at index'
+);
+
+select ok(
+  to_regprocedure('util.preview_supabase_functions_hooks_retention(interval,timestamp with time zone)') is not null,
+  'supabase functions hooks retention preview function exists'
+);
+
+select ok(
+  to_regprocedure('util.purge_supabase_functions_hooks(interval,integer)') is not null,
+  'supabase functions hooks retention purge function exists'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'util.preview_supabase_functions_hooks_retention(interval,timestamp with time zone)',
+    'EXECUTE'
+  ),
+  'service_role can execute supabase functions hooks retention preview'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from cron.job
+    where jobname = 'purge-supabase-functions-hooks'
+  ),
+  1,
+  'purge-supabase-functions-hooks is scheduled exactly once'
+);
+
+select is(
+  (
+    select schedule
+    from cron.job
+    where jobname = 'purge-supabase-functions-hooks'
+  ),
+  '47 3 * * *',
+  'purge-supabase-functions-hooks uses the daily low-frequency cadence'
+);
+
+select is(
+  (
+    select active
+    from cron.job
+    where jobname = 'purge-supabase-functions-hooks'
+  ),
+  true,
+  'purge-supabase-functions-hooks is active'
+);
+
+select ok(
+  (
+    select command like '%util.purge_supabase_functions_hooks%'
+      and command like '%14 days%'
+      and command like '%50000%'
+    from cron.job
+    where jobname = 'purge-supabase-functions-hooks'
+  ),
+  'purge-supabase-functions-hooks uses the 14 day retention window and bounded batch size'
+);
+
+delete from supabase_functions.hooks
+where hook_name like 'pgtap_hooks_retention_%';
+
+delete from net._http_response
+where id in (-9151013);
+
+insert into net._http_response (
+  id,
+  status_code,
+  content_type,
+  headers,
+  content,
+  timed_out,
+  error_msg,
+  created
+) values (
+  -9151013,
+  200,
+  'application/json',
+  '{}'::jsonb,
+  '{}',
+  false,
+  null,
+  pg_catalog.now()
+);
+
+insert into supabase_functions.hooks (
+  hook_table_id,
+  hook_name,
+  created_at,
+  request_id
+) values
+  (
+    9151001,
+    'pgtap_hooks_retention_old_eligible_1',
+    timestamp with time zone '2000-01-01 00:00:00+00',
+    -9151011
+  ),
+  (
+    9151001,
+    'pgtap_hooks_retention_old_eligible_2',
+    timestamp with time zone '2000-01-02 00:00:00+00',
+    -9151012
+  ),
+  (
+    9151001,
+    'pgtap_hooks_retention_old_live_response',
+    timestamp with time zone '2000-01-03 00:00:00+00',
+    -9151013
+  ),
+  (
+    9151001,
+    'pgtap_hooks_retention_recent',
+    pg_catalog.now() - interval '1 day',
+    -9151014
+  );
+
+create temporary table pg_temp.hooks_retention_preview as
+select *
+from util.preview_supabase_functions_hooks_retention(
+  interval '14 days',
+  pg_catalog.now()
+);
+
+select ok(
+  (select total_rows >= 4 from pg_temp.hooks_retention_preview),
+  'preview reports at least the inserted hooks audit rows'
+);
+
+select ok(
+  (select eligible_rows >= 2 from pg_temp.hooks_retention_preview),
+  'preview reports old hooks without live pg_net responses as eligible'
+);
+
+select ok(
+  (select protected_recent_rows >= 1 from pg_temp.hooks_retention_preview),
+  'preview protects hooks inside the retention window'
+);
+
+select ok(
+  (select protected_live_response_rows >= 1 from pg_temp.hooks_retention_preview),
+  'preview protects old hooks still linked to live pg_net responses'
+);
+
+create temporary table pg_temp.hooks_retention_first_purge as
+select util.purge_supabase_functions_hooks(interval '14 days', 1) as deleted_rows;
+
+select is(
+  (select deleted_rows from pg_temp.hooks_retention_first_purge),
+  1::bigint,
+  'purge respects the requested batch size'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from supabase_functions.hooks
+    where hook_name = 'pgtap_hooks_retention_old_eligible_2'
+  ),
+  1,
+  'first bounded purge leaves the later old eligible row for the next batch'
+);
+
+create temporary table pg_temp.hooks_retention_second_purge as
+select util.purge_supabase_functions_hooks(interval '14 days', 100) as deleted_rows;
+
+select ok(
+  (select deleted_rows >= 1 from pg_temp.hooks_retention_second_purge),
+  'second purge deletes remaining old eligible hooks'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from supabase_functions.hooks
+    where hook_name like 'pgtap_hooks_retention_old_eligible_%'
+  ),
+  0,
+  'purge deletes old hooks without live pg_net responses'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from supabase_functions.hooks
+    where hook_name = 'pgtap_hooks_retention_old_live_response'
+  ),
+  1,
+  'purge keeps old hooks still linked to live pg_net responses'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from supabase_functions.hooks
+    where hook_name = 'pgtap_hooks_retention_recent'
+  ),
+  1,
+  'purge keeps hooks inside the retention window'
+);
+
+create temporary table pg_temp.hooks_retention_error_check (
+  case_name text primary key,
+  raised boolean not null
+);
+
+do $$
+begin
+  perform util.purge_supabase_functions_hooks(interval '12 hours', 100);
+  insert into pg_temp.hooks_retention_error_check values ('purge-window', false);
+exception when invalid_parameter_value then
+  insert into pg_temp.hooks_retention_error_check values ('purge-window', true);
+end
+$$;
+
+do $$
+begin
+  perform util.purge_supabase_functions_hooks(interval '14 days', 0);
+  insert into pg_temp.hooks_retention_error_check values ('purge-batch', false);
+exception when invalid_parameter_value then
+  insert into pg_temp.hooks_retention_error_check values ('purge-batch', true);
+end
+$$;
+
+do $$
+begin
+  perform util.preview_supabase_functions_hooks_retention(interval '14 days', null);
+  insert into pg_temp.hooks_retention_error_check values ('preview-as-of', false);
+exception when invalid_parameter_value then
+  insert into pg_temp.hooks_retention_error_check values ('preview-as-of', true);
+end
+$$;
+
+select is(
+  (select raised from pg_temp.hooks_retention_error_check where case_name = 'purge-window'),
+  true,
+  'purge rejects retention windows shorter than one day'
+);
+
+select is(
+  (select raised from pg_temp.hooks_retention_error_check where case_name = 'purge-batch'),
+  true,
+  'purge rejects invalid batch sizes'
+);
+
+select is(
+  (select raised from pg_temp.hooks_retention_error_check where case_name = 'preview-as-of'),
+  true,
+  'preview rejects null as_of timestamps'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.preview_supabase_functions_hooks_retention(interval,timestamp with time zone)'),
+  'supabase functions hooks retention preview function pins an empty search_path'
+);
+
+select ok(
+  pg_temp.has_empty_search_path('util.purge_supabase_functions_hooks(interval,integer)'),
+  'supabase functions hooks retention purge function pins an empty search_path'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
Closes #153

## Summary
- Promote the dev merge for #152 into main so the supabase_functions.hooks retention migration can reach the production/main Supabase integration path.

## Key Decisions
- This promote PR contains no new schema edits beyond the already merged dev PR #152.
- Keep root workspace integration separate until database-engine main and production/main Supabase verification are complete.

## Validation
- Persistent dev Supabase workflow succeeded for merge commit fc4c82a2a426ef6448405386113e1f646f9518f0.
- Persistent dev read-only verification: migration 20260529124000 exists; util.preview_supabase_functions_hooks_retention(...) and util.purge_supabase_functions_hooks(...) exist; created_at index exists; purge-supabase-functions-hooks cron is active; preview helper executes.

## Risks / Rollback
- Low: promote-only PR. Rollback would be a follow-up revert/promotion if production main validation found an issue.

## Follow-ups
- After merge, verify production/main Supabase migration state, retention helpers, cron job, and dry-run output, then update #141/#151/#153.
- After production/main validation, perform lca-workspace submodule pointer integration.

## Workspace Integration
- Root workspace integration remains pending until database-engine main contains this promote merge.