### PR TITLE
promote: source latest RPC latency fix to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-02"
-lastReviewedCommit: "0db5b62225862a556e9cb0675a7c4b0906cd6be2"
+lastReviewedAt: "2026-06-03"
+lastReviewedCommit: "1115cae641ce62109b5ad05ddf1343f02b2a12b4"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0db5b62225862a556e9cb0675a7c4b0906cd6be2
+lastReviewedAt: 2026-06-03
+lastReviewedCommit: 1115cae641ce62109b5ad05ddf1343f02b2a12b4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0db5b62225862a556e9cb0675a7c4b0906cd6be2
+lastReviewedAt: 2026-06-03
+lastReviewedCommit: 1115cae641ce62109b5ad05ddf1343f02b2a12b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-02
-lastReviewedCommit: 0db5b62225862a556e9cb0675a7c4b0906cd6be2
+lastReviewedAt: 2026-06-03
+lastReviewedCommit: 1115cae641ce62109b5ad05ddf1343f02b2a12b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260603042523_fix_source_latest_versions_rls_latency.sql
+++ b/supabase/migrations/20260603042523_fix_source_latest_versions_rls_latency.sql
@@ -1,0 +1,194 @@
+-- Fix authenticated REST latency for source latest-version list pages.
+--
+-- The previous implementation compared f.user_id::text = this_user_id and
+-- carried json through latest/count/sort before pagination. Under RLS this
+-- caused the planner to scan sources_pkey and evaluate expensive review/team
+-- policy branches for thousands of rows. Normalize the caller id once, compare
+-- UUID-to-UUID, page lightweight keys first, then fetch json only for the page.
+
+CREATE INDEX IF NOT EXISTS "sources_user_id_id_version_modified_at_latest_idx"
+ON "public"."sources" USING "btree" ("user_id", "id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id", "state_code");
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_keys AS (
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.sources f
+      WHERE data_source = 'tg'
+        AND f.state_code = 100
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.sources f
+      WHERE data_source = 'co'
+        AND f.state_code = 200
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.sources f
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND f.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.sources f
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND f.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+    ),
+    latest_keys AS (
+      SELECT DISTINCT ON (visible_keys.id)
+        visible_keys.id,
+        visible_keys.version,
+        visible_keys.created_at,
+        visible_keys.modified_at,
+        visible_keys.team_id
+      FROM visible_keys
+      ORDER BY visible_keys.id, visible_keys.version DESC, visible_keys.modified_at DESC
+    ),
+    counted_keys AS (
+      SELECT latest_keys.*, count(*) OVER()::bigint AS total_count
+      FROM latest_keys
+    ),
+    paged_keys AS (
+      SELECT counted_keys.*
+      FROM counted_keys
+      ORDER BY
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_keys.version
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_keys.version
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_keys.created_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.created_at
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_keys.modified_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.modified_at
+        END DESC NULLS LAST,
+        counted_keys.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size
+    )
+    SELECT
+      payload.id,
+      payload.json,
+      payload.version,
+      payload.modified_at,
+      payload.team_id,
+      paged_keys.total_count
+    FROM paged_keys
+    JOIN public.sources payload
+      ON payload.id = paged_keys.id
+     AND payload.version = paged_keys.version
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN paged_keys.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN paged_keys.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN paged_keys.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN paged_keys.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.modified_at
+      END DESC NULLS LAST,
+      paged_keys.id;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_source_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";


### PR DESCRIPTION
## Summary
- Promote the database-engine dev branch to main so the source latest-version RPC latency fix from #183 can reach the production Supabase integration path.
- This promote includes get_latest_source_versions key-first pagination and UUID user filtering from database-engine#182.

## Key Decisions
- Use the standard M2 promote path dev -> main instead of applying the migration manually to production.

## Validation
- PR #183 passed Gitleaks and Supabase Preview before merge to dev.
- Authenticated main-project query-shape validation during #183 showed the source latest RPC path dropping from about 5.78s to about 34ms.

## Risks / Rollback
- Medium: production migration adds one source index and replaces one RPC body. Rollback is to restore the previous function body and drop sources_user_id_id_version_modified_at_latest_idx if needed.

## Follow-ups
- After this promote merges, verify production Supabase GitHub integration applies the migration, then update the lca-workspace database-engine submodule pointer when eligible.

## Workspace Integration
- Root workspace integration remains pending after this database-engine main promote merge.