### PR TITLE
promote: package retention preview alignment to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-29"
-lastReviewedCommit: "7fedf008e4417a7e0ff7e18f5b24fb098f88cb47"
+lastReviewedAt: "2026-05-30"
+lastReviewedCommit: "fc4c82a2a426ef6448405386113e1f646f9518f0"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 7fedf008e4417a7e0ff7e18f5b24fb098f88cb47
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: fc4c82a2a426ef6448405386113e1f646f9518f0
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 7fedf008e4417a7e0ff7e18f5b24fb098f88cb47
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: fc4c82a2a426ef6448405386113e1f646f9518f0
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: 7fedf008e4417a7e0ff7e18f5b24fb098f88cb47
+lastReviewedAt: 2026-05-30
+lastReviewedCommit: fc4c82a2a426ef6448405386113e1f646f9518f0
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260530114846_align_package_retention_preview_object_protection.sql
+++ b/supabase/migrations/20260530114846_align_package_retention_preview_object_protection.sql
@@ -1,0 +1,236 @@
+create or replace function util.preview_lca_package_retention(
+  p_job_retention_window interval default interval '30 days',
+  p_request_cache_retention_window interval default interval '30 days',
+  p_as_of timestamp with time zone default pg_catalog.now()
+) returns table (
+  retention_area text,
+  retention_action text,
+  is_eligible boolean,
+  reason text,
+  retention_window interval,
+  cutoff_time timestamp with time zone,
+  row_count bigint,
+  total_artifact_bytes bigint,
+  total_hit_count bigint,
+  oldest_observed_at timestamp with time zone,
+  newest_observed_at timestamp with time zone
+)
+language plpgsql
+stable
+set search_path to ''
+as $$
+begin
+  if p_as_of is null then
+    raise exception using
+      errcode = '22023',
+      message = 'package retention dry-run as_of timestamp must not be null';
+  end if;
+
+  if p_job_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'package job retention window must be at least 1 day';
+  end if;
+
+  if p_request_cache_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'package request-cache retention window must be at least 1 day';
+  end if;
+
+  return query
+  with job_rollup as (
+    select
+      jobs.id,
+      jobs.status,
+      coalesce(jobs.finished_at, jobs.updated_at, jobs.created_at) as lifecycle_at,
+      coalesce(
+        bool_or(artifacts.id is not null and artifacts.status <> 'deleted'),
+        false
+      ) as has_object_not_deleted,
+      exists (
+        select 1
+        from public.lca_package_artifacts as recent_artifact
+        join public.lca_package_request_cache as recent_cache
+          on recent_cache.export_artifact_id = recent_artifact.id
+          or recent_cache.report_artifact_id = recent_artifact.id
+        where recent_artifact.job_id = jobs.id
+          and recent_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window
+      ) as has_recent_artifact_cache,
+      coalesce(
+        sum(coalesce(artifacts.artifact_byte_size, 0))
+          filter (where artifacts.status <> 'deleted'),
+        0
+      )::bigint as artifact_bytes
+    from public.lca_package_jobs as jobs
+    left join public.lca_package_artifacts as artifacts
+      on artifacts.job_id = jobs.id
+    group by jobs.id
+  ),
+  job_classified as (
+    select
+      'lca_package_jobs'::text as retention_area,
+      'delete_job_metadata_cascade_after_artifact_gc'::text as retention_action,
+      (classified.reason = 'eligible_terminal_job_older_than_window') as is_eligible,
+      classified.reason,
+      p_job_retention_window as retention_window,
+      p_as_of - p_job_retention_window as cutoff_time,
+      1::bigint as row_count,
+      classified.artifact_bytes as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      classified.lifecycle_at as observed_at
+    from (
+      select
+        job_rollup.*,
+        case
+          when job_rollup.status in ('queued', 'running') then 'protected_active_job'
+          when job_rollup.status not in ('ready', 'completed', 'failed', 'stale') then 'protected_unknown_job_status'
+          when job_rollup.lifecycle_at >= p_as_of - p_job_retention_window then 'protected_inside_job_retention_window'
+          when job_rollup.has_object_not_deleted then 'protected_object_not_deleted'
+          when job_rollup.has_recent_artifact_cache then 'protected_recent_request_cache_reference'
+          else 'eligible_terminal_job_older_than_window'
+        end as reason
+      from job_rollup
+    ) as classified
+  ),
+  artifact_classified as (
+    select
+      'lca_package_artifacts'::text as retention_area,
+      'delete_object_then_mark_deleted'::text as retention_action,
+      (classified.reason = 'eligible_expired_unpinned_artifact') as is_eligible,
+      classified.reason,
+      null::interval as retention_window,
+      p_as_of as cutoff_time,
+      1::bigint as row_count,
+      coalesce(classified.artifact_byte_size, 0)::bigint as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      coalesce(classified.expires_at, classified.updated_at, classified.created_at) as observed_at
+    from (
+      select
+        artifacts.*,
+        jobs.status as parent_job_status,
+        coalesce(recent_cache.recent_cache_rows, 0) as recent_cache_rows,
+        case
+          when jobs.id is null then 'protected_missing_parent_job'
+          when artifacts.is_pinned then 'protected_pinned_artifact'
+          when artifacts.status = 'deleted' then 'protected_already_deleted'
+          when artifacts.status = 'pending' then 'protected_artifact_not_ready'
+          when jobs.status in ('queued', 'running') then 'protected_active_parent_job'
+          when artifacts.expires_at is null then 'protected_missing_expires_at'
+          when artifacts.expires_at > p_as_of then 'protected_expires_at_in_future'
+          when coalesce(recent_cache.recent_cache_rows, 0) > 0 then 'protected_recent_request_cache_reference'
+          else 'eligible_expired_unpinned_artifact'
+        end as reason
+      from public.lca_package_artifacts as artifacts
+      left join public.lca_package_jobs as jobs
+        on jobs.id = artifacts.job_id
+      left join lateral (
+        select count(*)::bigint as recent_cache_rows
+        from public.lca_package_request_cache as request_cache
+        where (
+            request_cache.export_artifact_id = artifacts.id
+            or request_cache.report_artifact_id = artifacts.id
+          )
+          and request_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window
+      ) as recent_cache on true
+    ) as classified
+  ),
+  request_cache_classified as (
+    select
+      'lca_package_request_cache'::text as retention_area,
+      'delete_stale_request_cache_row'::text as retention_action,
+      (classified.reason = 'eligible_stale_request_cache') as is_eligible,
+      classified.reason,
+      p_request_cache_retention_window as retention_window,
+      p_as_of - p_request_cache_retention_window as cutoff_time,
+      1::bigint as row_count,
+      0::bigint as total_artifact_bytes,
+      classified.hit_count::bigint as total_hit_count,
+      classified.last_accessed_at as observed_at
+    from (
+      select
+        request_cache.*,
+        jobs.status as parent_job_status,
+        case
+          when request_cache.status in ('pending', 'running') then 'protected_active_request_cache'
+          when request_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window then 'protected_recent_request_cache_access'
+          when jobs.status in ('queued', 'running') then 'protected_active_parent_job'
+          else 'eligible_stale_request_cache'
+        end as reason
+      from public.lca_package_request_cache as request_cache
+      left join public.lca_package_jobs as jobs
+        on jobs.id = request_cache.job_id
+    ) as classified
+  ),
+  export_item_classified as (
+    select
+      'lca_package_export_items'::text as retention_area,
+      'delete_export_items_with_parent_job'::text as retention_action,
+      (classified.reason = 'eligible_parent_job_cascade') as is_eligible,
+      classified.reason,
+      p_job_retention_window as retention_window,
+      p_as_of - p_job_retention_window as cutoff_time,
+      1::bigint as row_count,
+      0::bigint as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      classified.created_at as observed_at
+    from (
+      select
+        export_items.*,
+        case
+          when job_rollup.id is null then 'protected_missing_parent_job'
+          when job_rollup.status in ('queued', 'running') then 'protected_active_parent_job'
+          when job_rollup.status not in ('ready', 'completed', 'failed', 'stale') then 'protected_unknown_parent_job_status'
+          when job_rollup.lifecycle_at >= p_as_of - p_job_retention_window then 'protected_parent_inside_job_retention_window'
+          when job_rollup.has_object_not_deleted then 'protected_object_not_deleted'
+          when job_rollup.has_recent_artifact_cache then 'protected_recent_request_cache_reference'
+          else 'eligible_parent_job_cascade'
+        end as reason
+      from public.lca_package_export_items as export_items
+      left join job_rollup
+        on job_rollup.id = export_items.job_id
+    ) as classified
+  ),
+  classified as (
+    select * from job_classified
+    union all
+    select * from artifact_classified
+    union all
+    select * from request_cache_classified
+    union all
+    select * from export_item_classified
+  )
+  select
+    classified.retention_area,
+    classified.retention_action,
+    classified.is_eligible,
+    classified.reason,
+    classified.retention_window,
+    classified.cutoff_time,
+    sum(classified.row_count)::bigint as row_count,
+    coalesce(sum(classified.total_artifact_bytes), 0)::bigint as total_artifact_bytes,
+    coalesce(sum(classified.total_hit_count), 0)::bigint as total_hit_count,
+    min(classified.observed_at) as oldest_observed_at,
+    max(classified.observed_at) as newest_observed_at
+  from classified
+  group by
+    classified.retention_area,
+    classified.retention_action,
+    classified.is_eligible,
+    classified.reason,
+    classified.retention_window,
+    classified.cutoff_time
+  order by
+    classified.retention_area,
+    classified.is_eligible desc,
+    classified.reason;
+end;
+$$;
+
+alter function util.preview_lca_package_retention(interval, interval, timestamp with time zone) owner to postgres;
+revoke all on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) from public;
+grant usage on schema util to service_role;
+grant execute on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) to service_role;
+
+comment on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) is
+  'Operator dry-run helper for package metadata retention; reports aggregate eligible/protected counts for package jobs, artifacts, request cache, and export items without deleting or updating business rows. Parent job/export-item metadata is protected while any artifact object has not completed object-aware GC.';

