### PR TITLE
Fix hybrid search PGroonga query term escaping

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-11"
-lastReviewedCommit: "d544f26f0a27d861d8122ba8520d76412c02357b"
+lastReviewedAt: "2026-06-13"
+lastReviewedCommit: "5ce13e2d325eb3fc8272871c3a5784d4d64a90fc"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: d544f26f0a27d861d8122ba8520d76412c02357b
+lastReviewedAt: 2026-06-13
+lastReviewedCommit: 5ce13e2d325eb3fc8272871c3a5784d4d64a90fc
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: d544f26f0a27d861d8122ba8520d76412c02357b
+lastReviewedAt: 2026-06-13
+lastReviewedCommit: 5ce13e2d325eb3fc8272871c3a5784d4d64a90fc
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-11
-lastReviewedCommit: d544f26f0a27d861d8122ba8520d76412c02357b
+lastReviewedAt: 2026-06-13
+lastReviewedCommit: 5ce13e2d325eb3fc8272871c3a5784d4d64a90fc
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260613142228_hybrid_search_query_terms_escape.sql
+++ b/supabase/migrations/20260613142228_hybrid_search_query_terms_escape.sql
@@ -1,0 +1,190 @@
+create or replace function private.pgroonga_escape_query_terms(query_terms text[])
+returns text[]
+language sql
+immutable
+set search_path to 'extensions', 'pg_temp'
+as $$
+  select coalesce(
+    array_agg(extensions.pgroonga_query_escape(normalized_term) order by ord),
+    '{}'::text[]
+  )
+  from (
+    select regexp_replace(btrim(raw_term.term), '[[:space:]]+', ' ', 'g') as normalized_term,
+           raw_term.ord
+    from unnest(coalesce(query_terms, '{}'::text[])) with ordinality as raw_term(term, ord)
+    where raw_term.term is not null
+      and btrim(raw_term.term) <> ''
+  ) terms;
+$$;
+
+create or replace function pg_temp.required_replace(
+  source_text text,
+  old_text text,
+  new_text text,
+  replacement_label text
+) returns text
+language plpgsql
+as $$
+declare
+  replaced_text text;
+begin
+  replaced_text := replace(source_text, old_text, new_text);
+  if replaced_text = source_text then
+    raise exception 'required replacement did not apply: %', replacement_label;
+  end if;
+  return replaced_text;
+end;
+$$;
+
+do $$
+declare
+  flow_private constant regprocedure := 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure;
+  process_private constant regprocedure := 'private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure;
+  lifecyclemodel_private constant regprocedure := 'private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure;
+  flow_public constant regprocedure := 'public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure;
+  process_public constant regprocedure := 'public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure;
+  lifecyclemodel_public constant regprocedure := 'public.search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure;
+  flow_hybrid constant regprocedure := 'public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure;
+  process_hybrid constant regprocedure := 'public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure;
+  lifecyclemodel_hybrid constant regprocedure := 'public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure;
+  fn text;
+begin
+  fn := pg_get_functiondef(lifecyclemodel_private);
+  fn := pg_temp.required_replace(fn, 'state_code_filter integer DEFAULT NULL::integer)', 'state_code_filter integer DEFAULT NULL::integer, query_terms text[] DEFAULT NULL::text[])', 'lifecyclemodel private signature');
+  fn := pg_temp.required_replace(fn, '  v_sql text;', '  v_sql text;
+  escaped_query_terms text[];
+  text_match_clause text;', 'lifecyclemodel private declarations');
+  fn := pg_temp.required_replace(fn, '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);', '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);
+  escaped_query_terms := private.pgroonga_escape_query_terms(query_terms);
+  text_match_clause := case
+    when cardinality(escaped_query_terms) > 0 then ''where l.extracted_text &@~| $10''
+    else ''where l.extracted_text &@~ $1''
+  end;', 'lifecyclemodel private escaped terms');
+  fn := pg_temp.required_replace(fn, '      where l.extracted_text &@~ $1', '      %s', 'lifecyclemodel private text match clause');
+  fn := pg_temp.required_replace(fn, '$sql$, json_filter_clause);', '$sql$, text_match_clause, json_filter_clause);', 'lifecyclemodel private format args');
+  fn := pg_temp.required_replace(fn, '          normalized_data_source, effective_user_id, team_id_filter, state_code_filter, can_read_team_filter;', '          normalized_data_source, effective_user_id, team_id_filter, state_code_filter,
+          can_read_team_filter, escaped_query_terms;', 'lifecyclemodel private execute args');
+  execute fn;
+
+  fn := pg_get_functiondef(process_private);
+  fn := pg_temp.required_replace(fn, 'type_of_data_set_filter text DEFAULT ''all''::text)', 'type_of_data_set_filter text DEFAULT ''all''::text, query_terms text[] DEFAULT NULL::text[])', 'process private signature');
+  fn := pg_temp.required_replace(fn, '  v_sql text;', '  v_sql text;
+  escaped_query_terms text[];
+  text_match_clause text;', 'process private declarations');
+  fn := pg_temp.required_replace(fn, '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);', '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);
+  escaped_query_terms := private.pgroonga_escape_query_terms(query_terms);
+  text_match_clause := case
+    when cardinality(escaped_query_terms) > 0 then ''where p.extracted_text &@~| $11''
+    else ''where p.extracted_text &@~ $1''
+  end;', 'process private escaped terms');
+  fn := pg_temp.required_replace(fn, '      where p.extracted_text &@~ $1', '      %s', 'process private text match clause');
+  fn := pg_temp.required_replace(fn, '$sql$, json_filter_clause);', '$sql$, text_match_clause, json_filter_clause);', 'process private format args');
+  fn := pg_temp.required_replace(fn, '          can_read_team_filter, type_of_data_set_filter;', '          can_read_team_filter, type_of_data_set_filter, escaped_query_terms;', 'process private execute args');
+  execute fn;
+
+  fn := pg_get_functiondef(flow_private);
+  fn := pg_temp.required_replace(fn, 'state_code_filter integer DEFAULT NULL::integer)', 'state_code_filter integer DEFAULT NULL::integer, query_terms text[] DEFAULT NULL::text[])', 'flow private signature');
+  fn := pg_temp.required_replace(fn, '  v_sql text;', '  v_sql text;
+  escaped_query_terms text[];
+  text_match_clause text;', 'flow private declarations');
+  fn := pg_temp.required_replace(fn, '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);', '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);
+  escaped_query_terms := private.pgroonga_escape_query_terms(query_terms);
+  text_match_clause := case
+    when cardinality(escaped_query_terms) > 0 then ''where f.extracted_text &@~| $14''
+    else ''where f.extracted_text &@~ $1''
+  end;', 'flow private escaped terms');
+  fn := pg_temp.required_replace(fn, '      where f.extracted_text &@~ $1', '      %s', 'flow private text match clause');
+  fn := pg_temp.required_replace(fn, '$sql$, json_filter_clause);', '$sql$, text_match_clause, json_filter_clause);', 'flow private format args');
+  fn := pg_temp.required_replace(fn, '          can_read_team_filter, flow_type, flow_type_array, as_input, classification_filter;', '          can_read_team_filter, flow_type, flow_type_array, as_input, classification_filter,
+          escaped_query_terms;', 'flow private execute args');
+  execute fn;
+
+  fn := pg_get_functiondef(lifecyclemodel_public);
+  fn := pg_temp.required_replace(fn, 'state_code_filter integer DEFAULT NULL::integer)', 'state_code_filter integer DEFAULT NULL::integer, query_terms text[] DEFAULT NULL::text[])', 'lifecyclemodel public signature');
+  fn := pg_temp.required_replace(fn, '      state_code_filter
+    );', '      state_code_filter,
+      query_terms
+    );', 'lifecyclemodel public query_terms passthrough');
+  execute fn;
+
+  fn := pg_get_functiondef(process_public);
+  fn := pg_temp.required_replace(fn, 'type_of_data_set_filter text DEFAULT ''all''::text)', 'type_of_data_set_filter text DEFAULT ''all''::text, query_terms text[] DEFAULT NULL::text[])', 'process public signature');
+  fn := pg_temp.required_replace(fn, '      type_of_data_set_filter
+    );', '      type_of_data_set_filter,
+      query_terms
+    );', 'process public query_terms passthrough');
+  execute fn;
+
+  fn := pg_get_functiondef(flow_public);
+  fn := pg_temp.required_replace(fn, 'state_code_filter integer DEFAULT NULL::integer)', 'state_code_filter integer DEFAULT NULL::integer, query_terms text[] DEFAULT NULL::text[])', 'flow public signature');
+  fn := pg_temp.required_replace(fn, '      state_code_filter
+    );', '      state_code_filter,
+      query_terms
+    );', 'flow public query_terms passthrough');
+  execute fn;
+
+  fn := pg_get_functiondef(lifecyclemodel_hybrid);
+  fn := pg_temp.required_replace(fn, 'page_current integer DEFAULT 1)', 'page_current integer DEFAULT 1, query_terms text[] DEFAULT NULL::text[])', 'lifecyclemodel hybrid signature');
+  fn := pg_temp.required_replace(fn, '        null::integer
+      ) ts', '        null::integer,
+        query_terms
+      ) ts', 'lifecyclemodel hybrid query_terms passthrough');
+  execute fn;
+
+  fn := pg_get_functiondef(process_hybrid);
+  fn := pg_temp.required_replace(fn, 'page_current integer DEFAULT 1)', 'page_current integer DEFAULT 1, query_terms text[] DEFAULT NULL::text[])', 'process hybrid signature');
+  fn := pg_temp.required_replace(fn, '        ''all''
+      ) ts', '        ''all'',
+        query_terms
+      ) ts', 'process hybrid query_terms passthrough');
+  execute fn;
+
+  fn := pg_get_functiondef(flow_hybrid);
+  fn := pg_temp.required_replace(fn, 'page_current integer DEFAULT 1)', 'page_current integer DEFAULT 1, query_terms text[] DEFAULT NULL::text[])', 'flow hybrid signature');
+  fn := pg_temp.required_replace(fn, '        null::integer
+      ) ts', '        null::integer,
+        query_terms
+      ) ts', 'flow hybrid query_terms passthrough');
+  execute fn;
+end;
+$$;
+
+drop function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+drop function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+drop function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer);
+
+drop function public.search_flows_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer);
+drop function public.search_processes_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text);
+drop function public.search_lifecyclemodels_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer);
+
+drop function private.search_flows_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer);
+drop function private.search_processes_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text);
+drop function private.search_lifecyclemodels_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer);
+
+alter function private.pgroonga_escape_query_terms(text[]) owner to postgres;
+alter function private.search_lifecyclemodels_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text[]) owner to postgres;
+alter function private.search_processes_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text, text[]) owner to postgres;
+alter function private.search_flows_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text[]) owner to postgres;
+alter function public.search_lifecyclemodels_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text[]) owner to postgres;
+alter function public.search_processes_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text, text[]) owner to postgres;
+alter function public.search_flows_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text[]) owner to postgres;
+alter function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer, text[]) owner to postgres;
+alter function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer, text[]) owner to postgres;
+alter function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer, text[]) owner to postgres;
+
+revoke all on function private.pgroonga_escape_query_terms(text[]) from public;
+revoke all on function private.search_lifecyclemodels_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text[]) from public;
+revoke all on function private.search_processes_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text, text[]) from public;
+revoke all on function private.search_flows_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text[]) from public;
+
+grant execute on function private.pgroonga_escape_query_terms(text[]) to anon, authenticated, service_role;
+grant execute on function private.search_lifecyclemodels_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text[]) to anon, authenticated, service_role;
+grant execute on function private.search_processes_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text, text[]) to anon, authenticated, service_role;
+grant execute on function private.search_flows_latest_impl(text, jsonb, bigint, bigint, text, text, uuid, integer, text[]) to anon, authenticated, service_role;
+
+grant all on function public.search_lifecyclemodels_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text[]) to anon, authenticated, service_role;
+grant all on function public.search_processes_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text, text[]) to anon, authenticated, service_role;
+grant all on function public.search_flows_latest(text, jsonb, jsonb, bigint, bigint, text, text, uuid, integer, text[]) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_lifecyclemodels(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer, text[]) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_processes(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer, text[]) to anon, authenticated, service_role;
+grant all on function public.hybrid_search_flows(text, text, text, double precision, integer, double precision, double precision, double precision, integer, text, integer, integer, text[]) to anon, authenticated, service_role;

