### PR TITLE
fix: extend UUID mention search timeout

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-31"
-lastReviewedCommit: "daba3dff4a09b2191a00de2e05ef03f47f864d97"
+lastReviewedAt: "2026-06-01"
+lastReviewedCommit: "83846ec81ca1fa298d5d3619beb0f39af61ced2a"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-31
-lastReviewedCommit: daba3dff4a09b2191a00de2e05ef03f47f864d97
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 83846ec81ca1fa298d5d3619beb0f39af61ced2a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-31
-lastReviewedCommit: daba3dff4a09b2191a00de2e05ef03f47f864d97
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 83846ec81ca1fa298d5d3619beb0f39af61ced2a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-31
-lastReviewedCommit: daba3dff4a09b2191a00de2e05ef03f47f864d97
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: 83846ec81ca1fa298d5d3619beb0f39af61ced2a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260601104414_extend_dataset_json_uuid_timeout.sql
+++ b/supabase/migrations/20260601104414_extend_dataset_json_uuid_timeout.sql
@@ -1,0 +1,9 @@
+-- Extend the bounded timeout for UUID mention lookups. Large flow JSON payloads
+-- can exceed the original 8s budget while still being acceptable for this
+-- explicit, low-frequency lookup path.
+
+alter function private.search_dataset_json_uuid_mentions_impl(uuid, text[], text, text, uuid, integer, integer)
+  set statement_timeout to '20s';
+
+alter function public.search_dataset_json_uuid_mentions(uuid, text[], text, text, uuid, integer, integer)
+  set statement_timeout to '20s';

--- a/supabase/tests/20260529_dataset_json_uuid_deep_search.sql
+++ b/supabase/tests/20260529_dataset_json_uuid_deep_search.sql
@@ -40,8 +40,10 @@ select ok(
 
 select ok(
   strpos(pg_get_functiondef('private.search_dataset_json_uuid_mentions_impl(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), 'statement_timeout') > 0
-    and strpos(pg_get_functiondef('private.search_dataset_json_uuid_mentions_impl(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), '8s') > 0,
-  'JSON UUID mention RPC has bounded statement timeout'
+    and strpos(pg_get_functiondef('private.search_dataset_json_uuid_mentions_impl(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), '20s') > 0
+    and strpos(pg_get_functiondef('public.search_dataset_json_uuid_mentions(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), 'statement_timeout') > 0
+    and strpos(pg_get_functiondef('public.search_dataset_json_uuid_mentions(uuid,text[],text,text,uuid,integer,integer)'::regprocedure), '20s') > 0,
+  'JSON UUID mention RPC has bounded 20s statement timeout'
 );
 
 insert into auth.users (


### PR DESCRIPTION
## 概要
- 新增 migration，将 `search_dataset_json_uuid_mentions` 相关 private/public 函数的 `statement_timeout` 从 8s 延长到 20s
- 更新 JSON UUID mention search 的 pgTAP 断言，确认 private/public 函数都使用 20s timeout
- 刷新 docpact 要求的治理文档 review metadata

## 校验
- `git diff --check`
- `scripts/docpact lint --root . --files "supabase/migrations/20260601104414_extend_dataset_json_uuid_timeout.sql,supabase/tests/20260529_dataset_json_uuid_deep_search.sql,.docpact/config.yaml,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,AGENTS.md" --mode enforce`
- `scripts/docpact validate-config --root . --strict`

## 未跑
- `supabase db reset` / pgTAP SQL assertions：当前本地环境没有 `supabase` CLI 和 `psql`。