### PR TITLE
fix: speed up source latest RPC

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "0db5b62225862a556e9cb0675a7c4b0906cd6be2"
+lastReviewedAt: "2026-06-03"
+lastReviewedCommit: "1115cae641ce62109b5ad05ddf1343f02b2a12b4"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0db5b62225862a556e9cb0675a7c4b0906cd6be2
+lastReviewedAt: 2026-06-03
+lastReviewedCommit: 1115cae641ce62109b5ad05ddf1343f02b2a12b4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0db5b62225862a556e9cb0675a7c4b0906cd6be2
+lastReviewedAt: 2026-06-03
+lastReviewedCommit: 1115cae641ce62109b5ad05ddf1343f02b2a12b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0db5b62225862a556e9cb0675a7c4b0906cd6be2
+lastReviewedAt: 2026-06-03
+lastReviewedCommit: 1115cae641ce62109b5ad05ddf1343f02b2a12b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260603042523_fix_source_latest_versions_rls_latency.sql
+++ b/supabase/migrations/20260603042523_fix_source_latest_versions_rls_latency.sql
@@ -1,0 +1,194 @@
+-- Fix authenticated REST latency for source latest-version list pages.
+--
+-- The previous implementation compared f.user_id::text = this_user_id and
+-- carried json through latest/count/sort before pagination. Under RLS this
+-- caused the planner to scan sources_pkey and evaluate expensive review/team
+-- policy branches for thousands of rows. Normalize the caller id once, compare
+-- UUID-to-UUID, page lightweight keys first, then fetch json only for the page.
+
+CREATE INDEX IF NOT EXISTS "sources_user_id_id_version_modified_at_latest_idx"
+ON "public"."sources" USING "btree" ("user_id", "id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id", "state_code");
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_keys AS (
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.sources f
+      WHERE data_source = 'tg'
+        AND f.state_code = 100
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.sources f
+      WHERE data_source = 'co'
+        AND f.state_code = 200
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.sources f
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND f.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.sources f
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND f.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+    ),
+    latest_keys AS (
+      SELECT DISTINCT ON (visible_keys.id)
+        visible_keys.id,
+        visible_keys.version,
+        visible_keys.created_at,
+        visible_keys.modified_at,
+        visible_keys.team_id
+      FROM visible_keys
+      ORDER BY visible_keys.id, visible_keys.version DESC, visible_keys.modified_at DESC
+    ),
+    counted_keys AS (
+      SELECT latest_keys.*, count(*) OVER()::bigint AS total_count
+      FROM latest_keys
+    ),
+    paged_keys AS (
+      SELECT counted_keys.*
+      FROM counted_keys
+      ORDER BY
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_keys.version
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_keys.version
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_keys.created_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.created_at
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_keys.modified_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.modified_at
+        END DESC NULLS LAST,
+        counted_keys.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size
+    )
+    SELECT
+      payload.id,
+      payload.json,
+      payload.version,
+      payload.modified_at,
+      payload.team_id,
+      paged_keys.total_count
+    FROM paged_keys
+    JOIN public.sources payload
+      ON payload.id = paged_keys.id
+     AND payload.version = paged_keys.version
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN paged_keys.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN paged_keys.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN paged_keys.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN paged_keys.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.modified_at
+      END DESC NULLS LAST,
+      paged_keys.id;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";


### PR DESCRIPTION
Closes tiangong-lca/database-engine#182

## Summary
- Add a migration that rewrites get_latest_source_versions to normalize this_user_id to uuid and use key-first pagination before fetching source json.
- Add a supporting user_id/id/version/modified_at source index for latest-version my-data scans.

## Key Decisions
- Keep the function as an invoker/RLS-protected RPC; authenticated query-shape testing showed the UUID comparison and key-first plan avoid the expensive review-policy branches without introducing SECURITY DEFINER.
- Preserve the existing RPC return contract used by tiangong-lca-next source table loading.

## Validation
- git diff --cached --check
- scripts/docpact lint --root . --staged --mode enforce
- Supabase dev project transaction smoke: created index/function, called get_latest_source_versions(1, 1, 'tg', ...), returned smoke_rows=1, then ROLLBACK.
- Supabase main project authenticated reproduction: original get_latest_source_versions page 1 my-data plan was about 5.78s; equivalent fixed query shape ran in about 34ms with review RLS subplans not executed.
- supabase status / local db reset not run because local Docker/OrbStack daemon is not running.

## Risks / Rollback
- Low-medium: migration changes one RPC and adds one btree index. Rollback is to restore the prior function body and drop sources_user_id_id_version_modified_at_latest_idx.

## Follow-ups
- Evaluate processes and flows latest-version RPCs separately; they have related scalability risks but are outside this source-specific fix.

## Workspace Integration
- database-engine is an M2 repo; this routine PR targets dev. Workspace submodule integration remains pending after merge/promote according to branch policy.