### PR TITLE
Optimize My Data latest-version list RPCs

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-03"
-lastReviewedCommit: "b6c351231116fd0890d2e2d8186f6ec2e455fea0"
+lastReviewedAt: "2026-06-08"
+lastReviewedCommit: "93dcf5cfdc0f51d6ccce108fbcb666907ae193ab"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: b6c351231116fd0890d2e2d8186f6ec2e455fea0
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 93dcf5cfdc0f51d6ccce108fbcb666907ae193ab
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: b6c351231116fd0890d2e2d8186f6ec2e455fea0
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 93dcf5cfdc0f51d6ccce108fbcb666907ae193ab
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: b6c351231116fd0890d2e2d8186f6ec2e455fea0
+lastReviewedAt: 2026-06-08
+lastReviewedCommit: 93dcf5cfdc0f51d6ccce108fbcb666907ae193ab
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260608165317_optimize_simple_latest_list_rpcs.sql
+++ b/supabase/migrations/20260608165317_optimize_simple_latest_list_rpcs.sql
@@ -1,0 +1,566 @@
+-- Optimize authenticated latest-version list RPCs for simple dataset tables.
+--
+-- My Data list pages should compare UUID-to-UUID and page lightweight keys
+-- before fetching JSON payloads. This mirrors the source latest-version RPC
+-- shape introduced for the same latency class.
+
+CREATE INDEX IF NOT EXISTS "contacts_user_id_id_version_modified_at_latest_idx"
+ON "public"."contacts" USING "btree" ("user_id", "id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id", "state_code");
+
+CREATE INDEX IF NOT EXISTS "unitgroups_user_id_id_version_modified_at_latest_idx"
+ON "public"."unitgroups" USING "btree" ("user_id", "id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id", "state_code");
+
+CREATE INDEX IF NOT EXISTS "flowproperties_user_id_id_version_modified_at_latest_idx"
+ON "public"."flowproperties" USING "btree" ("user_id", "id", "version" DESC, "modified_at" DESC)
+INCLUDE ("created_at", "team_id", "state_code");
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_keys AS (
+      SELECT c.id, c.version, c.created_at, c.modified_at, c.team_id
+      FROM public.contacts c
+      WHERE data_source = 'tg'
+        AND c.state_code = 100
+        AND (team_id_filter IS NULL OR c.team_id = team_id_filter)
+      UNION ALL
+      SELECT c.id, c.version, c.created_at, c.modified_at, c.team_id
+      FROM public.contacts c
+      WHERE data_source = 'co'
+        AND c.state_code = 200
+        AND (team_id_filter IS NULL OR c.team_id = team_id_filter)
+      UNION ALL
+      SELECT c.id, c.version, c.created_at, c.modified_at, c.team_id
+      FROM public.contacts c
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND c.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR c.state_code = state_code_filter)
+      UNION ALL
+      SELECT c.id, c.version, c.created_at, c.modified_at, c.team_id
+      FROM public.contacts c
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND c.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR c.state_code = state_code_filter)
+    ),
+    latest_keys AS (
+      SELECT DISTINCT ON (visible_keys.id)
+        visible_keys.id,
+        visible_keys.version,
+        visible_keys.created_at,
+        visible_keys.modified_at,
+        visible_keys.team_id
+      FROM visible_keys
+      ORDER BY visible_keys.id, visible_keys.version DESC, visible_keys.modified_at DESC
+    ),
+    counted_keys AS (
+      SELECT latest_keys.*, count(*) OVER()::bigint AS total_count
+      FROM latest_keys
+    ),
+    paged_keys AS (
+      SELECT counted_keys.*
+      FROM counted_keys
+      ORDER BY
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_keys.version
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_keys.version
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_keys.created_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.created_at
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_keys.modified_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.modified_at
+        END DESC NULLS LAST,
+        counted_keys.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size
+    )
+    SELECT
+      payload.id,
+      payload.json,
+      payload.version,
+      payload.modified_at,
+      payload.team_id,
+      paged_keys.total_count
+    FROM paged_keys
+    JOIN public.contacts payload
+      ON payload.id = paged_keys.id
+     AND payload.version = paged_keys.version
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN paged_keys.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN paged_keys.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN paged_keys.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN paged_keys.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.modified_at
+      END DESC NULLS LAST,
+      paged_keys.id;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_contact_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_keys AS (
+      SELECT u.id, u.version, u.created_at, u.modified_at, u.team_id
+      FROM public.unitgroups u
+      WHERE data_source = 'tg'
+        AND u.state_code = 100
+        AND (team_id_filter IS NULL OR u.team_id = team_id_filter)
+      UNION ALL
+      SELECT u.id, u.version, u.created_at, u.modified_at, u.team_id
+      FROM public.unitgroups u
+      WHERE data_source = 'co'
+        AND u.state_code = 200
+        AND (team_id_filter IS NULL OR u.team_id = team_id_filter)
+      UNION ALL
+      SELECT u.id, u.version, u.created_at, u.modified_at, u.team_id
+      FROM public.unitgroups u
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND u.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR u.state_code = state_code_filter)
+      UNION ALL
+      SELECT u.id, u.version, u.created_at, u.modified_at, u.team_id
+      FROM public.unitgroups u
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND u.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR u.state_code = state_code_filter)
+    ),
+    latest_keys AS (
+      SELECT DISTINCT ON (visible_keys.id)
+        visible_keys.id,
+        visible_keys.version,
+        visible_keys.created_at,
+        visible_keys.modified_at,
+        visible_keys.team_id
+      FROM visible_keys
+      ORDER BY visible_keys.id, visible_keys.version DESC, visible_keys.modified_at DESC
+    ),
+    counted_keys AS (
+      SELECT latest_keys.*, count(*) OVER()::bigint AS total_count
+      FROM latest_keys
+    ),
+    paged_keys AS (
+      SELECT counted_keys.*
+      FROM counted_keys
+      ORDER BY
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_keys.version
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_keys.version
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_keys.created_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.created_at
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_keys.modified_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.modified_at
+        END DESC NULLS LAST,
+        counted_keys.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size
+    )
+    SELECT
+      payload.id,
+      payload.json,
+      payload.version,
+      payload.modified_at,
+      payload.team_id,
+      paged_keys.total_count
+    FROM paged_keys
+    JOIN public.unitgroups payload
+      ON payload.id = paged_keys.id
+     AND payload.version = paged_keys.version
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN paged_keys.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN paged_keys.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN paged_keys.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN paged_keys.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.modified_at
+      END DESC NULLS LAST,
+      paged_keys.id;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_unitgroup_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";
+
+CREATE OR REPLACE FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint DEFAULT 10,
+  "page_current" bigint DEFAULT 1,
+  "data_source" text DEFAULT 'tg'::text,
+  "this_user_id" text DEFAULT ''::text,
+  "team_id_filter" uuid DEFAULT NULL::uuid,
+  "state_code_filter" integer DEFAULT NULL::integer,
+  "sort_by" text DEFAULT 'modified_at'::text,
+  "sort_direction" text DEFAULT 'desc'::text
+) RETURNS TABLE(
+  "id" uuid,
+  "json" jsonb,
+  "version" character(9),
+  "modified_at" timestamp with time zone,
+  "team_id" uuid,
+  "total_count" bigint
+)
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  normalized_page_size bigint;
+  normalized_page_current bigint;
+  normalized_sort_by text;
+  normalized_sort_direction text;
+  normalized_this_user_id uuid;
+BEGIN
+  normalized_page_size := greatest(coalesce(page_size, 10), 1);
+  normalized_page_current := greatest(coalesce(page_current, 1), 1);
+  normalized_sort_by := lower(coalesce(sort_by, 'modified_at'));
+  normalized_sort_direction := lower(coalesce(sort_direction, 'desc'));
+  normalized_this_user_id := CASE
+    WHEN coalesce(btrim(this_user_id) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', false)
+      THEN btrim(this_user_id)::uuid
+    ELSE NULL::uuid
+  END;
+
+  RETURN QUERY
+    WITH visible_keys AS (
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.flowproperties f
+      WHERE data_source = 'tg'
+        AND f.state_code = 100
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.flowproperties f
+      WHERE data_source = 'co'
+        AND f.state_code = 200
+        AND (team_id_filter IS NULL OR f.team_id = team_id_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.flowproperties f
+      WHERE data_source = 'my'
+        AND normalized_this_user_id IS NOT NULL
+        AND f.user_id = normalized_this_user_id
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+      UNION ALL
+      SELECT f.id, f.version, f.created_at, f.modified_at, f.team_id
+      FROM public.flowproperties f
+      WHERE data_source = 'te'
+        AND team_id_filter IS NOT NULL
+        AND f.team_id = team_id_filter
+        AND (state_code_filter IS NULL OR f.state_code = state_code_filter)
+    ),
+    latest_keys AS (
+      SELECT DISTINCT ON (visible_keys.id)
+        visible_keys.id,
+        visible_keys.version,
+        visible_keys.created_at,
+        visible_keys.modified_at,
+        visible_keys.team_id
+      FROM visible_keys
+      ORDER BY visible_keys.id, visible_keys.version DESC, visible_keys.modified_at DESC
+    ),
+    counted_keys AS (
+      SELECT latest_keys.*, count(*) OVER()::bigint AS total_count
+      FROM latest_keys
+    ),
+    paged_keys AS (
+      SELECT counted_keys.*
+      FROM counted_keys
+      ORDER BY
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN counted_keys.version
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN counted_keys.version
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN counted_keys.created_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.created_at
+        END DESC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN counted_keys.modified_at
+        END ASC NULLS LAST,
+        CASE
+          WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN counted_keys.modified_at
+        END DESC NULLS LAST,
+        counted_keys.id
+      LIMIT normalized_page_size
+      OFFSET (normalized_page_current - 1) * normalized_page_size
+    )
+    SELECT
+      payload.id,
+      payload.json,
+      payload.version,
+      payload.modified_at,
+      payload.team_id,
+      paged_keys.total_count
+    FROM paged_keys
+    JOIN public.flowproperties payload
+      ON payload.id = paged_keys.id
+     AND payload.version = paged_keys.version
+    ORDER BY
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction = 'asc' THEN paged_keys.version
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'version' AND normalized_sort_direction <> 'asc' THEN paged_keys.version
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction = 'asc' THEN paged_keys.created_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'created_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.created_at
+      END DESC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction = 'asc' THEN paged_keys.modified_at
+      END ASC NULLS LAST,
+      CASE
+        WHEN normalized_sort_by = 'modified_at' AND normalized_sort_direction <> 'asc' THEN paged_keys.modified_at
+      END DESC NULLS LAST,
+      paged_keys.id;
+END;
+$$;
+
+ALTER FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) OWNER TO "postgres";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "anon";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "authenticated";
+
+GRANT ALL ON FUNCTION "public"."get_latest_flowproperty_versions"(
+  "page_size" bigint,
+  "page_current" bigint,
+  "data_source" text,
+  "this_user_id" text,
+  "team_id_filter" uuid,
+  "state_code_filter" integer,
+  "sort_by" text,
+  "sort_direction" text
+) TO "service_role";

--- a/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_contacts_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(12);
+select plan(15);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -207,6 +207,36 @@ select is(
   ),
   2::bigint,
   'team filter limits open contact latest-version rows before pagination'
+);
+
+select is(
+  strpos(
+    lower(pg_get_functiondef('public.get_latest_contact_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+    'user_id::text = this_user_id'
+  ),
+  0,
+  'contact latest list does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  strpos(
+    lower(pg_get_functiondef('public.get_latest_contact_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+    'with visible_keys as'
+  ) > 0
+    and strpos(
+      lower(pg_get_functiondef('public.get_latest_contact_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+      'paged_keys as'
+    ) > 0
+    and strpos(
+      lower(pg_get_functiondef('public.get_latest_contact_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+      'join public.contacts payload'
+    ) > 0,
+  'contact latest list paginates key rows before fetching json payload'
+);
+
+select ok(
+  to_regclass('public.contacts_user_id_id_version_modified_at_latest_idx') is not null,
+  'contact latest list has a my-data covering key index'
 );
 
 

--- a/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_flowproperties_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(11);
+select plan(14);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -168,6 +168,36 @@ select is(
   ),
   2::bigint,
   'team filter limits open flow property latest-version rows before pagination'
+);
+
+select is(
+  strpos(
+    lower(pg_get_functiondef('public.get_latest_flowproperty_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+    'user_id::text = this_user_id'
+  ),
+  0,
+  'flow property latest list does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  strpos(
+    lower(pg_get_functiondef('public.get_latest_flowproperty_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+    'with visible_keys as'
+  ) > 0
+    and strpos(
+      lower(pg_get_functiondef('public.get_latest_flowproperty_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+      'paged_keys as'
+    ) > 0
+    and strpos(
+      lower(pg_get_functiondef('public.get_latest_flowproperty_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+      'join public.flowproperties payload'
+    ) > 0,
+  'flow property latest list paginates key rows before fetching json payload'
+);
+
+select ok(
+  to_regclass('public.flowproperties_user_id_id_version_modified_at_latest_idx') is not null,
+  'flow property latest list has a my-data covering key index'
 );
 
 

--- a/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_unitgroups_latest_version_query_rpcs.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(11);
+select plan(14);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -168,6 +168,36 @@ select is(
   ),
   2::bigint,
   'team filter limits open unit group latest-version rows before pagination'
+);
+
+select is(
+  strpos(
+    lower(pg_get_functiondef('public.get_latest_unitgroup_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+    'user_id::text = this_user_id'
+  ),
+  0,
+  'unit group latest list does not cast user_id on the my-data predicate'
+);
+
+select ok(
+  strpos(
+    lower(pg_get_functiondef('public.get_latest_unitgroup_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+    'with visible_keys as'
+  ) > 0
+    and strpos(
+      lower(pg_get_functiondef('public.get_latest_unitgroup_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+      'paged_keys as'
+    ) > 0
+    and strpos(
+      lower(pg_get_functiondef('public.get_latest_unitgroup_versions(bigint,bigint,text,text,uuid,integer,text,text)'::regprocedure)),
+      'join public.unitgroups payload'
+    ) > 0,
+  'unit group latest list paginates key rows before fetching json payload'
+);
+
+select ok(
+  to_regclass('public.unitgroups_user_id_id_version_modified_at_latest_idx') is not null,
+  'unit group latest list has a my-data covering key index'
 );
 
 


### PR DESCRIPTION
Closes #203

## Summary
- Rewrite contact, unitgroup, and flowproperty latest-version list RPCs to normalize caller ids as uuid and avoid casting indexed user_id columns to text.
- Page visible/latest key rows before joining JSON payloads, preserving response shape, sorting, filters, and total_count behavior.
- Add targeted My Data covering key indexes and regression assertions for no-cast/key-first query shape.

## Key Decisions
- Kept frontend contracts unchanged; exact total_count and offset pagination remain in place for this first database-side fix.
- Reviewed process/lifecyclemodel latest RPCs; current dev already normalizes caller ids, while process typeOfDataSet JSON filtering should be handled separately if EXPLAIN shows it remains slow.

## Validation
- git diff --check
- docpact lint --root . --staged --format json --output /tmp/database-engine-docpact-issue203-staged.json
- PGTAP plan/assertion count checks for contacts, unitgroups, and flowproperties latest-version test files
- Disposable supabase/postgres:15.8.1.085 smoke: migration creation plus latest-version, total_count, and team-filter behavior for all three RPCs
- Not run: full supabase db reset / repository PGTAP; local host lacks supabase and psql CLI binaries
- Not captured: representative EXPLAIN ANALYZE; local checkout has no target Supabase branch data or production-size user dataset access

## Risks / Rollback
- Migration adds three btree covering indexes; rollback is dropping the new indexes and restoring prior function bodies if remote validation exposes an unexpected plan regression.

## Follow-ups
- Capture representative EXPLAIN on the target Supabase branch before merge or during branch validation if data access is available.
- If latency remains dominated by count(*) over() or offset pagination, open a separate API/product follow-up for count strategy or cursor pagination.

## Workspace Integration
- After merge and child main eligibility, lca-workspace needs a database-engine submodule pointer bump under the workspace integration policy.