### PR TITLE
Promote package retention table-absence-safe DB update

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-03"
-lastReviewedCommit: "4c860393cf50ac41ed5dd993ba743fc213612764"
+lastReviewedCommit: "d0234f083eceb035f4f00ea988d14de3be39c1aa"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-03
-lastReviewedCommit: 4c860393cf50ac41ed5dd993ba743fc213612764
+lastReviewedCommit: d0234f083eceb035f4f00ea988d14de3be39c1aa
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-03
-lastReviewedCommit: 4c860393cf50ac41ed5dd993ba743fc213612764
+lastReviewedCommit: d0234f083eceb035f4f00ea988d14de3be39c1aa
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-03
-lastReviewedCommit: 4c860393cf50ac41ed5dd993ba743fc213612764
+lastReviewedCommit: d0234f083eceb035f4f00ea988d14de3be39c1aa
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260603170500_package_retention_table_absence_safe.sql
+++ b/supabase/migrations/20260603170500_package_retention_table_absence_safe.sql
@@ -1,0 +1,242 @@
+create or replace function util.preview_lca_package_retention(
+  p_job_retention_window interval default interval '30 days',
+  p_request_cache_retention_window interval default interval '30 days',
+  p_as_of timestamp with time zone default pg_catalog.now()
+) returns table (
+  retention_area text,
+  retention_action text,
+  is_eligible boolean,
+  reason text,
+  retention_window interval,
+  cutoff_time timestamp with time zone,
+  row_count bigint,
+  total_artifact_bytes bigint,
+  total_hit_count bigint,
+  oldest_observed_at timestamp with time zone,
+  newest_observed_at timestamp with time zone
+)
+language plpgsql
+stable
+set search_path to ''
+as $$
+begin
+  if p_as_of is null then
+    raise exception using
+      errcode = '22023',
+      message = 'package retention dry-run as_of timestamp must not be null';
+  end if;
+
+  if p_job_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'package job retention window must be at least 1 day';
+  end if;
+
+  if p_request_cache_retention_window < interval '1 day' then
+    raise exception using
+      errcode = '22023',
+      message = 'package request-cache retention window must be at least 1 day';
+  end if;
+
+  return query
+  with package_worker_jobs as (
+    select
+      jobs.id,
+      jobs.status,
+      coalesce(jobs.finished_at, jobs.updated_at, jobs.created_at) as lifecycle_at
+    from public.worker_jobs as jobs
+    where jobs.job_kind in ('tidas.export_package', 'tidas.import_package')
+  ),
+  job_rollup as (
+    select
+      jobs.id,
+      jobs.status,
+      jobs.lifecycle_at,
+      coalesce(
+        bool_or(artifacts.id is not null and artifacts.status <> 'deleted'),
+        false
+      ) as has_object_not_deleted,
+      exists (
+        select 1
+        from public.lca_package_artifacts as recent_artifact
+        join public.lca_package_request_cache as recent_cache
+          on recent_cache.export_artifact_id = recent_artifact.id
+          or recent_cache.report_artifact_id = recent_artifact.id
+        where recent_artifact.worker_job_id = jobs.id
+          and recent_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window
+      ) as has_recent_artifact_cache,
+      coalesce(
+        sum(coalesce(artifacts.artifact_byte_size, 0))
+          filter (where artifacts.status <> 'deleted'),
+        0
+      )::bigint as artifact_bytes
+    from package_worker_jobs as jobs
+    left join public.lca_package_artifacts as artifacts
+      on artifacts.worker_job_id = jobs.id
+    group by jobs.id, jobs.status, jobs.lifecycle_at
+  ),
+  job_classified as (
+    select
+      'worker_jobs'::text as retention_area,
+      'delete_package_worker_metadata_after_artifact_gc'::text as retention_action,
+      (classified.reason = 'eligible_terminal_job_older_than_window') as is_eligible,
+      classified.reason,
+      p_job_retention_window as retention_window,
+      p_as_of - p_job_retention_window as cutoff_time,
+      1::bigint as row_count,
+      classified.artifact_bytes as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      classified.lifecycle_at as observed_at
+    from (
+      select
+        job_rollup.*,
+        case
+          when job_rollup.status in ('queued', 'running', 'waiting') then 'protected_active_job'
+          when job_rollup.lifecycle_at >= p_as_of - p_job_retention_window then 'protected_inside_job_retention_window'
+          when job_rollup.has_object_not_deleted then 'protected_object_not_deleted'
+          when job_rollup.has_recent_artifact_cache then 'protected_recent_request_cache_reference'
+          else 'eligible_terminal_job_older_than_window'
+        end as reason
+      from job_rollup
+    ) as classified
+  ),
+  artifact_classified as (
+    select
+      'lca_package_artifacts'::text as retention_area,
+      'delete_object_then_mark_deleted'::text as retention_action,
+      (classified.reason = 'eligible_expired_unpinned_artifact') as is_eligible,
+      classified.reason,
+      null::interval as retention_window,
+      p_as_of as cutoff_time,
+      1::bigint as row_count,
+      coalesce(classified.artifact_byte_size, 0)::bigint as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      coalesce(classified.expires_at, classified.updated_at, classified.created_at) as observed_at
+    from (
+      select
+        artifacts.*,
+        jobs.status as parent_job_status,
+        coalesce(recent_cache.recent_cache_rows, 0) as recent_cache_rows,
+        case
+          when artifacts.is_pinned then 'protected_pinned_artifact'
+          when artifacts.status = 'deleted' then 'protected_already_deleted'
+          when artifacts.status = 'pending' then 'protected_artifact_not_ready'
+          when jobs.id is null then 'protected_missing_worker_job'
+          when jobs.status in ('queued', 'running', 'waiting') then 'protected_active_parent_job'
+          when artifacts.expires_at is null then 'protected_missing_expires_at'
+          when artifacts.expires_at > p_as_of then 'protected_expires_at_in_future'
+          when coalesce(recent_cache.recent_cache_rows, 0) > 0 then 'protected_recent_request_cache_reference'
+          else 'eligible_expired_unpinned_artifact'
+        end as reason
+      from public.lca_package_artifacts as artifacts
+      left join package_worker_jobs as jobs
+        on jobs.id = artifacts.worker_job_id
+      left join lateral (
+        select count(*)::bigint as recent_cache_rows
+        from public.lca_package_request_cache as request_cache
+        where (
+            request_cache.export_artifact_id = artifacts.id
+            or request_cache.report_artifact_id = artifacts.id
+          )
+          and request_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window
+      ) as recent_cache on true
+    ) as classified
+  ),
+  request_cache_classified as (
+    select
+      'lca_package_request_cache'::text as retention_area,
+      'delete_stale_request_cache_row'::text as retention_action,
+      (classified.reason = 'eligible_stale_request_cache') as is_eligible,
+      classified.reason,
+      p_request_cache_retention_window as retention_window,
+      p_as_of - p_request_cache_retention_window as cutoff_time,
+      1::bigint as row_count,
+      0::bigint as total_artifact_bytes,
+      classified.hit_count::bigint as total_hit_count,
+      classified.last_accessed_at as observed_at
+    from (
+      select
+        request_cache.*,
+        jobs.status as parent_job_status,
+        case
+          when request_cache.status in ('pending', 'running') then 'protected_active_request_cache'
+          when request_cache.last_accessed_at >= p_as_of - p_request_cache_retention_window then 'protected_recent_request_cache_access'
+          when jobs.status in ('queued', 'running', 'waiting') then 'protected_active_parent_job'
+          else 'eligible_stale_request_cache'
+        end as reason
+      from public.lca_package_request_cache as request_cache
+      left join package_worker_jobs as jobs
+        on jobs.id = request_cache.worker_job_id
+    ) as classified
+  ),
+  export_item_classified as (
+    select
+      'lca_package_export_items'::text as retention_area,
+      'delete_export_items_with_parent_job'::text as retention_action,
+      (classified.reason = 'eligible_parent_job_cascade') as is_eligible,
+      classified.reason,
+      p_job_retention_window as retention_window,
+      p_as_of - p_job_retention_window as cutoff_time,
+      1::bigint as row_count,
+      0::bigint as total_artifact_bytes,
+      0::bigint as total_hit_count,
+      classified.created_at as observed_at
+    from (
+      select
+        export_items.*,
+        case
+          when export_items.worker_job_id is null or job_rollup.id is null then 'protected_missing_worker_job'
+          when job_rollup.status in ('queued', 'running', 'waiting') then 'protected_active_parent_job'
+          when job_rollup.lifecycle_at >= p_as_of - p_job_retention_window then 'protected_parent_inside_job_retention_window'
+          when job_rollup.has_object_not_deleted then 'protected_object_not_deleted'
+          when job_rollup.has_recent_artifact_cache then 'protected_recent_request_cache_reference'
+          else 'eligible_parent_job_cascade'
+        end as reason
+      from public.lca_package_export_items as export_items
+      left join job_rollup
+        on job_rollup.id = export_items.worker_job_id
+    ) as classified
+  ),
+  classified as (
+    select * from job_classified
+    union all
+    select * from artifact_classified
+    union all
+    select * from request_cache_classified
+    union all
+    select * from export_item_classified
+  )
+  select
+    classified.retention_area,
+    classified.retention_action,
+    classified.is_eligible,
+    classified.reason,
+    classified.retention_window,
+    classified.cutoff_time,
+    sum(classified.row_count)::bigint as row_count,
+    coalesce(sum(classified.total_artifact_bytes), 0)::bigint as total_artifact_bytes,
+    coalesce(sum(classified.total_hit_count), 0)::bigint as total_hit_count,
+    min(classified.observed_at) as oldest_observed_at,
+    max(classified.observed_at) as newest_observed_at
+  from classified
+  group by
+    classified.retention_area,
+    classified.retention_action,
+    classified.is_eligible,
+    classified.reason,
+    classified.retention_window,
+    classified.cutoff_time
+  order by
+    classified.retention_area,
+    classified.is_eligible desc,
+    classified.reason;
+end;
+$$;
+
+alter function util.preview_lca_package_retention(interval, interval, timestamp with time zone) owner to postgres;
+revoke all on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) from public;
+grant usage on schema util to service_role;
+grant execute on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) to service_role;
+
+comment on function util.preview_lca_package_retention(interval, interval, timestamp with time zone) is
+  'Operator dry-run helper for package metadata retention; reports aggregate eligible/protected counts for package worker jobs, artifacts, request cache, and export items without deleting or updating business rows.';

