### PR TITLE
chore: add advisor foreign key indexes

### DIFF
--- a/supabase/migrations/20260608090501_add_missing_fk_support_indexes.sql
+++ b/supabase/migrations/20260608090501_add_missing_fk_support_indexes.sql
@@ -1,0 +1,3 @@
+create index concurrently if not exists dataset_review_submit_gate_runs_supersedes_idx
+  on public.dataset_review_submit_gate_runs (supersedes_gate_run_id)
+  where supersedes_gate_run_id is not null;

--- a/supabase/migrations/20260608090628_add_lca_network_snapshots_lcia_index.sql
+++ b/supabase/migrations/20260608090628_add_lca_network_snapshots_lcia_index.sql
@@ -1,0 +1,3 @@
+create index concurrently if not exists lca_network_snapshots_lcia_idx
+  on public.lca_network_snapshots (lcia_method_id, lcia_method_version)
+  where lcia_method_id is not null;

--- a/supabase/migrations/20260608090629_add_lca_package_request_cache_export_artifact_index.sql
+++ b/supabase/migrations/20260608090629_add_lca_package_request_cache_export_artifact_index.sql
@@ -1,0 +1,3 @@
+create index concurrently if not exists lca_package_request_cache_export_artifact_idx
+  on public.lca_package_request_cache (export_artifact_id)
+  where export_artifact_id is not null;

--- a/supabase/migrations/20260608090630_add_lca_package_request_cache_report_artifact_index.sql
+++ b/supabase/migrations/20260608090630_add_lca_package_request_cache_report_artifact_index.sql
@@ -1,0 +1,3 @@
+create index concurrently if not exists lca_package_request_cache_report_artifact_idx
+  on public.lca_package_request_cache (report_artifact_id)
+  where report_artifact_id is not null;

--- a/supabase/migrations/20260608090631_add_lca_result_cache_snapshot_index.sql
+++ b/supabase/migrations/20260608090631_add_lca_result_cache_snapshot_index.sql
@@ -1,0 +1,2 @@
+create index concurrently if not exists lca_result_cache_snapshot_idx
+  on public.lca_result_cache (snapshot_id);

--- a/supabase/migrations/20260608090632_add_notifications_sender_user_id_index.sql
+++ b/supabase/migrations/20260608090632_add_notifications_sender_user_id_index.sql
@@ -1,0 +1,2 @@
+create index concurrently if not exists notifications_sender_user_id_idx
+  on public.notifications (sender_user_id);

--- a/supabase/migrations/20260608090633_add_worker_jobs_job_kind_index.sql
+++ b/supabase/migrations/20260608090633_add_worker_jobs_job_kind_index.sql
@@ -1,0 +1,2 @@
+create index concurrently if not exists worker_jobs_job_kind_idx
+  on public.worker_jobs (job_kind);

--- a/supabase/tests/20260608_missing_fk_support_indexes.sql
+++ b/supabase/tests/20260608_missing_fk_support_indexes.sql
@@ -1,0 +1,44 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(7);
+
+select ok(
+  to_regclass('public.dataset_review_submit_gate_runs_supersedes_idx') is not null,
+  'dataset_review_submit_gate_runs has a supersedes gate run support index'
+);
+
+select ok(
+  to_regclass('public.lca_network_snapshots_lcia_idx') is not null,
+  'lca_network_snapshots has an LCIA method support index'
+);
+
+select ok(
+  to_regclass('public.lca_package_request_cache_export_artifact_idx') is not null,
+  'lca_package_request_cache has an export artifact support index'
+);
+
+select ok(
+  to_regclass('public.lca_package_request_cache_report_artifact_idx') is not null,
+  'lca_package_request_cache has a report artifact support index'
+);
+
+select ok(
+  to_regclass('public.lca_result_cache_snapshot_idx') is not null,
+  'lca_result_cache has a snapshot support index'
+);
+
+select ok(
+  to_regclass('public.notifications_sender_user_id_idx') is not null,
+  'notifications has a sender user support index'
+);
+
+select ok(
+  to_regclass('public.worker_jobs_job_kind_idx') is not null,
+  'worker_jobs has a job kind support index'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #204

## Summary
- Add Supabase Advisor-reported support indexes for review-submit gate runs, LCA snapshot/cache tables, notifications, and worker_jobs.
- Keep nullable optional references as partial indexes so null rows are not indexed.

## Key Decisions
- Split the CREATE INDEX CONCURRENTLY statements into one migration file per index so Postgres can build them outside multi-statement transaction execution.
- Keep worker_jobs(job_kind) as the advisor-requested simple support index because job_kind is both a foreign key and a common job-family filter.

## Validation
- supabase db reset
- supabase test db supabase/tests/20260608_missing_fk_support_indexes.sql
- supabase migration list --local
- Supabase Preview check: cancelled before migration execution because the project reached the maximum concurrent preview branch limit; rerun after freeing preview capacity.

## Risks / Rollback
- Low semantic risk: index-only migrations do not change constraints, policies, grants, or table data.
- Operational risk is limited by using CREATE INDEX CONCURRENTLY; preview and remote dev should still validate Supabase branch migration application.
- Preview validation is pending on external Supabase preview branch capacity, not on a known SQL migration failure.

## Follow-ups
- Run Supabase Advisor again after preview/dev deployment to confirm the missing-index findings clear.

## Workspace Integration
- After this PR merges and database-engine is promoted as needed, update the lca-workspace submodule pointer through the normal integration workflow.