--- a/supabase/migrations/20260613142228_hybrid_search_query_terms_escape.sql
+++ b/supabase/migrations/20260613142228_hybrid_search_query_terms_escape.sql
@@ -56,10 +56,10 @@ begin
   text_match_clause text;', 'lifecyclemodel private declarations');
   fn := pg_temp.required_replace(fn, '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);', '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);
   escaped_query_terms := private.pgroonga_escape_query_terms(query_terms);
-  text_match_clause := case
-    when cardinality(escaped_query_terms) > 0 then ''where l.extracted_text &@~| $10''
-    else ''where l.extracted_text &@~ $1''
-  end;', 'lifecyclemodel private escaped terms');
+  if cardinality(escaped_query_terms) = 0 then
+    escaped_query_terms := private.pgroonga_escape_query_terms(array[query_text]);
+  end if;
+  text_match_clause := ''where l.extracted_text &@~| $10'';', 'lifecyclemodel private escaped terms');
   fn := pg_temp.required_replace(fn, '      where l.extracted_text &@~ $1', '      %s', 'lifecyclemodel private text match clause');
   fn := pg_temp.required_replace(fn, '$sql$, json_filter_clause);', '$sql$, text_match_clause, json_filter_clause);', 'lifecyclemodel private format args');
   fn := pg_temp.required_replace(fn, '          normalized_data_source, effective_user_id, team_id_filter, state_code_filter, can_read_team_filter;', '          normalized_data_source, effective_user_id, team_id_filter, state_code_filter,
@@ -73,10 +73,10 @@ begin
   text_match_clause text;', 'process private declarations');
   fn := pg_temp.required_replace(fn, '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);', '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);
   escaped_query_terms := private.pgroonga_escape_query_terms(query_terms);
-  text_match_clause := case
-    when cardinality(escaped_query_terms) > 0 then ''where p.extracted_text &@~| $11''
-    else ''where p.extracted_text &@~ $1''
-  end;', 'process private escaped terms');
+  if cardinality(escaped_query_terms) = 0 then
+    escaped_query_terms := private.pgroonga_escape_query_terms(array[query_text]);
+  end if;
+  text_match_clause := ''where p.extracted_text &@~| $11'';', 'process private escaped terms');
   fn := pg_temp.required_replace(fn, '      where p.extracted_text &@~ $1', '      %s', 'process private text match clause');
   fn := pg_temp.required_replace(fn, '$sql$, json_filter_clause);', '$sql$, text_match_clause, json_filter_clause);', 'process private format args');
   fn := pg_temp.required_replace(fn, '          can_read_team_filter, type_of_data_set_filter;', '          can_read_team_filter, type_of_data_set_filter, escaped_query_terms;', 'process private execute args');
@@ -89,10 +89,10 @@ begin
   text_match_clause text;', 'flow private declarations');
   fn := pg_temp.required_replace(fn, '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);', '  filter_condition_jsonb := coalesce(filter_condition, ''{}''::jsonb);
   escaped_query_terms := private.pgroonga_escape_query_terms(query_terms);
-  text_match_clause := case
-    when cardinality(escaped_query_terms) > 0 then ''where f.extracted_text &@~| $14''
-    else ''where f.extracted_text &@~ $1''
-  end;', 'flow private escaped terms');
+  if cardinality(escaped_query_terms) = 0 then
+    escaped_query_terms := private.pgroonga_escape_query_terms(array[query_text]);
+  end if;
+  text_match_clause := ''where f.extracted_text &@~| $14'';', 'flow private escaped terms');
   fn := pg_temp.required_replace(fn, '      where f.extracted_text &@~ $1', '      %s', 'flow private text match clause');
   fn := pg_temp.required_replace(fn, '$sql$, json_filter_clause);', '$sql$, text_match_clause, json_filter_clause);', 'flow private format args');
   fn := pg_temp.required_replace(fn, '          can_read_team_filter, flow_type, flow_type_array, as_input, classification_filter;', '          can_read_team_filter, flow_type, flow_type_array, as_input, classification_filter,

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -447,22 +447,22 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'join lateral') > 0,
   'flow open-data latest PGroonga search fetches latest versions with lateral index lookups'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.extracted_text &@~ $1') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~ $1') > 0,
   'flow latest PGroonga search matches query_text against extracted_text'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'json_filter_clause') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'json_filter_clause') > 0,
   'flow latest PGroonga search branches on empty JSON filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'and f.json @> $2') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'and f.json @> $2') > 0,
   'flow latest PGroonga search only keeps JSON containment for non-empty filters'
 );
 
