### PR TITLE
注册全国碳图谱缓存 worker job kind

### DIFF
--- a/supabase/migrations/20260612093000_national_carbon_graph_cache_worker_job_kind.sql
+++ b/supabase/migrations/20260612093000_national_carbon_graph_cache_worker_job_kind.sql
@@ -1,0 +1,37 @@
+insert into public.worker_job_kinds (
+  job_kind,
+  worker_runtime,
+  worker_queue,
+  default_visibility,
+  default_priority,
+  default_max_attempts,
+  default_lease_seconds,
+  payload_schema_version,
+  result_schema_version,
+  user_visible,
+  description
+) values (
+  'national_carbon.process_flow_graph_cache_build',
+  'calculator',
+  'maintenance',
+  'operator',
+  0,
+  1,
+  3600,
+  'national_carbon.process_flow_graph_cache_build.request.v1',
+  'national_carbon.process_flow_graph_cache_build.result.v1',
+  false,
+  'Build national carbon process-flow graph cache through the maintenance worker'
+)
+on conflict (job_kind) do update
+set worker_runtime = excluded.worker_runtime,
+    worker_queue = excluded.worker_queue,
+    default_visibility = excluded.default_visibility,
+    default_priority = excluded.default_priority,
+    default_max_attempts = excluded.default_max_attempts,
+    default_lease_seconds = excluded.default_lease_seconds,
+    payload_schema_version = excluded.payload_schema_version,
+    result_schema_version = excluded.result_schema_version,
+    user_visible = excluded.user_visible,
+    description = excluded.description,
+    updated_at = now();

--- a/supabase/tests/20260531_worker_jobs_foundation.sql
+++ b/supabase/tests/20260531_worker_jobs_foundation.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(40);
+select plan(42);
 
 select ok(to_regclass('public.worker_job_kinds') is not null, 'worker job kind registry exists');
 select ok(to_regclass('public.worker_jobs') is not null, 'worker_jobs table exists');
@@ -38,8 +38,25 @@ select ok(
 select cmp_ok(
   (select count(*) from public.worker_job_kinds),
   '>=',
-  12::bigint,
+  13::bigint,
   'initial worker job kinds are registered'
+);
+
+select ok(
+  exists (
+    select 1
+    from public.worker_job_kinds
+    where job_kind = 'national_carbon.process_flow_graph_cache_build'
+      and worker_runtime = 'calculator'
+      and worker_queue = 'maintenance'
+      and default_visibility = 'operator'
+      and default_max_attempts = 1
+      and default_lease_seconds = 3600
+      and payload_schema_version = 'national_carbon.process_flow_graph_cache_build.request.v1'
+      and result_schema_version = 'national_carbon.process_flow_graph_cache_build.result.v1'
+      and user_visible = false
+  ),
+  'national carbon process-flow graph cache worker job kind is registered'
 );
 
 set local role authenticated;
@@ -161,6 +178,32 @@ select is(
   )->>'code',
   'WORKER_JOB_CONCURRENCY_CONFLICT',
   'concurrencyKey prevents conflicting active jobs'
+);
+
+insert into worker_job_test_ids (label, job_id)
+select
+  'national_carbon_graph_cache',
+  (result->'data'->>'id')::uuid
+from (
+  select public.worker_enqueue_job(
+    p_job_kind => 'national_carbon.process_flow_graph_cache_build',
+    p_payload_json => '{"environment":"test","execute":true}'::jsonb,
+    p_requested_by => '96000000-0000-4000-8000-000000000001',
+    p_requester_type => 'operator',
+    p_idempotency_key => 'national-carbon:process-flow-graph-cache:test:execute',
+    p_concurrency_key => 'national-carbon:process-flow-graph-cache:test:execute',
+    p_subject_type => 'national_carbon_process_flow_graph_cache'
+  ) as result
+) as enqueue;
+
+select is(
+  (
+    select job_kind || ':' || worker_queue || ':' || visibility || ':' || max_attempts::text || ':' || payload_schema_version
+    from public.worker_jobs
+    where id = (select job_id from worker_job_test_ids where label = 'national_carbon_graph_cache')
+  ),
+  'national_carbon.process_flow_graph_cache_build:maintenance:operator:1:national_carbon.process_flow_graph_cache_build.request.v1',
+  'national carbon graph cache enqueue creates a maintenance operator worker job'
 );
 
 insert into worker_job_test_ids (label, job_id)


### PR DESCRIPTION
Closes tiangong-lca/database-engine#212

## Summary
- 新增 Supabase migration，注册 national_carbon.process_flow_graph_cache_build worker job kind，固定 calculator runtime 与 maintenance queue。
- 扩展 worker_jobs_foundation SQL 测试，覆盖 job kind 注册属性以及 worker_enqueue_job 入库契约。

## Key Decisions
- 将该任务注册为 operator-only、user_visible=false 的维护类 job，前端不会自行传入任意 job kind。

## Validation
- 已静态检查 migration 与 SQL 测试变更。
- 尝试运行 npx -y supabase@2.85.0 db reset；本机 Supabase start 因 Docker 拉取 public.ecr.aws 镜像走 127.0.0.1:7890 代理失败而阻塞，未能执行本地数据库测试。

## Risks / Rollback
- 低到中：仅新增 job kind seed/migration 与对应 foundation 测试；回滚可删除本次 migration 或补充反向 migration。

## Follow-ups
- 待 PR CI 或可用 Supabase Docker 环境执行 SQL 测试后再合并。

## Workspace Integration
- 合并到 database-engine dev 后仍需按 workspace release/promotion 规则处理 root submodule integration。