### PR TITLE
chore: add legacy table retirement audit

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "40a09eba7788999b38ee55b3a056ab30da09d3fc"
+lastReviewedCommit: "8585e5c517b4b9b14dca6ca3edcbda2d35a9be50"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 40a09eba7788999b38ee55b3a056ab30da09d3fc
+lastReviewedCommit: 8585e5c517b4b9b14dca6ca3edcbda2d35a9be50
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 40a09eba7788999b38ee55b3a056ab30da09d3fc
+lastReviewedCommit: 8585e5c517b4b9b14dca6ca3edcbda2d35a9be50
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 40a09eba7788999b38ee55b3a056ab30da09d3fc
+lastReviewedCommit: 8585e5c517b4b9b14dca6ca3edcbda2d35a9be50
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260529124000_supabase_functions_hooks_retention.sql
+++ b/supabase/migrations/20260529124000_supabase_functions_hooks_retention.sql
@@ -1,5 +1,10 @@
-create index if not exists supabase_functions_hooks_created_at_idx
-  on supabase_functions.hooks (created_at);
+do $$
+begin
+  if to_regclass('supabase_functions.hooks') is not null then
+    execute 'create index if not exists supabase_functions_hooks_created_at_idx on supabase_functions.hooks (created_at)';
+  end if;
+end
+$$;
 
 create or replace function util.preview_supabase_functions_hooks_retention(
   p_retention_window interval default interval '14 days',
@@ -29,6 +34,20 @@ begin
     raise exception using
       errcode = '22023',
       message = 'supabase functions hooks retention window must be at least 1 day';
+  end if;
+
+  if to_regclass('supabase_functions.hooks') is null then
+    return query
+    select
+      p_retention_window as retention_window,
+      p_as_of - p_retention_window as cutoff_time,
+      0::bigint as total_rows,
+      0::bigint as eligible_rows,
+      0::bigint as protected_recent_rows,
+      0::bigint as protected_live_response_rows,
+      null::timestamp with time zone as oldest_eligible_created_at,
+      null::timestamp with time zone as newest_eligible_created_at;
+    return;
   end if;
 
   return query
@@ -94,6 +113,10 @@ begin
     raise exception using
       errcode = '22023',
       message = 'supabase functions hooks purge batch size must be between 1 and 100000';
+  end if;
+
+  if to_regclass('supabase_functions.hooks') is null then
+    return 0;
   end if;
 
   if not pg_catalog.pg_try_advisory_xact_lock(

--- a/supabase/migrations/20260602070118_worker_legacy_table_retirement_audit.sql
+++ b/supabase/migrations/20260602070118_worker_legacy_table_retirement_audit.sql
@@ -1,0 +1,166 @@
+create or replace view public.worker_legacy_table_retirement_blockers
+with (security_invoker = true)
+as
+with legacy_targets as (
+  select
+    target_namespace.nspname as legacy_schema,
+    target_class.relname as legacy_table,
+    target_class.oid as table_oid,
+    target_class.reltype as row_type_oid
+  from (
+    values
+      ('public'::name, 'lca_jobs'::name),
+      ('public'::name, 'lca_package_jobs'::name),
+      ('public'::name, 'dataset_review_submit_jobs'::name)
+  ) as targets(schema_name, table_name)
+  join pg_namespace as target_namespace
+    on target_namespace.nspname = targets.schema_name
+  join pg_class as target_class
+    on target_class.relnamespace = target_namespace.oid
+   and target_class.relname = targets.table_name
+   and target_class.relkind in ('r', 'p')
+),
+foreign_key_blockers as (
+  select
+    concat(legacy_schema, '.', legacy_table) as legacy_table,
+    'foreign_key'::text as blocker_type,
+    dependent_namespace.nspname::text as blocker_schema,
+    dependent_class.relname::text as blocker_name,
+    constraint_record.conname::text as blocker_identity,
+    true as is_drop_restrict_blocker,
+    jsonb_build_object(
+      'constraintName', constraint_record.conname,
+      'dependentTable', concat(dependent_namespace.nspname, '.', dependent_class.relname),
+      'dependentColumns',
+        (
+          select jsonb_agg(dependent_attribute.attname order by dependent_attribute.attnum)
+          from unnest(constraint_record.conkey) as constraint_column(attnum)
+          join pg_attribute as dependent_attribute
+            on dependent_attribute.attrelid = constraint_record.conrelid
+           and dependent_attribute.attnum = constraint_column.attnum
+        ),
+      'referencedColumns',
+        (
+          select jsonb_agg(referenced_attribute.attname order by referenced_attribute.attnum)
+          from unnest(constraint_record.confkey) as referenced_column(attnum)
+          join pg_attribute as referenced_attribute
+            on referenced_attribute.attrelid = constraint_record.confrelid
+           and referenced_attribute.attnum = referenced_column.attnum
+        ),
+      'onDelete', constraint_record.confdeltype
+    ) as details
+  from legacy_targets
+  join pg_constraint as constraint_record
+    on constraint_record.confrelid = legacy_targets.table_oid
+   and constraint_record.contype = 'f'
+  join pg_class as dependent_class
+    on dependent_class.oid = constraint_record.conrelid
+  join pg_namespace as dependent_namespace
+    on dependent_namespace.oid = dependent_class.relnamespace
+  where constraint_record.conrelid <> legacy_targets.table_oid
+),
+view_blockers as (
+  select distinct
+    concat(legacy_schema, '.', legacy_table) as legacy_table,
+    case dependent_class.relkind
+      when 'm' then 'dependent_materialized_view'
+      else 'dependent_view'
+    end as blocker_type,
+    dependent_namespace.nspname::text as blocker_schema,
+    dependent_class.relname::text as blocker_name,
+    concat(dependent_namespace.nspname, '.', dependent_class.relname)::text as blocker_identity,
+    true as is_drop_restrict_blocker,
+    jsonb_build_object(
+      'dependentView', concat(dependent_namespace.nspname, '.', dependent_class.relname),
+      'relkind', dependent_class.relkind
+    ) as details
+  from legacy_targets
+  join pg_depend as dependency
+    on dependency.refobjid = legacy_targets.table_oid
+  join pg_rewrite as rewrite_rule
+    on rewrite_rule.oid = dependency.objid
+  join pg_class as dependent_class
+    on dependent_class.oid = rewrite_rule.ev_class
+  join pg_namespace as dependent_namespace
+    on dependent_namespace.oid = dependent_class.relnamespace
+  where dependent_class.oid <> legacy_targets.table_oid
+    and dependent_class.relkind in ('v', 'm')
+),
+function_signature_blockers as (
+  select distinct
+    concat(legacy_schema, '.', legacy_table) as legacy_table,
+    'function_signature'::text as blocker_type,
+    function_namespace.nspname::text as blocker_schema,
+    function_record.proname::text as blocker_name,
+    concat(
+      function_namespace.nspname,
+      '.',
+      function_record.proname,
+      '(',
+      pg_get_function_identity_arguments(function_record.oid),
+      ')'
+    )::text as blocker_identity,
+    true as is_drop_restrict_blocker,
+    jsonb_build_object(
+      'arguments', pg_get_function_arguments(function_record.oid),
+      'result', pg_get_function_result(function_record.oid)
+    ) as details
+  from legacy_targets
+  join (
+    select *
+    from pg_proc
+    where prokind in ('f', 'p', 'w')
+  ) as function_record
+    on lower(pg_get_function_arguments(function_record.oid)) like '%' || lower(legacy_table) || '%'
+    or lower(pg_get_function_result(function_record.oid)) like '%' || lower(legacy_table) || '%'
+  join pg_namespace as function_namespace
+    on function_namespace.oid = function_record.pronamespace
+),
+function_source_references as (
+  select distinct
+    concat(legacy_schema, '.', legacy_table) as legacy_table,
+    'function_source_reference'::text as blocker_type,
+    function_namespace.nspname::text as blocker_schema,
+    function_record.proname::text as blocker_name,
+    concat(
+      function_namespace.nspname,
+      '.',
+      function_record.proname,
+      '(',
+      pg_get_function_identity_arguments(function_record.oid),
+      ')'
+    )::text as blocker_identity,
+    false as is_drop_restrict_blocker,
+    jsonb_build_object(
+      'reason', 'Function source text references the legacy table name; this may not block DROP TABLE RESTRICT, but it is a runtime migration blocker.',
+      'arguments', pg_get_function_arguments(function_record.oid),
+      'result', pg_get_function_result(function_record.oid)
+    ) as details
+  from legacy_targets
+  join (
+    select *
+    from pg_proc
+    where prokind in ('f', 'p', 'w')
+  ) as function_record
+    on lower(pg_get_functiondef(function_record.oid)) like '%' || lower(legacy_table) || '%'
+  join pg_namespace as function_namespace
+    on function_namespace.oid = function_record.pronamespace
+  where function_namespace.nspname not in ('pg_catalog', 'information_schema')
+)
+select *
+from foreign_key_blockers
+union all
+select *
+from view_blockers
+union all
+select *
+from function_signature_blockers
+union all
+select *
+from function_source_references;
+
+revoke all on public.worker_legacy_table_retirement_blockers from public, anon, authenticated;
+grant select on public.worker_legacy_table_retirement_blockers to service_role;
+
+comment on view public.worker_legacy_table_retirement_blockers
+  is 'Service-role audit view for DROP TABLE RESTRICT blockers and runtime references that must be resolved before retiring legacy worker job tables.';

--- a/supabase/tests/20260602_worker_legacy_table_retirement_audit.sql
+++ b/supabase/tests/20260602_worker_legacy_table_retirement_audit.sql
@@ -1,0 +1,129 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(10);
+
+select has_view(
+  'public',
+  'worker_legacy_table_retirement_blockers',
+  'legacy table retirement blocker audit view exists'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '97000000-0000-4000-8000-000000000001', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+
+select ok(
+  not has_table_privilege(
+    'authenticated',
+    'public.worker_legacy_table_retirement_blockers',
+    'SELECT'
+  ),
+  'authenticated users cannot read legacy table retirement blockers'
+);
+
+reset role;
+set local role service_role;
+select set_config('request.jwt.claim.sub', '', true);
+select set_config('request.jwt.claim.role', 'service_role', true);
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+select ok(
+  has_table_privilege(
+    'service_role',
+    'public.worker_legacy_table_retirement_blockers',
+    'SELECT'
+  ),
+  'service_role can read legacy table retirement blockers'
+);
+
+select cmp_ok(
+  (
+    select count(*)
+    from public.worker_legacy_table_retirement_blockers
+    where legacy_table = 'public.lca_jobs'
+      and blocker_type = 'foreign_key'
+      and is_drop_restrict_blocker
+  ),
+  '>=',
+  1::bigint,
+  'audit reports lca_jobs foreign-key DROP RESTRICT blockers'
+);
+
+select cmp_ok(
+  (
+    select count(*)
+    from public.worker_legacy_table_retirement_blockers
+    where legacy_table = 'public.lca_package_jobs'
+      and blocker_type = 'foreign_key'
+      and is_drop_restrict_blocker
+  ),
+  '>=',
+  1::bigint,
+  'audit reports lca_package_jobs foreign-key DROP RESTRICT blockers'
+);
+
+select ok(
+  exists (
+    select 1
+    from public.worker_legacy_table_retirement_blockers
+    where legacy_table = 'public.dataset_review_submit_jobs'
+      and blocker_type = 'function_signature'
+      and blocker_identity like 'public.cmd_dataset_review_submit_job_payload(%'
+      and is_drop_restrict_blocker
+  ),
+  'audit reports dataset_review_submit_jobs function-signature blocker'
+);
+
+select ok(
+  exists (
+    select 1
+    from public.worker_legacy_table_retirement_blockers
+    where legacy_table = 'public.lca_jobs'
+      and blocker_type = 'dependent_view'
+      and blocker_identity = 'public.worker_legacy_lifecycle_audit'
+      and is_drop_restrict_blocker
+  ),
+  'audit reports legacy lifecycle audit as a dependent view'
+);
+
+select ok(
+  exists (
+    select 1
+    from public.worker_legacy_table_retirement_blockers
+    where legacy_table = 'public.lca_package_jobs'
+      and blocker_type = 'function_source_reference'
+      and not is_drop_restrict_blocker
+  ),
+  'audit reports package function source references as runtime blockers'
+);
+
+select ok(
+  exists (
+    select 1
+    from public.worker_legacy_table_retirement_blockers
+    where legacy_table = 'public.lca_jobs'
+      and details ? 'dependentColumns'
+  ),
+  'foreign-key blocker details include dependent column metadata'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.worker_legacy_table_retirement_blockers
+    where legacy_table not in (
+      'public.lca_jobs',
+      'public.lca_package_jobs',
+      'public.dataset_review_submit_jobs'
+    )
+  ),
+  '0',
+  'audit is scoped to the three legacy worker job retirement tables'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- add `public.worker_legacy_table_retirement_blockers` as a service-role audit view for the three legacy worker job tables targeted for retirement
- report `DROP TABLE ... RESTRICT` blockers separately from runtime function-source references
- cover FK, dependent view, function-signature, privilege, and scoped-table behavior with a focused PGTAP test

## Validation
- `supabase db reset`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -f supabase/tests/20260602_worker_legacy_table_retirement_audit.sql`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -f supabase/tests/20260531_worker_jobs_legacy_lifecycle_cleanup.sql`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -f supabase/tests/20260602_worker_jobs_canonical_task_contract.sql`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -f supabase/tests/20260531_worker_jobs_foundation.sql`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -P pager=off -c "select legacy_table, blocker_type, is_drop_restrict_blocker, count(*) from public.worker_legacy_table_retirement_blockers group by 1,2,3 order by 1,2,3;"`
- `scripts/docpact lint --root . --files supabase/migrations/20260602070118_worker_legacy_table_retirement_audit.sql,supabase/tests/20260602_worker_legacy_table_retirement_audit.sql,.docpact/config.yaml,AGENTS.md,docs/agents/repo-architecture.md,docs/agents/repo-validation.md --format json --output .docpact/runs/latest.json`
- `supabase migration list --local`

## Notes
Refs #173 and tiangong-lca/workspace#242. This does not drop legacy tables yet; it makes the remaining drop blockers queryable and classifies which blockers are catalog `DROP ... RESTRICT` blockers versus runtime migration blockers.