@@ -482,22 +482,22 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'join lateral') > 0,
   'process latest PGroonga search fetches latest versions with lateral index lookups'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'p.extracted_text &@~ $1') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'p.extracted_text &@~ $1') > 0,
   'process latest PGroonga search matches query_text against extracted_text'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'json_filter_clause') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'json_filter_clause') > 0,
   'process latest PGroonga search branches on empty JSON filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'and p.json @> $2') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'and p.json @> $2') > 0,
   'process latest PGroonga search only keeps JSON containment for non-empty filters'
 );
 
@@ -517,22 +517,22 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'join lateral') > 0,
   'lifecyclemodel latest PGroonga search fetches latest versions with lateral index lookups'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'l.extracted_text &@~ $1') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'l.extracted_text &@~ $1') > 0,
   'lifecyclemodel latest PGroonga search matches query_text against extracted_text'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'json_filter_clause') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'json_filter_clause') > 0,
   'lifecyclemodel latest PGroonga search branches on empty JSON filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'and l.json @> $2') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'and l.json @> $2') > 0,
   'lifecyclemodel latest PGroonga search only keeps JSON containment for non-empty filters'
 );
 

--- a/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
+++ b/supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql
@@ -452,8 +452,8 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~ $1') > 0,
-  'flow latest PGroonga search matches query_text against extracted_text'
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~| $14') > 0,
+  'flow latest PGroonga search matches escaped query terms against extracted_text'
 );
 
 select ok(
@@ -487,8 +487,8 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'p.extracted_text &@~ $1') > 0,
-  'process latest PGroonga search matches query_text against extracted_text'
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'p.extracted_text &@~| $11') > 0,
+  'process latest PGroonga search matches escaped query terms against extracted_text'
 );
 
 select ok(
@@ -522,8 +522,8 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'l.extracted_text &@~ $1') > 0,
-  'lifecyclemodel latest PGroonga search matches query_text against extracted_text'
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'l.extracted_text &@~| $10') > 0,
+  'lifecyclemodel latest PGroonga search matches escaped query terms against extracted_text'
 );
 
 select ok(

--- a/supabase/tests/20260528_dataset_search_rls_private_helpers.sql
+++ b/supabase/tests/20260528_dataset_search_rls_private_helpers.sql
@@ -25,37 +25,37 @@ select plan(26);
 select ok(to_regnamespace('private') is not null, 'private schema exists for non-exposed search helpers');
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'private.search_flows_latest_impl') > 0,
+  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'private.search_flows_latest_impl') > 0,
   'flow public search wrapper delegates to private helper'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'private.search_processes_latest_impl') > 0,
