### PR TITLE
fix: use latest processes for LCIA result manifests

### DIFF
--- a/supabase/migrations/20260623133000_lcia_result_latest_manifest.sql
+++ b/supabase/migrations/20260623133000_lcia_result_latest_manifest.sql
@@ -1,0 +1,56 @@
+create or replace function public.lcia_result_current_eligible_manifest()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  with eligible as (
+    select distinct on (id)
+      id,
+      version,
+      state_code
+    from public.processes
+    where state_code between 100 and 199
+      and json ? 'processDataSet'
+    order by id, version desc, modified_at desc
+  ),
+  aggregated as (
+    select
+      count(*)::integer as eligible_count,
+      md5(
+        coalesce(
+          string_agg(id::text || ':' || version, ',' order by id, version),
+          ''
+        ) || '|published:100-199:latest-per-id:v1'
+      ) as input_manifest_hash,
+      coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'id', id,
+            'version', version,
+            'stateCode', state_code
+          )
+          order by id, version
+        ),
+        '[]'::jsonb
+      ) as processes
+    from eligible
+  )
+  select jsonb_build_object(
+    'predicateVersion', 'published-state-code-100-199:latest-per-id:v1',
+    'inputStatusFilter', jsonb_build_object(
+      'state_code',
+      jsonb_build_object('between', jsonb_build_array(100, 199))
+    ),
+    'eligibleInputCount', eligible_count,
+    'includedInputCount', eligible_count,
+    'inputManifestHash', input_manifest_hash,
+    'inputManifest', jsonb_build_object(
+      'predicateVersion', 'published-state-code-100-199:latest-per-id:v1',
+      'selectionMode', 'all_eligible',
+      'processes', processes
+    )
+  )
+  from aggregated
+$$;

--- a/supabase/tests/20260623_data_product_publication_mvp.sql
+++ b/supabase/tests/20260623_data_product_publication_mvp.sql
@@ -20,7 +20,7 @@ begin
 end;
 $$;
 
-select plan(32);
+select plan(34);
 
 select has_table('public', 'lcia_result_packages', 'LCIA result packages table exists');
 select has_table('public', 'lcia_result_publications', 'LCIA result publications table exists');
@@ -181,8 +181,25 @@ select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_
 insert into public.processes (id, version, json, user_id, state_code)
 values
   ('98230000-0000-4000-8000-000000000101', '01.00.000', '{"processDataSet":{"name":"eligible-1"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 100),
+  ('98230000-0000-4000-8000-000000000101', '01.00.001', '{"processDataSet":{"name":"eligible-1-latest"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 100),
   ('98230000-0000-4000-8000-000000000102', '01.00.000', '{"processDataSet":{"name":"eligible-2"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 100),
   ('98230000-0000-4000-8000-000000000103', '01.00.000', '{"processDataSet":{"name":"draft"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 0);
+
+select is(
+  (public.lcia_result_current_eligible_manifest()->>'eligibleInputCount')::integer,
+  2,
+  'global eligible manifest counts latest published process versions only'
+);
+
+select is(
+  (
+    select process.value->>'version'
+    from jsonb_array_elements(public.lcia_result_current_eligible_manifest()->'inputManifest'->'processes') as process(value)
+    where process.value->>'id' = '98230000-0000-4000-8000-000000000101'
+  ),
+  '01.00.001',
+  'global eligible manifest keeps the latest published version per process id'
+);
 
 set local role authenticated;
 select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000002', true);
@@ -498,7 +515,7 @@ select set_config('request.jwt.claims', '{"role":"anon"}', true);
 select is(
   public.get_published_lcia_result_package(
     '98230000-0000-4000-8000-000000000101',
-    '01.00.000',
+    '01.00.001',
     'climate-change'
   )->'data'->'resultArtifact'->>'artifactUrl',
   's3://bucket/lcia-result.json',


### PR DESCRIPTION
## Summary
- make `lcia_result_current_eligible_manifest()` emit one latest published process version per process id
- align global data product manifests with snapshot_builder candidate selection
- add a pgtap regression covering duplicate published process versions

## Validation
- `supabase test db supabase/tests/20260623_data_product_publication_mvp.sql`
- Applied the same function replacement to the dev Supabase database and verified the manifest is 2037 rows / 2037 distinct ids / 0 duplicates.
- Enqueued a dev build after the worker rollout; worker job `0d07e015-73f9-4581-af21-4bc3f15481d8` completed and package `14f3a4a4-05d9-447b-9212-950e89f297dd` is `preview_ready`.

Follow-up to #218.