### PR TITLE
fix: schedule review-submit coordinator

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "83846ec81ca1fa298d5d3619beb0f39af61ced2a"
+lastReviewedCommit: "75d6fca4daf13059dc72aeb5c172b938535367b3"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 83846ec81ca1fa298d5d3619beb0f39af61ced2a
+lastReviewedCommit: 75d6fca4daf13059dc72aeb5c172b938535367b3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 83846ec81ca1fa298d5d3619beb0f39af61ced2a
+lastReviewedCommit: 75d6fca4daf13059dc72aeb5c172b938535367b3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-01
-lastReviewedCommit: 83846ec81ca1fa298d5d3619beb0f39af61ced2a
+lastReviewedCommit: 75d6fca4daf13059dc72aeb5c172b938535367b3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260601043000_review_submit_worker_coordinator_cron.sql
+++ b/supabase/migrations/20260601043000_review_submit_worker_coordinator_cron.sql
@@ -1,0 +1,89 @@
+alter table public.unitgroups
+  drop constraint if exists unitgroups_state_code_check;
+
+alter table public.unitgroups
+  add constraint unitgroups_state_code_check
+  check (state_code in (0, 20, 100, 200));
+
+create or replace function util.invoke_edge_function(
+  name text,
+  body jsonb,
+  timeout_milliseconds integer default ((5 * 60) * 1000)
+) returns void
+language plpgsql
+security definer
+set search_path to ''
+as $$
+declare
+  service_key text;
+begin
+  service_key := util.project_secret_key();
+
+  perform net.http_post(
+    url => util.project_url() || '/functions/v1/' || name,
+    headers => jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || service_key,
+      'apikey', service_key,
+      'x_region', 'us-east-1'
+    ),
+    body => body,
+    timeout_milliseconds => timeout_milliseconds
+  );
+end;
+$$;
+
+alter function util.invoke_edge_function(text, jsonb, integer) owner to postgres;
+
+create or replace function util.process_dataset_review_submit_jobs(
+  batch_size integer default 10,
+  stale_submitting_seconds integer default 300,
+  timeout_milliseconds integer default 60000
+) returns void
+language plpgsql
+security definer
+set search_path to ''
+as $$
+begin
+  if coalesce(batch_size, 0) <= 0 then
+    return;
+  end if;
+
+  if not pg_try_advisory_xact_lock(hashtext('util.process_dataset_review_submit_jobs')) then
+    return;
+  end if;
+
+  perform util.invoke_edge_function(
+    name => 'process_dataset_review_submit_jobs',
+    body => jsonb_build_object(
+      'batchSize', least(greatest(batch_size, 1), 50),
+      'staleSubmittingSeconds', least(greatest(coalesce(stale_submitting_seconds, 300), 1), 3600)
+    ),
+    timeout_milliseconds => least(greatest(coalesce(timeout_milliseconds, 60000), 1000), 300000)
+  );
+end;
+$$;
+
+alter function util.process_dataset_review_submit_jobs(integer, integer, integer) owner to postgres;
+revoke all on function util.process_dataset_review_submit_jobs(integer, integer, integer) from public;
+
+do $$
+begin
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    begin
+      perform cron.unschedule('process-dataset-review-submit-jobs');
+    exception when others then
+      null;
+    end;
+
+    perform cron.schedule(
+      'process-dataset-review-submit-jobs',
+      '* * * * *',
+      'select util.process_dataset_review_submit_jobs();'
+    );
+  end if;
+end
+$$;
+
+comment on function util.process_dataset_review_submit_jobs(integer, integer, integer) is
+  'Invokes the Edge review-submit coordinator that advances persisted dataset_review_submit_jobs after calculator worker gate results are available.';

--- a/supabase/tests/20260601_review_submit_worker_coordinator_cron.sql
+++ b/supabase/tests/20260601_review_submit_worker_coordinator_cron.sql
@@ -1,0 +1,55 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(4);
+
+select ok(
+  strpos(
+    pg_get_constraintdef(
+      (
+        select oid
+        from pg_constraint
+        where conrelid = 'public.unitgroups'::regclass
+          and conname = 'unitgroups_state_code_check'
+      )
+    ),
+    '20'
+  ) > 0,
+  'unitgroups state_code constraint allows under-review state 20'
+);
+
+select ok(
+  strpos(
+    pg_get_functiondef('util.invoke_edge_function(text,jsonb,integer)'::regprocedure),
+    '''Authorization'''
+  ) > 0
+    and strpos(
+      pg_get_functiondef('util.invoke_edge_function(text,jsonb,integer)'::regprocedure),
+      '''Bearer '' || service_key'
+    ) > 0,
+  'database Edge invocations include Authorization bearer service key header'
+);
+
+select ok(
+  to_regprocedure('util.process_dataset_review_submit_jobs(integer,integer,integer)') is not null,
+  'review-submit coordinator cron wrapper exists'
+);
+
+select ok(
+  case
+    when exists (select 1 from pg_extension where extname = 'pg_cron') then
+      exists (
+        select 1
+        from cron.job
+        where jobname = 'process-dataset-review-submit-jobs'
+          and command = 'select util.process_dataset_review_submit_jobs();'
+      )
+    else true
+  end,
+  'review-submit coordinator cron is scheduled when pg_cron is available'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- Allow `unitgroups.state_code = 20` so review-submit final submit can move draft unit group dependencies into under-review state without constraint failures.
- Add `util.process_dataset_review_submit_jobs()` and a pg_cron schedule to invoke the Edge review-submit coordinator every minute.
- Update `util.invoke_edge_function()` to send both `Authorization: Bearer <service_key>` and `apikey`, so DB-originated Edge calls work when the remote gateway requires an Authorization header.

## Context
- Closes #163
- Refs tiangong-lca/workspace#217
- Refs linancn/tiangong-lca-edge-functions#153

## Validation
- `supabase db reset`
- `supabase test db supabase/tests/20260601_review_submit_worker_coordinator_cron.sql supabase/tests/20260529_review_submit_jobs.sql supabase/tests/20260531_worker_jobs_foundation.sql`
- `supabase test db supabase/tests/20260404_review_submit_rpc.sql supabase/tests/20260405_review_workflow_rpcs.sql`
- `supabase test db` (42 files / 702 tests)
- `supabase migration list --local`
- `git diff --check`
- `scripts/docpact validate-config --root . --strict --format json`
- `scripts/docpact lint --root . --worktree --mode enforce --format json`

## Rollout Notes
- After merge to `dev`, apply the migration to the persistent dev Supabase branch and verify `cron.job` contains `process-dataset-review-submit-jobs`.
- After Edge `process_dataset_review_submit_jobs` is deployed with service auth configured, passed gate jobs should advance from `waiting_gate` to `submitted` without browser participation.