+  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'private.search_processes_latest_impl') > 0,
   'process public search wrapper delegates to private helper'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'private.search_lifecyclemodels_latest_impl') > 0,
+  strpos(pg_get_functiondef('public.search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'private.search_lifecyclemodels_latest_impl') > 0,
   'lifecyclemodel public search wrapper delegates to private helper'
 );
 
 select ok(
-  (select prosecdef from pg_proc where oid = 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  (select prosecdef from pg_proc where oid = 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure),
   'flow private helper is security definer'
 );
 
 select ok(
-  (select prosecdef from pg_proc where oid = 'private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure),
+  (select prosecdef from pg_proc where oid = 'private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure),
   'process private helper is security definer'
 );
 
 select ok(
-  (select prosecdef from pg_proc where oid = 'private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  (select prosecdef from pg_proc where oid = 'private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure),
   'lifecyclemodel private helper is security definer'
 );
 
 select ok(
-  not (select prosecdef from pg_proc where oid = 'public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  not (select prosecdef from pg_proc where oid = 'public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure),
   'public search wrapper remains security invoker'
 );
 
@@ -70,7 +70,7 @@ select ok(
 );
 
 select ok(
-  has_function_privilege('authenticated', 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)', 'EXECUTE'),
+  has_function_privilege('authenticated', 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])', 'EXECUTE'),
   'authenticated can execute the hardcoded flow search helper through the wrapper path'
 );
 

--- a/supabase/tests/20260528_dataset_search_text_first_plan.sql
+++ b/supabase/tests/20260528_dataset_search_text_first_plan.sql
@@ -6,80 +6,80 @@ set local search_path = extensions, public;
 select plan(16);
 
 select ok(
-  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'private.search_flows_latest_impl') > 0,
+  strpos(pg_get_functiondef('public.search_flows_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'private.search_flows_latest_impl') > 0,
   'flow public latest search delegates scanning to the private helper'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'with text_matches as materialized') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'with text_matches as materialized') > 0,
   'flow latest search materializes text matches before non-text filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'where f.extracted_text &@~ $1') > 0
-    and strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'from text_matches f') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'where f.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'from text_matches f') > 0,
   'flow latest search separates extracted_text scan from source/filter predicates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'join lateral') > 0,
   'flow latest search keeps lateral latest-version lookup after candidate matching'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'private.search_processes_latest_impl') > 0,
+  strpos(pg_get_functiondef('public.search_processes_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'private.search_processes_latest_impl') > 0,
   'process public latest search delegates scanning to the private helper'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'with text_matches as materialized') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'with text_matches as materialized') > 0,
   'process latest search materializes text matches before non-text filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'where p.extracted_text &@~ $1') > 0
-    and strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'from text_matches p') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'where p.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'from text_matches p') > 0,
   'process latest search separates extracted_text scan from source/filter predicates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'join lateral') > 0,
   'process latest search keeps lateral latest-version lookup after candidate matching'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'private.search_lifecyclemodels_latest_impl') > 0,
+  strpos(pg_get_functiondef('public.search_lifecyclemodels_latest(text,jsonb,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'private.search_lifecyclemodels_latest_impl') > 0,
   'lifecyclemodel public latest search delegates scanning to the private helper'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'with text_matches as materialized') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'with text_matches as materialized') > 0,
   'lifecyclemodel latest search materializes text matches before non-text filters'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'where l.extracted_text &@~ $1') > 0
-    and strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'from text_matches l') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'where l.extracted_text &@~ $1') > 0
+    and strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'from text_matches l') > 0,
   'lifecyclemodel latest search separates extracted_text scan from source/filter predicates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'join lateral') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'join lateral') > 0,
   'lifecyclemodel latest search keeps lateral latest-version lookup after candidate matching'
 );
 
 select ok(
-  (select prosecdef from pg_proc where oid = 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  (select prosecdef from pg_proc where oid = 'private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure),
   'flow private helper is security definer'
 );
 
 select ok(
-  (select prosecdef from pg_proc where oid = 'private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure),
+  (select prosecdef from pg_proc where oid = 'private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure),
   'process private helper is security definer'
 );
 
 select ok(
-  (select prosecdef from pg_proc where oid = 'private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure),
+  (select prosecdef from pg_proc where oid = 'private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure),
   'lifecyclemodel private helper is security definer'
 );
 

--- a/supabase/tests/20260528_dataset_search_text_first_plan.sql
+++ b/supabase/tests/20260528_dataset_search_text_first_plan.sql
@@ -16,7 +16,7 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'where f.extracted_text &@~ $1') > 0
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'where f.extracted_text &@~| $14') > 0
     and strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'from text_matches f') > 0,
   'flow latest search separates extracted_text scan from source/filter predicates'
 );
@@ -37,7 +37,7 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'where p.extracted_text &@~ $1') > 0
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'where p.extracted_text &@~| $11') > 0
     and strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'from text_matches p') > 0,
   'process latest search separates extracted_text scan from source/filter predicates'
 );