--- a/supabase/tests/20260529_lca_package_retention_dry_run.sql
+++ b/supabase/tests/20260529_lca_package_retention_dry_run.sql
@@ -17,7 +17,7 @@ as $$
   );
 $$;
 
-select plan(22);
+select plan(23);
 
 select ok(
   to_regprocedure('util.preview_lca_package_retention(interval,interval,timestamp with time zone)') is not null,
@@ -33,11 +33,14 @@ select ok(
   'service_role can execute package retention dry-run function'
 );
 
-insert into public.lca_package_jobs (
+insert into public.worker_jobs (
   id,
-  job_type,
+  job_kind,
+  worker_runtime,
+  worker_queue,
   status,
-  payload,
+  payload_schema_version,
+  payload_json,
   diagnostics,
   requested_by,
   created_at,
@@ -46,8 +49,11 @@ insert into public.lca_package_jobs (
 ) values
   (
     '91460000-0000-4000-8000-000000000001',
-    'export_package',
-    'ready',
+    'tidas.export_package',
+    'calculator',
+    'package',
+    'completed',
+    'tidas.export_package.request.v1',
     '{}'::jsonb,
     '{}'::jsonb,
     '91460000-0000-4000-8000-000000000100',
@@ -57,8 +63,11 @@ insert into public.lca_package_jobs (
   ),
   (
     '91460000-0000-4000-8000-000000000002',
-    'export_package',
+    'tidas.export_package',
+    'calculator',
+    'package',
     'queued',
+    'tidas.export_package.request.v1',
     '{}'::jsonb,
     '{}'::jsonb,
     '91460000-0000-4000-8000-000000000100',
@@ -68,8 +77,11 @@ insert into public.lca_package_jobs (
   ),
   (
     '91460000-0000-4000-8000-000000000003',
-    'export_package',
-    'ready',
+    'tidas.export_package',
+    'calculator',
+    'package',
+    'completed',
+    'tidas.export_package.request.v1',
     '{}'::jsonb,
     '{}'::jsonb,
     '91460000-0000-4000-8000-000000000100',
@@ -79,8 +91,11 @@ insert into public.lca_package_jobs (
   ),
   (
     '91460000-0000-4000-8000-000000000004',
-    'export_package',
-    'ready',
+    'tidas.export_package',
+    'calculator',
+    'package',
+    'completed',
+    'tidas.export_package.request.v1',
     '{}'::jsonb,
     '{}'::jsonb,
     '91460000-0000-4000-8000-000000000100',
@@ -90,8 +105,11 @@ insert into public.lca_package_jobs (
   ),
   (
     '91460000-0000-4000-8000-000000000005',
-    'export_package',
-    'ready',
+    'tidas.export_package',
+    'calculator',
+    'package',
+    'completed',
+    'tidas.export_package.request.v1',
     '{}'::jsonb,
     '{}'::jsonb,
     '91460000-0000-4000-8000-000000000100',
@@ -101,8 +119,11 @@ insert into public.lca_package_jobs (
   ),
   (
     '91460000-0000-4000-8000-000000000006',
-    'export_package',
-    'ready',
+    'tidas.export_package',
+    'calculator',
+    'package',
+    'completed',
+    'tidas.export_package.request.v1',
     '{}'::jsonb,
     '{}'::jsonb,
     '91460000-0000-4000-8000-000000000100',
@@ -112,8 +133,11 @@ insert into public.lca_package_jobs (
   ),
   (
     '91460000-0000-4000-8000-000000000007',
-    'export_package',
-    'ready',
+    'tidas.export_package',
+    'calculator',
+    'package',
+    'completed',
+    'tidas.export_package.request.v1',
     '{}'::jsonb,
     '{}'::jsonb,
     '91460000-0000-4000-8000-000000000100',
@@ -123,8 +147,11 @@ insert into public.lca_package_jobs (
   ),
   (
     '91460000-0000-4000-8000-000000000008',
-    'export_package',
-    'ready',
+    'tidas.export_package',
+    'calculator',
+    'package',
+    'completed',
+    'tidas.export_package.request.v1',
     '{}'::jsonb,
     '{}'::jsonb,
     '91460000-0000-4000-8000-000000000100',
@@ -136,6 +163,7 @@ insert into public.lca_package_jobs (
 insert into public.lca_package_artifacts (
   id,
   job_id,
+  worker_job_id,
   artifact_kind,
   status,
   artifact_url,
@@ -151,6 +179,7 @@ insert into public.lca_package_artifacts (
 ) values
   (
     '91460000-0000-4000-8000-000000000103',
+    '91460000-0000-4000-8000-000000000003',
     '91460000-0000-4000-8000-000000000003',
     'export_zip',
     'ready',
@@ -168,6 +197,7 @@ insert into public.lca_package_artifacts (
   (
     '91460000-0000-4000-8000-000000000104',
     '91460000-0000-4000-8000-000000000004',
+    '91460000-0000-4000-8000-000000000004',
     'export_zip',
     'ready',
     'storage://package/expired.zip',
@@ -183,6 +213,7 @@ insert into public.lca_package_artifacts (
   ),
   (
     '91460000-0000-4000-8000-000000000105',
+    '91460000-0000-4000-8000-000000000005',
     '91460000-0000-4000-8000-000000000005',
     'export_zip',
     'ready',
@@ -200,6 +231,7 @@ insert into public.lca_package_artifacts (
   (
     '91460000-0000-4000-8000-000000000106',
     '91460000-0000-4000-8000-000000000006',
+    '91460000-0000-4000-8000-000000000006',
     'export_zip',
     'deleted',
     'storage://package/deleted.zip',
@@ -215,6 +247,7 @@ insert into public.lca_package_artifacts (
   ),
   (
     '91460000-0000-4000-8000-000000000107',
+    '91460000-0000-4000-8000-000000000007',
     '91460000-0000-4000-8000-000000000007',
     'export_zip',
     'ready',
@@ -233,6 +266,7 @@ insert into public.lca_package_artifacts (
 insert into public.lca_package_export_items (
   id,
   job_id,
+  worker_job_id,
   table_name,
   dataset_id,
   version,
@@ -243,6 +277,7 @@ insert into public.lca_package_export_items (
 ) values
   (
     '91460000-0000-4000-8000-000000000201',
+    '91460000-0000-4000-8000-000000000001',
     '91460000-0000-4000-8000-000000000001',
     'processes',
     '91460000-0000-4000-8000-000000000301',
@@ -255,6 +290,7 @@ insert into public.lca_package_export_items (
   (
     '91460000-0000-4000-8000-000000000202',
     '91460000-0000-4000-8000-000000000002',
+    '91460000-0000-4000-8000-000000000002',
     'processes',
     '91460000-0000-4000-8000-000000000302',
     '000000001',
@@ -265,6 +301,7 @@ insert into public.lca_package_export_items (
   ),
   (
     '91460000-0000-4000-8000-000000000203',
+    '91460000-0000-4000-8000-000000000003',
     '91460000-0000-4000-8000-000000000003',
     'processes',
     '91460000-0000-4000-8000-000000000303',
@@ -277,6 +314,7 @@ insert into public.lca_package_export_items (
   (
     '91460000-0000-4000-8000-000000000204',
     '91460000-0000-4000-8000-000000000004',
+    '91460000-0000-4000-8000-000000000004',
     'processes',
     '91460000-0000-4000-8000-000000000304',
     '000000001',
@@ -287,6 +325,7 @@ insert into public.lca_package_export_items (
   ),
   (
     '91460000-0000-4000-8000-000000000205',
+    '91460000-0000-4000-8000-000000000005',
     '91460000-0000-4000-8000-000000000005',
     'processes',
     '91460000-0000-4000-8000-000000000305',
@@ -299,6 +338,7 @@ insert into public.lca_package_export_items (
   (
     '91460000-0000-4000-8000-000000000206',
     '91460000-0000-4000-8000-000000000006',
+    '91460000-0000-4000-8000-000000000006',
     'processes',
     '91460000-0000-4000-8000-000000000306',
     '000000001',
@@ -310,6 +350,7 @@ insert into public.lca_package_export_items (
   (
     '91460000-0000-4000-8000-000000000207',
     '91460000-0000-4000-8000-000000000007',
+    '91460000-0000-4000-8000-000000000007',
     'processes',
     '91460000-0000-4000-8000-000000000307',
     '000000001',
@@ -320,6 +361,7 @@ insert into public.lca_package_export_items (
   ),
   (
     '91460000-0000-4000-8000-000000000208',
+    '91460000-0000-4000-8000-000000000008',
     '91460000-0000-4000-8000-000000000008',
     'processes',
     '91460000-0000-4000-8000-000000000308',
@@ -338,6 +380,7 @@ insert into public.lca_package_request_cache (
   request_payload,
   status,
   job_id,
+  worker_job_id,
   export_artifact_id,
   report_artifact_id,
   hit_count,
@@ -352,6 +395,7 @@ insert into public.lca_package_request_cache (
     'old-ready-cache',
     '{}'::jsonb,
     'ready',
+    null,
     null,
     null,
     null,
@@ -370,6 +414,7 @@ insert into public.lca_package_request_cache (
     null,
     null,
     null,
+    null,
     3,
     '2026-01-30 00:00:00+00',
     '2026-01-30 00:00:00+00',
@@ -385,6 +430,7 @@ insert into public.lca_package_request_cache (
     null,
     null,
     null,
+    null,
     0,
     '2025-12-01 00:00:00+00',
     '2025-12-01 00:00:00+00',
@@ -397,6 +443,7 @@ insert into public.lca_package_request_cache (
     'recent-artifact-cache',
     '{}'::jsonb,
     'ready',
+    '91460000-0000-4000-8000-000000000005',
     '91460000-0000-4000-8000-000000000005',
     '91460000-0000-4000-8000-000000000105',
     null,
@@ -424,11 +471,11 @@ select ok(
   (
     select row_count >= 2
     from pg_temp.package_retention_preview
-    where retention_area = 'lca_package_jobs'
+    where retention_area = 'worker_jobs'
       and is_eligible
       and reason = 'eligible_terminal_job_older_than_window'
   ),
-  'old terminal jobs with no remaining object work are eligible'
+  'old terminal package worker jobs with no remaining object work are eligible'
 );
 
 select ok(
@@ -436,33 +483,33 @@ select ok(
     select row_count >= 4
       and total_artifact_bytes >= 110
     from pg_temp.package_retention_preview
-    where retention_area = 'lca_package_jobs'
+    where retention_area = 'worker_jobs'
       and not is_eligible
       and reason = 'protected_object_not_deleted'
   ),
-  'jobs with non-deleted artifact rows are protected until object-aware GC completes'
+  'package worker jobs with non-deleted artifact rows are protected until object-aware GC completes'
 );
 
 select ok(
   (
     select row_count >= 1
     from pg_temp.package_retention_preview
-    where retention_area = 'lca_package_jobs'
+    where retention_area = 'worker_jobs'
       and not is_eligible
       and reason = 'protected_inside_job_retention_window'
   ),
-  'recent terminal jobs are protected by the job retention window'
+  'recent terminal package worker jobs are protected by the job retention window'
 );
 
 select ok(
   (
     select row_count >= 1
     from pg_temp.package_retention_preview
-    where retention_area = 'lca_package_jobs'
+    where retention_area = 'worker_jobs'
       and not is_eligible
       and reason = 'protected_active_job'
   ),
-  'active package jobs are protected'
+  'active package worker jobs are protected'
 );
 
 select ok(
@@ -641,6 +688,11 @@ select ok(
   and lower(pg_get_functiondef('util.preview_lca_package_retention(interval,interval,timestamp with time zone)'::regprocedure)) not like '%update public.lca_package%'
   and lower(pg_get_functiondef('util.preview_lca_package_retention(interval,interval,timestamp with time zone)'::regprocedure)) not like '%insert into public.lca_package%',
   'dry-run function does not contain destructive package DML'
+);
+
+select ok(
+  lower(pg_get_functiondef('util.preview_lca_package_retention(interval,interval,timestamp with time zone)'::regprocedure)) not like '%lca_package_jobs%',
+  'dry-run function does not reference the legacy package job table'
 );
 
 select * from finish();

--- a/supabase/tests/20260602_worker_legacy_table_retirement_audit.sql
+++ b/supabase/tests/20260602_worker_legacy_table_retirement_audit.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(15);
+select plan(16);
 
 select has_view(
   'public',
@@ -148,15 +148,16 @@ select cmp_ok(
   'audit reports no runtime function body references to dataset_review_submit_jobs after coordinator cutover'
 );
 
-select ok(
-  exists (
-    select 1
+select cmp_ok(
+  (
+    select count(*)
     from public.worker_legacy_table_retirement_blockers
     where legacy_table = 'public.lca_package_jobs'
       and blocker_type = 'function_source_reference'
-      and not is_drop_restrict_blocker
   ),
-  'audit reports package function source references as runtime blockers'
+  '=',
+  0::bigint,
+  'audit reports no runtime function body references to lca_package_jobs after retention preview cutover'
 );
 
 select ok(
@@ -188,6 +189,11 @@ reset role;
 select lives_ok(
   $$drop table public.lca_jobs, public.lca_package_jobs, public.dataset_review_submit_jobs restrict$$,
   'legacy job tables can be dropped with RESTRICT inside the test transaction after DB blockers are removed'
+);
+
+select lives_ok(
+  $$select count(*) from util.preview_lca_package_retention(interval '30 days', interval '7 days', now())$$,
+  'package retention preview still runs after the legacy package job table is absent'
 );
 
 select * from finish();


### PR DESCRIPTION
## Summary
- Promotes the package retention table-absence-safe DB update from `dev` to `main`.
- Includes migration `20260603170500_package_retention_table_absence_safe.sql` from PR #194.

## Validation
Already completed on `dev` after PR #194 merged:
- `Supabase Dev` workflow succeeded for merge commit `79cac6cb80ae6d1f91afa2cd7942abd330e1acb0`.
- `supabase_migrations.schema_migrations` contains `20260603170500` on persistent dev.
- `worker_legacy_table_retirement_blockers` returned 0 rows for package/review-submit legacy table blocker/source-reference query.
- Transaction-scoped `DROP TABLE public.lca_package_jobs RESTRICT` succeeded, `util.preview_lca_package_retention(...)` still executed with the table absent, then rollback completed.

## Rollout Notes
- Production migrations are applied by the Supabase GitHub integration after `main` advances.
- After merge, run production proof for migration presence, blocker query, and transaction-scoped absence proof.

Refs #186
Refs tiangong-lca/workspace#242
