### PR TITLE
docs: clarify review-submit coordinator retirement target

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-03"
-lastReviewedCommit: "93524f6734ec75e81ab39fecab6997e4cfdca989"
+lastReviewedCommit: "0b20b834cad18def0addb9c58abb4ae539a92fbb"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-03
-lastReviewedCommit: 93524f6734ec75e81ab39fecab6997e4cfdca989
+lastReviewedCommit: 0b20b834cad18def0addb9c58abb4ae539a92fbb
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-03
-lastReviewedCommit: 93524f6734ec75e81ab39fecab6997e4cfdca989
+lastReviewedCommit: 0b20b834cad18def0addb9c58abb4ae539a92fbb
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-03
-lastReviewedCommit: 93524f6734ec75e81ab39fecab6997e4cfdca989
+lastReviewedCommit: 0b20b834cad18def0addb9c58abb4ae539a92fbb
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260603150000_review_submit_coordinator_contract.sql
+++ b/supabase/migrations/20260603150000_review_submit_coordinator_contract.sql
@@ -1,0 +1,15 @@
+-- Clarify that dataset_review_submit_jobs remains a legacy retirement target
+-- even though it still carries active review-submit coordinator responsibilities
+-- during the worker_jobs cutover.
+
+comment on table public.dataset_review_submit_jobs
+  is 'Legacy review-submit coordinator/request table retained during the worker_jobs cutover. It remains a retirement target under workspace#242, but it cannot be dropped until submit-review idempotency, retry/coordinator recovery, final submit status, and UI/status recovery have moved to worker_jobs or a replacement domain coordinator table.';
+
+comment on column public.dataset_review_submit_jobs.submit_worker_job_id
+  is 'Canonical root review_submit.submit worker_jobs task for this legacy review-submit coordinator row during cutover.';
+
+comment on function util.process_dataset_review_submit_jobs(integer, integer, integer)
+  is 'Invokes the Edge review-submit coordinator that advances retained dataset_review_submit_jobs rows after worker gate results are available. This wrapper is part of the legacy coordinator cutover and must be retired or retargeted before dataset_review_submit_jobs is dropped.';
+
+comment on view public.worker_legacy_table_retirement_blockers
+  is 'Service-role audit view for legacy worker job DROP TABLE RESTRICT blockers. Targets include public.lca_jobs, public.lca_package_jobs, and public.dataset_review_submit_jobs; dataset_review_submit_jobs additionally requires coordinator/runtime migration before destructive retirement.';

--- a/supabase/tests/20260602_worker_jobs_canonical_task_contract.sql
+++ b/supabase/tests/20260602_worker_jobs_canonical_task_contract.sql
@@ -337,8 +337,12 @@ select ok(
     where attrelid = 'public.lca_results'::regclass
       and attname = 'worker_job_id'
   )) is not null
+  and obj_description('public.dataset_review_submit_jobs'::regclass, 'pg_class')
+    like '%retirement target%'
+  and obj_description('public.dataset_review_submit_jobs'::regclass, 'pg_class')
+    like '%coordinator%'
   and obj_description('public.worker_job_domain_refs'::regclass, 'pg_class') is not null,
-  'canonical worker job references are documented with comments'
+  'canonical worker job references and review-submit coordinator retirement contract are documented with comments'
 );
 
 select * from finish();


### PR DESCRIPTION
## Summary
- Clarifies that `dataset_review_submit_jobs` remains a legacy retirement target under `workspace#242`, not a long-term active table.
- Documents the current coordinator cutover responsibilities that must move before destructive retirement.
- Strengthens the worker_jobs canonical SQL assertion so the table comment must include both retirement-target and coordinator semantics.

Closes #187

## Validation
- `supabase db reset`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -f supabase/tests/20260602_worker_jobs_canonical_task_contract.sql`
- `psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -v ON_ERROR_STOP=1 -f supabase/tests/20260602_worker_legacy_table_retirement_audit.sql`
- `supabase migration list --local`
- `scripts/docpact validate-config --root . --strict`
- `scripts/docpact lint --root . --worktree --mode enforce`
- `git diff --check`

## Notes
- This does not migrate coordinator state yet. It fixes the contract and test wording so later `dataset_review_submit_jobs` retirement work stays in scope instead of being accidentally treated as a permanent active table.
- Dev/main destructive retirement is still gated by coordinator/runtime migration and workspace#242 smoke evidence.