@@ -58,7 +58,7 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'where l.extracted_text &@~ $1') > 0
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'where l.extracted_text &@~| $10') > 0
     and strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'from text_matches l') > 0,
   'lifecyclemodel latest search separates extracted_text scan from source/filter predicates'
 );

--- a/supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
+++ b/supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
@@ -94,7 +94,25 @@ with latest_zero_embedding(value) as (
   select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
 )
 select is(
-  (select id::text from public.hybrid_search_flows('(电子器件) OR (electronic component)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  (
+    select id::text
+    from public.hybrid_search_flows(
+      '(电子器件) OR (electronic component)',
+      (select value from latest_zero_embedding),
+      '{}',
+      0.5,
+      20,
+      0.3,
+      0.2,
+      0.5,
+      10,
+      'tg',
+      10,
+      1,
+      array['电子器件', 'electronic component']
+    )
+    limit 1
+  ),
   'f1000000-0000-0000-0000-000000000101',
   'flow hybrid tg search returns a text candidate through latest search'
 );
@@ -103,7 +121,25 @@ with latest_zero_embedding(value) as (
   select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
 )
 select is(
-  (select id::text from public.hybrid_search_flows('(电子器件) OR (electronic component)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  (
+    select id::text
+    from public.hybrid_search_flows(
+      '(电子器件) OR (electronic component)',
+      (select value from latest_zero_embedding),
+      '{}',
+      0.5,
+      20,
+      0.3,
+      0.2,
+      0.5,
+      10,
+      'my',
+      10,
+      1,
+      array['电子器件', 'electronic component']
+    )
+    limit 1
+  ),
   'f2000000-0000-0000-0000-000000000101',
   'flow hybrid my search returns the authenticated owner text candidate'
 );
@@ -121,7 +157,25 @@ with latest_zero_embedding(value) as (
   select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
 )
 select is(
-  (select id::text from public.hybrid_search_processes('(正极材料) OR (cathode material)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  (
+    select id::text
+    from public.hybrid_search_processes(
+      '(正极材料) OR (cathode material)',
+      (select value from latest_zero_embedding),
+      '{}',
+      0.5,
+      20,
+      0.3,
+      0.2,
+      0.5,
+      10,
+      'tg',
+      10,
+      1,
+      array['正极材料', 'cathode material']
+    )
+    limit 1
+  ),
   'e1000000-0000-0000-0000-000000000101',
   'process hybrid tg search returns a text candidate through latest search'
 );
@@ -130,7 +184,25 @@ with latest_zero_embedding(value) as (
   select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
 )
 select is(
-  (select id::text from public.hybrid_search_processes('(正极材料) OR (cathode material)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  (
+    select id::text
+    from public.hybrid_search_processes(
+      '(正极材料) OR (cathode material)',
+      (select value from latest_zero_embedding),
+      '{}',
+      0.5,
+      20,
+      0.3,
+      0.2,
+      0.5,
+      10,
+      'my',
+      10,
+      1,
+      array['正极材料', 'cathode material']
+    )
+    limit 1
+  ),
   'e2000000-0000-0000-0000-000000000101',
   'process hybrid my search returns the authenticated owner text candidate'
 );
@@ -148,7 +220,25 @@ with latest_zero_embedding(value) as (
   select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
 )
 select is(
-  (select id::text from public.hybrid_search_lifecyclemodels('(交流电) OR (electricity)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'tg', 10, 1) limit 1),
+  (
+    select id::text
+    from public.hybrid_search_lifecyclemodels(
+      '(交流电) OR (electricity)',
+      (select value from latest_zero_embedding),
+      '{}',
+      0.5,
+      20,
+      0.3,
+      0.2,
+      0.5,
+      10,
+      'tg',
+      10,
+      1,
+      array['交流电', 'electricity']
+    )
+    limit 1
+  ),
   'd1000000-0000-0000-0000-000000000101',
   'lifecyclemodel hybrid tg search returns a text candidate through latest search'
 );
@@ -157,7 +247,25 @@ with latest_zero_embedding(value) as (
   select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
 )
 select is(
-  (select id::text from public.hybrid_search_lifecyclemodels('(交流电) OR (electricity)', (select value from latest_zero_embedding), '{}', 0.5, 20, 0.3, 0.2, 0.5, 10, 'my', 10, 1) limit 1),
+  (
+    select id::text
+    from public.hybrid_search_lifecyclemodels(
+      '(交流电) OR (electricity)',
+      (select value from latest_zero_embedding),
+      '{}',
+      0.5,
+      20,
+      0.3,
+      0.2,
+      0.5,
+      10,
+      'my',
+      10,
+      1,
+      array['交流电', 'electricity']
+    )
+    limit 1
+  ),
   'd2000000-0000-0000-0000-000000000101',
   'lifecyclemodel hybrid my search returns the authenticated owner text candidate'
 );

--- a/supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
+++ b/supabase/tests/20260528_hybrid_search_latest_text_candidates.sql
@@ -23,23 +23,23 @@ end;
 $$;
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_flows_latest') > 0,
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'public.search_flows_latest') > 0,
   'flow hybrid search uses latest text search for text candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_processes_latest') > 0,
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'public.search_processes_latest') > 0,
   'process hybrid search uses latest text search for text candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.search_lifecyclemodels_latest') > 0,
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'public.search_lifecyclemodels_latest') > 0,
   'lifecyclemodel hybrid search uses latest text search for text candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'pgroonga_search_processes_v1') = 0
-    and strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'pgroonga_search_processes_text_v1') = 0,
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'pgroonga_search_processes_v1') = 0
+    and strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'pgroonga_search_processes_text_v1') = 0,
   'process hybrid search no longer depends on legacy process PGroonga helpers'
 );
 

