### PR TITLE
fix: add lca_results retention contract

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "8585e5c517b4b9b14dca6ca3edcbda2d35a9be50"
+lastReviewedCommit: "7fcc161ee42335f933505384578d1e416f269c4e"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8585e5c517b4b9b14dca6ca3edcbda2d35a9be50
+lastReviewedCommit: 7fcc161ee42335f933505384578d1e416f269c4e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8585e5c517b4b9b14dca6ca3edcbda2d35a9be50
+lastReviewedCommit: 7fcc161ee42335f933505384578d1e416f269c4e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 8585e5c517b4b9b14dca6ca3edcbda2d35a9be50
+lastReviewedCommit: 7fcc161ee42335f933505384578d1e416f269c4e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260602091430_lca_results_retention_contract.sql
+++ b/supabase/migrations/20260602091430_lca_results_retention_contract.sql
@@ -1,0 +1,29 @@
+alter table public.lca_results
+  add column if not exists expires_at timestamp with time zone,
+  add column if not exists is_pinned boolean;
+
+update public.lca_results
+set
+  expires_at = coalesce(expires_at, now() + interval '30 days'),
+  is_pinned = coalesce(is_pinned, false)
+where expires_at is null
+   or is_pinned is null;
+
+alter table public.lca_results
+  alter column expires_at set default (now() + interval '30 days'),
+  alter column expires_at set not null,
+  alter column is_pinned set default false,
+  alter column is_pinned set not null;
+
+create index if not exists lca_results_expires_at_idx
+  on public.lca_results (expires_at, created_at)
+  where is_pinned = false;
+
+create index if not exists lca_results_created_desc_idx
+  on public.lca_results (created_at desc);
+
+comment on column public.lca_results.expires_at is
+  'Result artifact retention deadline used by tiangong-lca-worker lca.result_gc; existing rows created before this contract receive a 30 day migration grace period.';
+
+comment on column public.lca_results.is_pinned is
+  'When true, protects the LCA result artifact metadata row from automatic result GC.';