--- a/supabase/tests/20260529_lca_package_retention_dry_run.sql
+++ b/supabase/tests/20260529_lca_package_retention_dry_run.sql
@@ -17,7 +17,7 @@ as $$
   );
 $$;
 
-select plan(16);
+select plan(22);
 
 select ok(
   to_regprocedure('util.preview_lca_package_retention(interval,interval,timestamp with time zone)') is not null,
@@ -98,6 +98,39 @@ insert into public.lca_package_jobs (
     '2025-12-01 00:00:00+00',
     '2025-12-01 00:00:00+00',
     '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000006',
+    'export_package',
+    'ready',
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '91460000-0000-4000-8000-000000000100',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000007',
+    'export_package',
+    'ready',
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '91460000-0000-4000-8000-000000000100',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000008',
+    'export_package',
+    'ready',
+    '{}'::jsonb,
+    '{}'::jsonb,
+    '91460000-0000-4000-8000-000000000100',
+    '2026-01-25 00:00:00+00',
+    '2026-01-25 00:00:00+00',
+    '2026-01-25 00:00:00+00'
   );
 
 insert into public.lca_package_artifacts (
@@ -163,6 +196,38 @@ insert into public.lca_package_artifacts (
     false,
     '2025-12-01 00:00:00+00',
     '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000106',
+    '91460000-0000-4000-8000-000000000006',
+    'export_zip',
+    'deleted',
+    'storage://package/deleted.zip',
+    null,
+    40,
+    'tidas-package-zip:v1',
+    'application/zip',
+    '{}'::jsonb,
+    '2025-12-15 00:00:00+00',
+    false,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000107',
+    '91460000-0000-4000-8000-000000000007',
+    'export_zip',
+    'ready',
+    'storage://package/pinned.zip',
+    null,
+    50,
+    'tidas-package-zip:v1',
+    'application/zip',
+    '{}'::jsonb,
+    '2025-12-15 00:00:00+00',
+    true,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
   );
 
 insert into public.lca_package_export_items (
@@ -219,6 +284,50 @@ insert into public.lca_package_export_items (
     true,
     '2025-12-01 00:00:00+00',
     '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000205',
+    '91460000-0000-4000-8000-000000000005',
+    'processes',
+    '91460000-0000-4000-8000-000000000305',
+    '000000001',
+    false,
+    true,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000206',
+    '91460000-0000-4000-8000-000000000006',
+    'processes',
+    '91460000-0000-4000-8000-000000000306',
+    '000000001',
+    false,
+    true,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000207',
+    '91460000-0000-4000-8000-000000000007',
+    'processes',
+    '91460000-0000-4000-8000-000000000307',
+    '000000001',
+    false,
+    true,
+    '2025-12-01 00:00:00+00',
+    '2025-12-01 00:00:00+00'
+  ),
+  (
+    '91460000-0000-4000-8000-000000000208',
+    '91460000-0000-4000-8000-000000000008',
+    'processes',
+    '91460000-0000-4000-8000-000000000308',
+    '000000001',
+    false,
+    true,
+    '2026-01-25 00:00:00+00',
+    '2026-01-25 00:00:00+00'
   );
 
 insert into public.lca_package_request_cache (
@@ -319,7 +428,19 @@ select ok(
       and is_eligible
       and reason = 'eligible_terminal_job_older_than_window'
   ),
-  'old terminal jobs without protected artifacts are eligible'
+  'old terminal jobs with no remaining object work are eligible'
+);
+
+select ok(
+  (
+    select row_count >= 4
+      and total_artifact_bytes >= 110
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_jobs'
+      and not is_eligible
+      and reason = 'protected_object_not_deleted'
+  ),
+  'jobs with non-deleted artifact rows are protected until object-aware GC completes'
 );
 
 select ok(
@@ -328,9 +449,9 @@ select ok(
     from pg_temp.package_retention_preview
     where retention_area = 'lca_package_jobs'
       and not is_eligible
-      and reason = 'protected_artifact_not_expired'
+      and reason = 'protected_inside_job_retention_window'
   ),
-  'jobs with attached missing-expiry artifacts are protected'
+  'recent terminal jobs are protected by the job retention window'
 );
 
 select ok(
@@ -339,9 +460,9 @@ select ok(
     from pg_temp.package_retention_preview
     where retention_area = 'lca_package_jobs'
       and not is_eligible
-      and reason = 'protected_recent_request_cache_reference'
+      and reason = 'protected_active_job'
   ),
-  'jobs with recently referenced artifacts are protected'
+  'active package jobs are protected'
 );
 
 select ok(
@@ -381,6 +502,28 @@ select ok(
 select ok(
   (
     select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_artifacts'
+      and not is_eligible
+      and reason = 'protected_pinned_artifact'
+  ),
+  'pinned artifacts are protected'
+);
+
+select ok(
+  (
+    select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_artifacts'
+      and not is_eligible
+      and reason = 'protected_already_deleted'
+  ),
+  'deleted artifacts are reported as already deleted'
+);
+
+select ok(
+  (
+    select row_count >= 1
       and total_hit_count >= 3
     from pg_temp.package_retention_preview
     where retention_area = 'lca_package_request_cache'
@@ -409,7 +552,40 @@ select ok(
       and is_eligible
       and reason = 'eligible_parent_job_cascade'
   ),
-  'export items follow eligible parent job lifecycle'
+  'export items follow parent jobs with no remaining object work'
+);
+
+select ok(
+  (
+    select row_count >= 4
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_export_items'
+      and not is_eligible
+      and reason = 'protected_object_not_deleted'
+  ),
+  'export items are protected while the parent job still has non-deleted artifacts'
+);
+
+select ok(
+  (
+    select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_export_items'
+      and not is_eligible
+      and reason = 'protected_active_parent_job'
+  ),
+  'export items with active parent jobs are protected'
+);
+
+select ok(
+  (
+    select row_count >= 1
+    from pg_temp.package_retention_preview
+    where retention_area = 'lca_package_export_items'
+      and not is_eligible
+      and reason = 'protected_parent_inside_job_retention_window'
+  ),
+  'export items with recent parent jobs are protected by the job retention window'
 );
 
 create temporary table pg_temp.package_retention_error_check (


### PR DESCRIPTION
Closes #158

## Summary
- Promote the dev merge for #157 into main so the package retention preview alignment migration can reach the production/main Supabase integration path.

## Key Decisions
- This promote PR contains no new schema edits beyond the already merged dev PR #157.
- The promote range was checked before opening: `origin/main..origin/dev` only contains merge commit `8a9ecac` for #157.
- Keep root workspace integration separate until database-engine main and production/main Supabase verification are complete.

## Validation
- Persistent dev Supabase workflow succeeded for merge commit `8a9ecac04b3c68f5caf2d9d30624c44630e8ecb4`.
- `supabase db reset`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -f supabase/tests/20260529_lca_package_retention_dry_run.sql`
- `supabase migration list --local` includes `20260530114846`.
- `git diff origin/main..HEAD --check`
- `scripts/docpact lint --root . --worktree --mode enforce --base origin/main`

## Risks / Rollback
- Low: promote-only PR. Rollback would be a follow-up revert/promotion if production main validation found an issue.

## Follow-ups
- After merge, verify production/main Supabase migration state and `util.preview_lca_package_retention(...)` behavior, then update #141/#156/#158.
- After production/main validation, perform lca-workspace submodule pointer integration.

## Workspace Integration
- Root workspace integration remains pending until database-engine main contains this promote merge and production/main validation is recorded.