--- a/supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql
+++ b/supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql
@@ -6,57 +6,57 @@ set local search_path = extensions, public, auth;
 select plan(9);
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'semantic_match_count integer') > 0,
   'flow hybrid declares a separate semantic match count'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'match_threshold,
         semantic_match_count,
         data_source') > 0,
   'flow hybrid passes the unexpanded semantic match count to semantic candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'match_threshold,
         candidate_limit,
         data_source') = 0,
   'flow hybrid no longer passes the 10x text candidate limit to semantic candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'semantic_match_count integer') > 0,
   'process hybrid declares a separate semantic match count'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'match_threshold,
         semantic_match_count,
         data_source') > 0,
   'process hybrid passes the unexpanded semantic match count to semantic candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'match_threshold,
         candidate_limit,
         data_source') = 0,
   'process hybrid no longer passes the 10x text candidate limit to semantic candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'semantic_match_count integer') > 0,
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'semantic_match_count integer') > 0,
   'lifecyclemodel hybrid declares a separate semantic match count'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'match_threshold,
         semantic_match_count,
         data_source') > 0,
   'lifecyclemodel hybrid passes the unexpanded semantic match count to semantic candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'match_threshold,
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'match_threshold,
         candidate_limit,
         data_source') = 0,
   'lifecyclemodel hybrid no longer passes the 10x text candidate limit to semantic candidates'

--- a/supabase/tests/20260528_semantic_hybrid_candidate_helpers.sql
+++ b/supabase/tests/20260528_semantic_hybrid_candidate_helpers.sql
@@ -38,20 +38,20 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'private.semantic_flow_candidates') > 0
-    and strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.semantic_search_flows_v1') = 0,
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'private.semantic_flow_candidates') > 0
+    and strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'public.semantic_search_flows_v1') = 0,
   'flow hybrid search uses lightweight private semantic candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'private.semantic_process_candidates') > 0
-    and strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.semantic_search_processes_v1') = 0,
+  strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'private.semantic_process_candidates') > 0
+    and strpos(pg_get_functiondef('public.hybrid_search_processes(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'public.semantic_search_processes_v1') = 0,
   'process hybrid search uses lightweight private semantic candidates'
 );
 
 select ok(
-  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'private.semantic_lifecyclemodel_candidates') > 0
-    and strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer)'::regprocedure), 'public.semantic_search_lifecyclemodels_v1') = 0,
+  strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'private.semantic_lifecyclemodel_candidates') > 0
+    and strpos(pg_get_functiondef('public.hybrid_search_lifecyclemodels(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'public.semantic_search_lifecyclemodels_v1') = 0,
   'lifecyclemodel hybrid search uses lightweight private semantic candidates'
 );
 

--- a/supabase/tests/20260529_uuid_search_fast_path.sql
+++ b/supabase/tests/20260529_uuid_search_fast_path.sql
@@ -23,17 +23,17 @@ $$;
 select plan(21);
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'exact_query_id') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'exact_query_id') > 0,
   'flow latest search has an exact UUID fast path'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text)'::regprocedure), 'exact_query_id') > 0,
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'exact_query_id') > 0,
   'process latest search has an exact UUID fast path'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'exact_query_id') > 0,
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'exact_query_id') > 0,
   'lifecyclemodel latest search has an exact UUID fast path'
 );
 
@@ -43,7 +43,7 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer)'::regprocedure), 'f.extracted_text &@~ $1') > 0,
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~ $1') > 0,
   'flow non-UUID search still uses extracted_text PGroonga'
 );
 

--- a/supabase/tests/20260529_uuid_search_fast_path.sql
+++ b/supabase/tests/20260529_uuid_search_fast_path.sql
@@ -43,8 +43,8 @@ select ok(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~ $1') > 0,
-  'flow non-UUID search still uses extracted_text PGroonga'
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~| $14') > 0,
+  'flow non-UUID search still uses extracted_text PGroonga through escaped term-array search'
 );
 
 select ok(

--- a/supabase/tests/20260613_hybrid_search_query_terms_escape.sql
+++ b/supabase/tests/20260613_hybrid_search_query_terms_escape.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(18);
+select plan(20);
 
 create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger_name text)
 returns void