--- a/supabase/tests/20260602_lca_results_retention_contract.sql
+++ b/supabase/tests/20260602_lca_results_retention_contract.sql
@@ -1,0 +1,183 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(14);
+
+select has_column(
+  'public',
+  'lca_results',
+  'expires_at',
+  'lca_results exposes a result retention deadline'
+);
+
+select col_type_is(
+  'public',
+  'lca_results',
+  'expires_at',
+  'timestamp with time zone',
+  'lca_results.expires_at is timestamptz'
+);
+
+select col_not_null(
+  'public',
+  'lca_results',
+  'expires_at',
+  'lca_results.expires_at is required'
+);
+
+select col_has_default(
+  'public',
+  'lca_results',
+  'expires_at',
+  'lca_results.expires_at has a default retention deadline'
+);
+
+select has_column(
+  'public',
+  'lca_results',
+  'is_pinned',
+  'lca_results exposes a result GC pin flag'
+);
+
+select col_type_is(
+  'public',
+  'lca_results',
+  'is_pinned',
+  'boolean',
+  'lca_results.is_pinned is boolean'
+);
+
+select col_not_null(
+  'public',
+  'lca_results',
+  'is_pinned',
+  'lca_results.is_pinned is required'
+);
+
+select col_has_default(
+  'public',
+  'lca_results',
+  'is_pinned',
+  'lca_results.is_pinned has a default value'
+);
+
+select ok(
+  to_regclass('public.lca_results_expires_at_idx') is not null,
+  'lca_results has an expires_at retention index'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_index i
+    join pg_class c on c.oid = i.indexrelid
+    where c.oid = 'public.lca_results_expires_at_idx'::regclass
+      and pg_get_indexdef(i.indexrelid) like '%expires_at%'
+      and pg_get_indexdef(i.indexrelid) like '%created_at%'
+      and pg_get_expr(i.indpred, i.indrelid) like '%is_pinned%'
+      and pg_get_expr(i.indpred, i.indrelid) like '%false%'
+  ),
+  'lca_results expires_at index covers unpinned retention candidates'
+);
+
+select ok(
+  to_regclass('public.lca_results_created_desc_idx') is not null,
+  'lca_results has a created_at desc index for recent result lookups'
+);
+
+insert into public.lca_network_snapshots (
+  id,
+  scope,
+  process_filter,
+  provider_matching_rule,
+  source_hash,
+  status,
+  created_at,
+  updated_at
+) values (
+  '91620000-0000-4000-8000-000000000001',
+  'full_library',
+  '{}'::jsonb,
+  'split_by_evidence_hybrid',
+  'pgtap-lca-results-retention',
+  'ready',
+  now(),
+  now()
+);
+
+insert into public.lca_jobs (
+  id,
+  job_type,
+  snapshot_id,
+  status,
+  payload,
+  diagnostics,
+  requested_by,
+  request_key,
+  created_at,
+  updated_at
+) values (
+  '91620000-0000-4000-8000-000000000002',
+  'solve_one',
+  '91620000-0000-4000-8000-000000000001',
+  'completed',
+  '{}'::jsonb,
+  '{}'::jsonb,
+  '91620000-0000-4000-8000-000000000101',
+  'pgtap-lca-results-retention',
+  now(),
+  now()
+);
+
+insert into public.lca_results (
+  id,
+  job_id,
+  snapshot_id,
+  payload,
+  diagnostics,
+  artifact_url,
+  artifact_byte_size,
+  artifact_format
+) values (
+  '91620000-0000-4000-8000-000000000003',
+  '91620000-0000-4000-8000-000000000002',
+  '91620000-0000-4000-8000-000000000001',
+  '{}'::jsonb,
+  '{}'::jsonb,
+  'storage://lca_results/pgtap/result.h5',
+  128,
+  'hdf5:v1'
+);
+
+select is(
+  (
+    select is_pinned::text
+    from public.lca_results
+    where id = '91620000-0000-4000-8000-000000000003'
+  ),
+  'false',
+  'new lca_results rows default to unpinned'
+);
+
+select ok(
+  (
+    select expires_at > created_at
+    from public.lca_results
+    where id = '91620000-0000-4000-8000-000000000003'
+  ),
+  'new lca_results rows default to a future retention deadline'
+);
+
+select ok(
+  (
+    select expires_at <= created_at + interval '31 days'
+    from public.lca_results
+    where id = '91620000-0000-4000-8000-000000000003'
+  ),
+  'default lca_results retention deadline is approximately 30 days'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- Add `public.lca_results.expires_at` and `public.lca_results.is_pinned` as the DB-owned retention contract used by `tiangong-lca-worker` `lca.result_gc`.
- Backfill existing rows with a 30-day migration grace period, then enforce defaults and NOT NULL.
- Add retention indexes plus pgTAP coverage for the column/index/default behavior.
- Record docpact review evidence for the schema/test change.

Closes linancn/tiangong-lca-worker#92
Refs tiangong-lca/database-engine#173
Refs tiangong-lca/workspace#242

## Validation
- `supabase db reset`
- `supabase test db supabase/tests/20260602_lca_results_retention_contract.sql`
- `supabase test db supabase/tests/20260531_worker_jobs_foundation.sql supabase/tests/20260531_worker_jobs_legacy_lifecycle_cleanup.sql supabase/tests/20260602_worker_legacy_table_retirement_audit.sql supabase/tests/20260531_lca_snapshot_retention_contract.sql`
- `supabase migration list --local`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres ...` to inspect `lca_results` retention columns/indexes
- `scripts/docpact lint --root . --worktree --mode enforce`
- `scripts/docpact validate-config --root . --strict`
- `cargo check -p solver-worker --bin result_gc --bin maintenance_worker --bin maintenance_enqueue` in `tiangong-lca-worker`
- `cargo test -p solver-worker result_gc` in `tiangong-lca-worker`
- `cargo test -p solver-worker maintenance_worker` in `tiangong-lca-worker`

## Follow-up / Deployment
- After merge into `dev`, confirm the Supabase dev migration applies.
- Rerun a fresh `lca.result_gc` dry-run through `worker_jobs` on dev and confirm the worker job reaches `completed`.
- This PR does not drop legacy job tables and does not use `DROP ... CASCADE`.