@@ -255,6 +255,27 @@ select is(
 select is(
   (
     select id::text
+    from public.search_processes_latest(
+      'alternating current',
+      '{}'::jsonb,
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '',
+      null::uuid,
+      null::integer,
+      'all'
+    )
+    limit 1
+  ),
+  'e6130000-0000-0000-0000-000000000001',
+  'process latest search derives escaped query terms from query_text when query_terms is omitted'
+);
+
+select is(
+  (
+    select id::text
     from public.search_lifecyclemodels_latest(
       'ignored-invalid-query (硅酸盐水泥)',
       '{}'::jsonb,
@@ -271,6 +292,29 @@ select is(
   ),
   'd6130000-0000-0000-0000-000000000001',
   'lifecyclemodel latest search query_terms handle Chinese terms'
+);
+
+with chemical(term) as (
+  values ('Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-')
+)
+select is(
+  (
+    select id::text
+    from public.search_flows_latest(
+      (select term from chemical),
+      '{}'::jsonb,
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '',
+      null::uuid,
+      null::integer
+    )
+    limit 1
+  ),
+  'f6130000-0000-0000-0000-000000000001',
+  'flow latest query_text-only search escapes nested chemical punctuation'
 );
 
 select is(
@@ -290,7 +334,7 @@ select is(
     limit 1
   ),
   'd6130000-0000-0000-0000-000000000002',
-  'legacy query_text fallback still works when query_terms is omitted'
+  'query_text-only search still works when query_terms is omitted'
 );
 
 select is(
@@ -335,18 +379,21 @@ select is(
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~| $14') > 0,
-  'flow latest implementation has a query_terms branch'
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~| $14') > 0
+    and strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~ $1') = 0,
+  'flow latest implementation always uses escaped term-array text search'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'p.extracted_text &@~| $11') > 0,
-  'process latest implementation has a query_terms branch'
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'p.extracted_text &@~| $11') > 0
+    and strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'p.extracted_text &@~ $1') = 0,
+  'process latest implementation always uses escaped term-array text search'
 );
 
 select ok(
-  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'l.extracted_text &@~| $10') > 0,
-  'lifecyclemodel latest implementation has a query_terms branch'
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'l.extracted_text &@~| $10') > 0
+    and strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'l.extracted_text &@~ $1') = 0,
+  'lifecyclemodel latest implementation always uses escaped term-array text search'
 );
 
 select ok(

--- a/supabase/tests/20260613_hybrid_search_query_terms_escape.sql
+++ b/supabase/tests/20260613_hybrid_search_query_terms_escape.sql
@@ -1,0 +1,359 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(18);
+
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger_name text)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger_name
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger_name);
+  end if;
+end;
+$$;
+
+select is(
+  private.pgroonga_escape_query_terms(array[null, '', '  alternating   current  ', 'AC power']),
+  array[
+    extensions.pgroonga_query_escape('alternating current'),
+    extensions.pgroonga_query_escape('AC power')
+  ],
+  'query term helper ignores empty values and normalizes whitespace'
+);
+
+select is(
+  (private.pgroonga_escape_query_terms(array['111479-05-1']))[1],
+  extensions.pgroonga_query_escape('111479-05-1'),
+  'query term helper delegates PGroonga syntax escaping'
+);
+
+select ok(
+  'industrial alternating grid current'::text &@~ extensions.pgroonga_query_escape('alternating current'),
+  'escaped ordinary multi-word term keeps PGroonga AND-style matching'
+);
+
+select ok(
+  not ('industrial alternating grid current'::text &@~ '"alternating current"'),
+  'quoted phrase search would not match separated ordinary words'
+);
+
+select ok(
+  'sodium chloride reagent'::text &@~| private.pgroonga_escape_query_terms(array['no-match-token', 'sodium chloride']),
+  '&@~| matches when any escaped query term matches'
+);
+
+select ok(
+  '111479-05-1 quizalofop P tefuryl'::text &@~| private.pgroonga_escape_query_terms(array['111479-05-1']),
+  'escaped CAS term with hyphens matches through term array search'
+);
+
+with sample(term) as (
+  values ('Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-')
+)
+select ok(
+  (select ('USLCI ' || term)::text &@~| private.pgroonga_escape_query_terms(array[term]) from sample),
+  'escaped nested chemical term with brackets commas hyphens and parentheses does not throw'
+);
+
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flows_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_dataset_extraction_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'zz_flows_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'processes_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'zz_processes_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodel_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'lifecyclemodels_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.lifecyclemodels'::regclass, 'zz_lifecyclemodels_extracted_text_sync_trigger');
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('a6130000-0000-0000-0000-000000000001', '{"email":"query-terms-owner@example.com"}'::jsonb, null),
+  ('b6130000-0000-0000-0000-000000000001', '{"email":"query-terms-outsider@example.com"}'::jsonb, null);
+
+insert into public.flows (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  (
+    'f6130000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"search":"query-terms-public-flow-token"}'::jsonb,
+    '{"search":"query-terms-public-flow-token"}'::json,
+    'b6130000-0000-0000-0000-000000000001',
+    100,
+    null,
+    'query-terms-public-flow-token 111479-05-1 Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-',
+    true,
+    now(),
+    now()
+  ),
+  (
+    'f6130000-0000-0000-0000-000000000002',
+    '01.00.000',
+    '{"search":"query-terms-owner-flow-token"}'::jsonb,
+    '{"search":"query-terms-owner-flow-token"}'::json,
+    'a6130000-0000-0000-0000-000000000001',
+    0,
+    null,
+    'query-terms-owner-flow-token owner chemical term',
+    true,
+    now(),
+    now()
+  ),
+  (
+    'f6130000-0000-0000-0000-000000000003',
+    '01.00.000',
+    '{"search":"query-terms-outsider-flow-token"}'::jsonb,
+    '{"search":"query-terms-outsider-flow-token"}'::json,
+    'b6130000-0000-0000-0000-000000000001',
+    0,
+    null,
+    'query-terms-outsider-flow-token outsider chemical term',
+    true,
+    now(),
+    now()
+  );
+
+insert into public.processes (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values (
+  'e6130000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{"search":"query-terms-process-token"}'::jsonb,
+  '{"search":"query-terms-process-token"}'::json,
+  'b6130000-0000-0000-0000-000000000001',
+  100,
+  null,
+  'query-terms-process-token industrial alternating grid current with AC grid power',
+  true,
+  now(),
+  now()
+);
+
+insert into public.lifecyclemodels (
+  id, version, json, json_ordered, user_id, state_code, team_id, extracted_text, rule_verification, created_at, modified_at
+)
+values
+  (
+    'd6130000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"search":"query-terms-lifecycle-token"}'::jsonb,
+    '{"search":"query-terms-lifecycle-token"}'::json,
+    'b6130000-0000-0000-0000-000000000001',
+    100,
+    null,
+    'query-terms-lifecycle-token 硅酸盐水泥 clinker',
+    true,
+    now(),
+    now()
+  ),
+  (
+    'd6130000-0000-0000-0000-000000000002',
+    '01.00.000',
+    '{"search":"query-terms-legacy-token"}'::jsonb,
+    '{"search":"query-terms-legacy-token"}'::json,
+    'b6130000-0000-0000-0000-000000000001',
+    100,
+    null,
+    'query-terms-legacy-token legacy fallback term',
+    true,
+    now(),
+    now()
+  );
+
+with chemical(term) as (
+  values ('Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-')
+)
+select is(
+  (
+    select id::text
+    from public.search_flows_latest(
+      '(111479-05-1) OR (Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-)',
+      '{}'::jsonb,
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '',
+      null::uuid,
+      null::integer,
+      array['111479-05-1', (select term from chemical)]
+    )
+    limit 1
+  ),
+  'f6130000-0000-0000-0000-000000000001',
+  'flow latest search uses escaped query_terms and does not evaluate invalid query_text'
+);
+
+with latest_zero_embedding(value) as (
+  select '[' || array_to_string(array_fill('0'::text, array[1024]), ',') || ']'
+),
+chemical(term) as (
+  values ('Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-')
+)
+select is(
+  (
+    select id::text
+    from public.hybrid_search_flows(
+      '(111479-05-1) OR (Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-)',
+      (select value from latest_zero_embedding),
+      '{}',
+      0.5,
+      20,
+      0.3,
+      0.2,
+      0.5,
+      10,
+      'tg',
+      10,
+      1,
+      array['111479-05-1', (select term from chemical)]
+    )
+    limit 1
+  ),
+  'f6130000-0000-0000-0000-000000000001',
+  'flow hybrid search passes query_terms into latest text candidates'
+);
+
+select is(
+  (
+    select id::text
+    from public.search_processes_latest(
+      'ignored-invalid-query (alternating current) OR (AC power)',
+      '{}'::jsonb,
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '',
+      null::uuid,
+      null::integer,
+      'all',
+      array['alternating current', 'AC power']
+    )
+    limit 1
+  ),
+  'e6130000-0000-0000-0000-000000000001',
+  'process latest search query_terms preserve ordinary multi-word matching'
+);
+
+select is(
+  (
+    select id::text
+    from public.search_lifecyclemodels_latest(
+      'ignored-invalid-query (硅酸盐水泥)',
+      '{}'::jsonb,
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '',
+      null::uuid,
+      null::integer,
+      array['硅酸盐水泥']
+    )
+    limit 1
+  ),
+  'd6130000-0000-0000-0000-000000000001',
+  'lifecyclemodel latest search query_terms handle Chinese terms'
+);
+
+select is(
+  (
+    select id::text
+    from public.search_lifecyclemodels_latest(
+      'legacy fallback term',
+      '{}'::jsonb,
+      '{}'::jsonb,
+      10,
+      1,
+      'tg',
+      '',
+      null::uuid,
+      null::integer
+    )
+    limit 1
+  ),
+  'd6130000-0000-0000-0000-000000000002',
+  'legacy query_text fallback still works when query_terms is omitted'
+);
+
+select is(
+  (
+    select id::text
+    from public.search_flows_latest(
+      'ignored',
+      '{}'::jsonb,
+      '{}'::jsonb,
+      10,
+      1,
+      'my',
+      'a6130000-0000-0000-0000-000000000001',
+      null::uuid,
+      null::integer,
+      array['owner chemical term']
+    )
+    limit 1
+  ),
+  'f6130000-0000-0000-0000-000000000002',
+  'my-data visibility still returns the authenticated owner result'
+);
+
+select is(
+  (
+    select count(*)
+    from public.search_flows_latest(
+      'ignored',
+      '{}'::jsonb,
+      '{}'::jsonb,
+      10,
+      1,
+      'my',
+      'a6130000-0000-0000-0000-000000000001',
+      null::uuid,
+      null::integer,
+      array['outsider chemical term']
+    )
+  ),
+  0::bigint,
+  'my-data visibility still excludes another user result'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.search_flows_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'f.extracted_text &@~| $14') > 0,
+  'flow latest implementation has a query_terms branch'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.search_processes_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text,text[])'::regprocedure), 'p.extracted_text &@~| $11') > 0,
+  'process latest implementation has a query_terms branch'
+);
+
+select ok(
+  strpos(pg_get_functiondef('private.search_lifecyclemodels_latest_impl(text,jsonb,bigint,bigint,text,text,uuid,integer,text[])'::regprocedure), 'l.extracted_text &@~| $10') > 0,
+  'lifecyclemodel latest implementation has a query_terms branch'
+);
+
+select ok(
+  strpos(pg_get_functiondef('public.hybrid_search_flows(text,text,text,double precision,integer,double precision,double precision,double precision,integer,text,integer,integer,text[])'::regprocedure), 'query_terms') > 0,
+  'flow hybrid signature exposes query_terms as the trailing optional argument'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary

- Adds `private.pgroonga_escape_query_terms(text[])` and threads trailing optional `query_terms text[]` through the latest-search and hybrid-search RPC chain.
- Treats `query_text` as the normal raw search input and `query_terms` as optional pre-split terms; private latest-search helpers derive effective terms from `query_terms` when present, otherwise from `query_text`, then always search with escaped `extracted_text &@~| $terms`.
- Removes the unsafe direct `extracted_text &@~ query_text` execution path while preserving exact-UUID search and existing callers that only pass `query_text`.
- Updates hybrid/latest-search SQL assertions and regression coverage for CAS numbers, nested chemical names, ordinary multi-word terms, Chinese terms, query_text-only behavior, explicit query_terms behavior, and visibility rules.

Closes #215

## Validation

- `npx supabase start`
- `npx supabase db reset`
- `docker exec -i supabase_db_database-engine psql -U postgres -d postgres -v ON_ERROR_STOP=1 < supabase/tests/20260613_hybrid_search_query_terms_escape.sql` — 20/20 PASS
- `docker exec -i supabase_db_database-engine psql -U postgres -d postgres -v ON_ERROR_STOP=1 < supabase/tests/20260520_core_datasets_latest_version_query_rpcs.sql` — 54/54 PASS
- `docker exec -i supabase_db_database-engine psql -U postgres -d postgres -v ON_ERROR_STOP=1 < supabase/tests/20260528_dataset_search_text_first_plan.sql` — 16/16 PASS
- `docker exec -i supabase_db_database-engine psql -U postgres -d postgres -v ON_ERROR_STOP=1 < supabase/tests/20260528_dataset_search_rls_private_helpers.sql` — 26/26 PASS
- `docker exec -i supabase_db_database-engine psql -U postgres -d postgres -v ON_ERROR_STOP=1 < supabase/tests/20260528_hybrid_search_latest_text_candidates.sql` — 12/12 PASS
- `docker exec -i supabase_db_database-engine psql -U postgres -d postgres -v ON_ERROR_STOP=1 < supabase/tests/20260528_hybrid_semantic_candidate_limit_hotfix.sql` — 9/9 PASS
- `docker exec -i supabase_db_database-engine psql -U postgres -d postgres -v ON_ERROR_STOP=1 < supabase/tests/20260528_semantic_hybrid_candidate_helpers.sql` — 15/15 PASS
- `docker exec -i supabase_db_database-engine psql -U postgres -d postgres -v ON_ERROR_STOP=1 < supabase/tests/20260529_uuid_search_fast_path.sql` — 21/21 PASS
- `npx supabase migration list --local`
- pre-push docpact gate: `validate-config` PASS, `lint` PASS

Full-suite note: `npx supabase test db --local supabase/tests` was previously attempted and still fails in `supabase/tests/20260611_dataset_create_version_rpc.sql` with `permission denied for table command_audit_log`; running that file alone reproduced the same unrelated failure.

## Rollout / Follow-up

- Merge/apply this database change before deploying the matching Edge Functions PR.
- Persistent Supabase `dev` proof is deferred until this PR lands on Git `dev` and the repo workflow applies the migration.
- Production `main` promotion and root workspace submodule integration remain separate follow-up steps after DB and Edge commits are both on their child repo `main` branches.