### PR TITLE
promote: data product publication schema to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-13"
-lastReviewedCommit: "5ce13e2d325eb3fc8272871c3a5784d4d64a90fc"
+lastReviewedAt: "2026-06-23"
+lastReviewedCommit: "522ceecee46b2163e03e455a332d0412822d60fb"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-06-23"
-lastReviewedCommit: "522ceecee46b2163e03e455a332d0412822d60fb"
+lastReviewedCommit: "f216783f244b13ca5790d2883dae54072af9f5b3"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 5ce13e2d325eb3fc8272871c3a5784d4d64a90fc
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 522ceecee46b2163e03e455a332d0412822d60fb
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-23
-lastReviewedCommit: 522ceecee46b2163e03e455a332d0412822d60fb
+lastReviewedCommit: f216783f244b13ca5790d2883dae54072af9f5b3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 5ce13e2d325eb3fc8272871c3a5784d4d64a90fc
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 522ceecee46b2163e03e455a332d0412822d60fb
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-23
-lastReviewedCommit: 522ceecee46b2163e03e455a332d0412822d60fb
+lastReviewedCommit: f216783f244b13ca5790d2883dae54072af9f5b3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-23
-lastReviewedCommit: 522ceecee46b2163e03e455a332d0412822d60fb
+lastReviewedCommit: f216783f244b13ca5790d2883dae54072af9f5b3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 5ce13e2d325eb3fc8272871c3a5784d4d64a90fc
+lastReviewedAt: 2026-06-23
+lastReviewedCommit: 522ceecee46b2163e03e455a332d0412822d60fb
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260623075159_data_product_publication_mvp.sql
+++ b/supabase/migrations/20260623075159_data_product_publication_mvp.sql
@@ -1,0 +1,1495 @@
+-- Data product calculation/publication MVP.
+-- This migration intentionally keeps data product package facts separate from
+-- process publication state and from transient LCA query caches.
+
+alter table public.roles
+  drop constraint if exists roles_role_check;
+
+alter table public.roles
+  add constraint roles_role_check
+  check (
+    role::text = any (
+      array[
+        'owner',
+        'admin',
+        'member',
+        'is_invited',
+        'rejected',
+        'review-admin',
+        'review-member',
+        'data_product_manager'
+      ]::text[]
+    )
+  );
+
+alter table public.lca_network_snapshots
+  drop constraint if exists lca_network_snapshots_scope_chk;
+
+alter table public.lca_network_snapshots
+  add constraint lca_network_snapshots_scope_chk
+  check (scope = any (array['full_library'::text, 'data_product'::text]));
+
+insert into public.worker_job_kinds (
+  job_kind,
+  worker_runtime,
+  worker_queue,
+  default_visibility,
+  default_priority,
+  default_max_attempts,
+  default_lease_seconds,
+  payload_schema_version,
+  result_schema_version,
+  user_visible,
+  description
+) values (
+  'data_product.package_build',
+  'calculator',
+  'solver',
+  'operator',
+  0,
+  3,
+  3600,
+  'data_product.package_build.request.v1',
+  'data_product.package_build.result.v1',
+  false,
+  'Builds a data product package from a published-only snapshot, materialized LCIA rows, and pinned/copied artifacts.'
+) on conflict (job_kind) do update
+set worker_runtime = excluded.worker_runtime,
+    worker_queue = excluded.worker_queue,
+    default_visibility = excluded.default_visibility,
+    default_priority = excluded.default_priority,
+    default_max_attempts = excluded.default_max_attempts,
+    default_lease_seconds = excluded.default_lease_seconds,
+    payload_schema_version = excluded.payload_schema_version,
+    result_schema_version = excluded.result_schema_version,
+    user_visible = excluded.user_visible,
+    description = excluded.description,
+    updated_at = now();
+
+create table if not exists public.data_product_runs (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  input_scope jsonb not null default '{}'::jsonb,
+  input_status_filter jsonb not null default '{"state_code":{"between":[100,199]}}'::jsonb,
+  coverage_mode text not null,
+  eligibility_definition jsonb not null default '{}'::jsonb,
+  eligibility_resolved_at timestamptz not null default now(),
+  eligible_input_count integer not null default 0,
+  included_input_count integer not null default 0,
+  input_manifest_hash text not null,
+  lcia_method_set jsonb not null default '[]'::jsonb,
+  default_impact_category text,
+  postprocess_mode text not null default 'skipped',
+  postprocess_status text not null default 'skipped',
+  status text not null default 'created',
+  worker_job_id uuid references public.worker_jobs(id) on delete set null,
+  idempotency_key text,
+  created_by uuid not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint data_product_runs_counts_chk check (
+    eligible_input_count >= 0 and included_input_count >= 0
+  ),
+  constraint data_product_runs_coverage_chk check (
+    coverage_mode in ('subset', 'global_eligible')
+  ),
+  constraint data_product_runs_lcia_method_set_chk check (
+    jsonb_typeof(lcia_method_set) = 'array'
+  ),
+  constraint data_product_runs_status_chk check (
+    status in ('created', 'queued', 'computing', 'computed', 'failed', 'deprecated')
+  )
+);
+
+create unique index if not exists data_product_runs_idempotency_uidx
+  on public.data_product_runs (created_by, idempotency_key)
+  where idempotency_key is not null;
+
+create table if not exists public.data_product_run_inputs (
+  run_id uuid not null references public.data_product_runs(id) on delete cascade,
+  process_id uuid not null,
+  process_version character(9) not null,
+  state_code integer not null,
+  ordinal integer not null,
+  created_at timestamptz not null default now(),
+  primary key (run_id, process_id, process_version),
+  constraint data_product_run_inputs_process_fk
+    foreign key (process_id, process_version)
+    references public.processes(id, version)
+    on delete restrict,
+  constraint data_product_run_inputs_state_chk check (
+    state_code between 100 and 199
+  )
+);
+
+create table if not exists public.data_product_packages (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references public.data_product_runs(id) on delete restrict,
+  package_version text not null,
+  coverage_mode text not null,
+  eligibility_definition jsonb not null,
+  eligibility_resolved_at timestamptz not null,
+  eligible_input_count integer not null,
+  included_input_count integer not null,
+  input_manifest_hash text not null,
+  snapshot_id uuid references public.lca_network_snapshots(id) on delete restrict,
+  source_result_id uuid references public.lca_results(id) on delete set null,
+  package_result_hash text not null,
+  lcia_method_set jsonb not null default '[]'::jsonb,
+  postprocess_mode text not null default 'skipped',
+  postprocess_status text not null default 'skipped',
+  default_impact_category text,
+  status text not null default 'preview_ready',
+  created_by uuid not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint data_product_packages_counts_chk check (
+    eligible_input_count >= 0 and included_input_count >= 0
+  ),
+  constraint data_product_packages_coverage_chk check (
+    coverage_mode in ('subset', 'global_eligible')
+  ),
+  constraint data_product_packages_status_chk check (
+    status in ('preview_ready', 'deprecated', 'failed')
+  ),
+  constraint data_product_packages_lcia_method_set_chk check (
+    jsonb_typeof(lcia_method_set) = 'array'
+  )
+);
+
+create unique index if not exists data_product_packages_package_version_uidx
+  on public.data_product_packages (package_version);
+
+create index if not exists data_product_packages_run_idx
+  on public.data_product_packages (run_id, created_at desc);
+
+create table if not exists public.data_product_package_items (
+  package_id uuid not null references public.data_product_packages(id) on delete cascade,
+  process_id uuid not null,
+  process_version character(9) not null,
+  state_code integer not null,
+  ordinal integer not null,
+  created_at timestamptz not null default now(),
+  primary key (package_id, process_id, process_version),
+  constraint data_product_package_items_process_fk
+    foreign key (process_id, process_version)
+    references public.processes(id, version)
+    on delete restrict,
+  constraint data_product_package_items_state_chk check (
+    state_code between 100 and 199
+  )
+);
+
+create table if not exists public.data_product_lcia_results (
+  id uuid primary key default gen_random_uuid(),
+  package_id uuid not null references public.data_product_packages(id) on delete cascade,
+  process_id uuid not null,
+  process_version character(9) not null,
+  impact_category_id text not null,
+  impact_category_version text,
+  impact_label_snapshot text,
+  value numeric not null,
+  unit text,
+  source_result_id uuid references public.lca_results(id) on delete set null,
+  source_artifact_sha256 text,
+  created_at timestamptz not null default now(),
+  constraint data_product_lcia_results_package_item_fk
+    foreign key (package_id, process_id, process_version)
+    references public.data_product_package_items(package_id, process_id, process_version)
+    on delete cascade
+);
+
+create unique index if not exists data_product_lcia_results_unique_row_uidx
+  on public.data_product_lcia_results (
+    package_id,
+    process_id,
+    process_version,
+    impact_category_id
+  );
+
+create index if not exists data_product_lcia_results_public_lookup_idx
+  on public.data_product_lcia_results (
+    process_id,
+    process_version,
+    impact_category_id
+  );
+
+create table if not exists public.data_product_artifacts (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid references public.data_product_runs(id) on delete set null,
+  package_id uuid references public.data_product_packages(id) on delete cascade,
+  artifact_type text not null,
+  storage_ref text not null,
+  sha256 text,
+  byte_size bigint,
+  format text,
+  persistence_mode text not null,
+  is_persisted boolean not null default false,
+  source_result_id uuid references public.lca_results(id) on delete set null,
+  snapshot_id uuid references public.lca_network_snapshots(id) on delete set null,
+  worker_job_id uuid references public.worker_jobs(id) on delete set null,
+  created_at timestamptz not null default now(),
+  constraint data_product_artifacts_size_chk check (
+    byte_size is null or byte_size >= 0
+  ),
+  constraint data_product_artifacts_persistence_chk check (
+    persistence_mode in ('pinned', 'copied')
+  ),
+  constraint data_product_artifacts_type_chk check (
+    artifact_type in (
+      'snapshot',
+      'snapshot_index',
+      'source_result',
+      'query_sidecar',
+      'input_manifest',
+      'postprocess_manifest',
+      'package_result_manifest'
+    )
+  )
+);
+
+create index if not exists data_product_artifacts_package_idx
+  on public.data_product_artifacts (package_id, artifact_type);
+
+create table if not exists public.data_product_publications (
+  id uuid primary key default gen_random_uuid(),
+  package_id uuid not null references public.data_product_packages(id) on delete restrict,
+  publication_series_key text not null default 'global',
+  publication_channel text not null default 'public',
+  visibility_scope text not null default 'public',
+  is_current boolean not null default false,
+  status text not null,
+  display_default_impact_category text,
+  published_by uuid,
+  published_at timestamptz,
+  unpublished_by uuid,
+  unpublished_at timestamptz,
+  reason text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint data_product_publications_channel_chk check (
+    publication_channel = 'public'
+  ),
+  constraint data_product_publications_visibility_chk check (
+    visibility_scope = 'public'
+  ),
+  constraint data_product_publications_status_chk check (
+    status in ('current', 'superseded', 'unpublished')
+  )
+);
+
+create unique index if not exists data_product_publications_current_uidx
+  on public.data_product_publications (
+    publication_series_key,
+    publication_channel,
+    visibility_scope
+  )
+  where is_current = true;
+
+create index if not exists data_product_publications_package_idx
+  on public.data_product_publications (package_id, created_at desc);
+
+alter table public.data_product_runs enable row level security;
+alter table public.data_product_run_inputs enable row level security;
+alter table public.data_product_packages enable row level security;
+alter table public.data_product_package_items enable row level security;
+alter table public.data_product_lcia_results enable row level security;
+alter table public.data_product_artifacts enable row level security;
+alter table public.data_product_publications enable row level security;
+
+grant all on table public.data_product_runs to service_role;
+grant all on table public.data_product_run_inputs to service_role;
+grant all on table public.data_product_packages to service_role;
+grant all on table public.data_product_package_items to service_role;
+grant all on table public.data_product_lcia_results to service_role;
+grant all on table public.data_product_artifacts to service_role;
+grant all on table public.data_product_publications to service_role;
+
+create or replace function public.data_product_is_service_request()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select coalesce(current_setting('request.jwt.claim.role', true), '') = 'service_role'
+     or current_user = 'service_role'
+$$;
+
+create or replace function public.data_product_is_manager()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select public.policy_is_current_user_in_roles(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    array['data_product_manager']
+  )
+$$;
+
+create or replace function public.data_product_can_write()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select public.data_product_is_manager()
+      or public.data_product_is_service_request()
+$$;
+
+create or replace function public.data_product_error(
+  p_code text,
+  p_status integer,
+  p_message text
+)
+returns jsonb
+language sql
+stable
+set search_path = public, pg_temp
+as $$
+  select jsonb_build_object(
+    'ok', false,
+    'code', p_code,
+    'status', p_status,
+    'message', p_message
+  )
+$$;
+
+create or replace function public.data_product_current_eligible_manifest()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  with eligible as (
+    select id, version
+    from public.processes
+    where state_code between 100 and 199
+    order by id, version
+  ),
+  aggregated as (
+    select
+      count(*)::integer as eligible_count,
+      md5(
+        coalesce(
+          string_agg(id::text || ':' || version, ',' order by id, version),
+          ''
+        ) || '|published:100-199:v1'
+      ) as input_manifest_hash
+    from eligible
+  )
+  select jsonb_build_object(
+    'predicateVersion', 'published-state-code-100-199:v1',
+    'inputStatusFilter', jsonb_build_object(
+      'state_code',
+      jsonb_build_object('between', jsonb_build_array(100, 199))
+    ),
+    'eligibleInputCount', eligible_count,
+    'inputManifestHash', input_manifest_hash
+  )
+  from aggregated
+$$;
+
+create or replace function public.data_product_selected_manifest(p_run_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  with selected as (
+    select process_id, process_version
+    from public.data_product_run_inputs
+    where run_id = p_run_id
+    order by process_id, process_version
+  ),
+  aggregated as (
+    select
+      count(*)::integer as included_count,
+      md5(
+        coalesce(
+          string_agg(process_id::text || ':' || process_version, ',' order by process_id, process_version),
+          ''
+        ) || '|published:100-199:v1'
+      ) as input_manifest_hash
+    from selected
+  )
+  select jsonb_build_object(
+    'includedInputCount', included_count,
+    'inputManifestHash', input_manifest_hash
+  )
+  from aggregated
+$$;
+
+create or replace function public.cmd_system_change_member_role(
+  p_user_id uuid,
+  p_role text default null::text,
+  p_action text default 'set'::text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_action text := lower(coalesce(p_action, 'set'));
+  v_team_id uuid := '00000000-0000-0000-0000-000000000000'::uuid;
+  v_actor_is_owner boolean;
+  v_actor_is_manager boolean;
+  v_existing_role text;
+  v_role_row jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object('ok', false, 'code', 'AUTH_REQUIRED', 'status', 401, 'message', 'Authentication required');
+  end if;
+
+  if p_user_id is null then
+    return jsonb_build_object('ok', false, 'code', 'USER_ID_REQUIRED', 'status', 400, 'message', 'userId is required');
+  end if;
+
+  v_actor_is_owner := public.cmd_membership_is_system_owner(v_actor);
+  v_actor_is_manager := public.cmd_membership_is_system_manager(v_actor);
+
+  if not v_actor_is_manager then
+    return jsonb_build_object('ok', false, 'code', 'FORBIDDEN', 'status', 403, 'message', 'The actor cannot manage system members');
+  end if;
+
+  select role
+    into v_existing_role
+  from public.roles
+  where user_id = p_user_id
+    and team_id = v_team_id
+  for update;
+
+  if v_action = 'remove' then
+    if v_existing_role is null then
+      return jsonb_build_object('ok', false, 'code', 'ROLE_NOT_FOUND', 'status', 404, 'message', 'Role not found');
+    end if;
+
+    if p_user_id = v_actor or v_existing_role = 'owner' then
+      return jsonb_build_object('ok', false, 'code', 'FORBIDDEN', 'status', 403, 'message', 'The actor cannot remove this system member');
+    end if;
+
+    delete from public.roles
+    where user_id = p_user_id
+      and team_id = v_team_id;
+
+    insert into public.command_audit_log (
+      command,
+      actor_user_id,
+      target_table,
+      target_id,
+      target_version,
+      payload
+    )
+    values (
+      'cmd_system_change_member_role',
+      v_actor,
+      'roles',
+      p_user_id,
+      v_team_id::text,
+      coalesce(p_audit, '{}'::jsonb) || jsonb_build_object('action', 'remove')
+    );
+
+    return jsonb_build_object(
+      'ok', true,
+      'data', jsonb_build_object('removed', true, 'user_id', p_user_id, 'team_id', v_team_id)
+    );
+  end if;
+
+  if v_action <> 'set' then
+    return jsonb_build_object('ok', false, 'code', 'INVALID_ACTION', 'status', 400, 'message', 'Unsupported action');
+  end if;
+
+  if p_role not in ('member', 'admin', 'data_product_manager') then
+    return jsonb_build_object('ok', false, 'code', 'INVALID_ROLE', 'status', 400, 'message', 'Unsupported system role transition');
+  end if;
+
+  if p_role = 'admin' and not v_actor_is_owner then
+    return jsonb_build_object('ok', false, 'code', 'FORBIDDEN', 'status', 403, 'message', 'Only the system owner can assign admin roles');
+  end if;
+
+  if p_role = 'member' and v_existing_role = 'admin' and not v_actor_is_owner then
+    return jsonb_build_object('ok', false, 'code', 'FORBIDDEN', 'status', 403, 'message', 'Only the system owner can demote an admin');
+  end if;
+
+  if v_existing_role is null then
+    insert into public.roles (user_id, team_id, role, modified_at)
+    values (p_user_id, v_team_id, p_role, now())
+    returning to_jsonb(roles.*)
+      into v_role_row;
+  elsif v_existing_role in ('owner', 'admin', 'member', 'data_product_manager') then
+    if v_existing_role = 'owner' then
+      return jsonb_build_object('ok', false, 'code', 'FORBIDDEN', 'status', 403, 'message', 'The owner role cannot be modified');
+    end if;
+
+    update public.roles
+      set role = p_role,
+          modified_at = now()
+    where user_id = p_user_id
+      and team_id = v_team_id
+    returning to_jsonb(roles.*)
+      into v_role_row;
+  else
+    return jsonb_build_object('ok', false, 'code', 'ROLE_CONFLICT', 'status', 409, 'message', 'The existing zero-team role belongs to another scope');
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_system_change_member_role',
+    v_actor,
+    'roles',
+    p_user_id,
+    v_team_id::text,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object('action', 'set', 'role', p_role)
+  );
+
+  return jsonb_build_object('ok', true, 'data', v_role_row);
+exception
+  when unique_violation then
+    return jsonb_build_object('ok', false, 'code', 'ROLE_CONFLICT', 'status', 409, 'message', 'The existing zero-team role belongs to another scope');
+end;
+$$;
+
+create or replace function public.data_product_prevent_ready_package_content_update()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+begin
+  if old.status = 'preview_ready'
+     and (
+       old.run_id is distinct from new.run_id
+       or old.coverage_mode is distinct from new.coverage_mode
+       or old.eligibility_definition is distinct from new.eligibility_definition
+       or old.eligibility_resolved_at is distinct from new.eligibility_resolved_at
+       or old.eligible_input_count is distinct from new.eligible_input_count
+       or old.included_input_count is distinct from new.included_input_count
+       or old.input_manifest_hash is distinct from new.input_manifest_hash
+       or old.snapshot_id is distinct from new.snapshot_id
+       or old.source_result_id is distinct from new.source_result_id
+       or old.package_result_hash is distinct from new.package_result_hash
+       or old.lcia_method_set is distinct from new.lcia_method_set
+       or old.postprocess_mode is distinct from new.postprocess_mode
+       or old.postprocess_status is distinct from new.postprocess_status
+       or old.default_impact_category is distinct from new.default_impact_category
+     ) then
+    raise exception 'data_product_package_immutable'
+      using errcode = '23514';
+  end if;
+
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists data_product_packages_prevent_ready_update
+  on public.data_product_packages;
+
+create trigger data_product_packages_prevent_ready_update
+before update on public.data_product_packages
+for each row
+execute function public.data_product_prevent_ready_package_content_update();
+
+create or replace function public.cmd_data_product_run_create(
+  p_name text,
+  p_processes jsonb default null::jsonb,
+  p_coverage_mode text default 'global_eligible'::text,
+  p_default_impact_category text default null::text,
+  p_lcia_method_set jsonb default '[]'::jsonb,
+  p_idempotency_key text default null::text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_coverage_mode text := lower(trim(coalesce(p_coverage_mode, 'global_eligible')));
+  v_current_manifest jsonb;
+  v_existing public.data_product_runs%rowtype;
+  v_run public.data_product_runs%rowtype;
+  v_selected_count integer;
+  v_invalid_count integer;
+  v_selected_manifest jsonb;
+begin
+  if not public.data_product_is_manager() then
+    return public.data_product_error('not_data_product_manager', 403, 'Data product manager role is required');
+  end if;
+
+  if v_actor is null then
+    return public.data_product_error('auth_required', 401, 'Authentication required');
+  end if;
+
+  if v_coverage_mode not in ('subset', 'global_eligible') then
+    return public.data_product_error('invalid_coverage_mode', 400, 'coverage_mode must be subset or global_eligible');
+  end if;
+
+  if v_coverage_mode = 'global_eligible'
+     and p_processes is not null
+     and jsonb_array_length(p_processes) > 0 then
+    return public.data_product_error('invalid_coverage_mode', 400, 'global_eligible runs are resolved from the current published input predicate');
+  end if;
+
+  if jsonb_typeof(coalesce(p_lcia_method_set, '[]'::jsonb)) <> 'array' then
+    return public.data_product_error('invalid_lcia_method_set', 400, 'lcia_method_set must be a JSON array');
+  end if;
+
+  if p_processes is not null and jsonb_typeof(p_processes) <> 'array' then
+    return public.data_product_error('invalid_process_selection', 400, 'process selection must be a JSON array');
+  end if;
+
+  if p_idempotency_key is not null then
+    select *
+      into v_existing
+    from public.data_product_runs
+    where created_by = v_actor
+      and idempotency_key = p_idempotency_key
+    order by created_at desc
+    limit 1;
+
+    if v_existing.id is not null then
+      return jsonb_build_object(
+        'ok', true,
+        'data', jsonb_build_object(
+          'runId', v_existing.id,
+          'coverageMode', v_existing.coverage_mode,
+          'eligibleInputCount', v_existing.eligible_input_count,
+          'includedInputCount', v_existing.included_input_count,
+          'inputManifestHash', v_existing.input_manifest_hash
+        ),
+        'reused', true
+      );
+    end if;
+  end if;
+
+  v_current_manifest := public.data_product_current_eligible_manifest();
+
+  insert into public.data_product_runs (
+    name,
+    input_scope,
+    input_status_filter,
+    coverage_mode,
+    eligibility_definition,
+    eligibility_resolved_at,
+    eligible_input_count,
+    included_input_count,
+    input_manifest_hash,
+    lcia_method_set,
+    default_impact_category,
+    status,
+    idempotency_key,
+    created_by
+  )
+  values (
+    nullif(trim(coalesce(p_name, '')), ''),
+    jsonb_build_object('selectionMode', case when p_processes is null or jsonb_array_length(p_processes) = 0 then 'all_eligible' else 'manual' end),
+    v_current_manifest->'inputStatusFilter',
+    v_coverage_mode,
+    v_current_manifest - 'eligibleInputCount' - 'inputManifestHash',
+    now(),
+    (v_current_manifest->>'eligibleInputCount')::integer,
+    0,
+    'pending',
+    coalesce(p_lcia_method_set, '[]'::jsonb),
+    nullif(trim(coalesce(p_default_impact_category, '')), ''),
+    'created',
+    nullif(trim(coalesce(p_idempotency_key, '')), ''),
+    v_actor
+  )
+  returning *
+    into v_run;
+
+  if p_processes is null or jsonb_array_length(p_processes) = 0 then
+    insert into public.data_product_run_inputs (
+      run_id,
+      process_id,
+      process_version,
+      state_code,
+      ordinal
+    )
+    select
+      v_run.id,
+      p.id,
+      p.version,
+      p.state_code,
+      row_number() over (order by p.id, p.version)::integer
+    from public.processes as p
+    where p.state_code between 100 and 199
+    order by p.id, p.version;
+  else
+    with requested as (
+      select
+        (item.value->>'id')::uuid as process_id,
+        coalesce(item.value->>'version', item.value->>'process_version')::character(9) as process_version,
+        item.ordinality::integer as ordinal
+      from jsonb_array_elements(p_processes) with ordinality as item(value, ordinality)
+    ),
+    resolved as (
+      select
+        r.process_id,
+        r.process_version,
+        r.ordinal,
+        p.state_code
+      from requested as r
+      left join public.processes as p
+        on p.id = r.process_id
+       and p.version = r.process_version
+    )
+    insert into public.data_product_run_inputs (
+      run_id,
+      process_id,
+      process_version,
+      state_code,
+      ordinal
+    )
+    select
+      v_run.id,
+      process_id,
+      process_version,
+      state_code,
+      ordinal
+    from resolved
+    where state_code between 100 and 199;
+
+    with requested as (
+      select
+        (item.value->>'id')::uuid as process_id,
+        coalesce(item.value->>'version', item.value->>'process_version')::character(9) as process_version
+      from jsonb_array_elements(p_processes) as item(value)
+    )
+    select count(*)::integer
+      into v_invalid_count
+    from requested as r
+    left join public.processes as p
+      on p.id = r.process_id
+     and p.version = r.process_version
+    where p.id is null
+       or p.state_code is null
+       or p.state_code not between 100 and 199;
+
+    if v_invalid_count > 0 then
+      delete from public.data_product_runs where id = v_run.id;
+      return public.data_product_error('input_not_eligible', 400, 'All data product inputs must be published process rows');
+    end if;
+  end if;
+
+  select count(*)::integer
+    into v_selected_count
+  from public.data_product_run_inputs
+  where run_id = v_run.id;
+
+  if v_selected_count = 0 then
+    delete from public.data_product_runs where id = v_run.id;
+    return public.data_product_error('input_empty', 400, 'Data product run requires at least one eligible process');
+  end if;
+
+  v_selected_manifest := public.data_product_selected_manifest(v_run.id);
+
+  update public.data_product_runs
+    set included_input_count = v_selected_count,
+        input_manifest_hash = v_selected_manifest->>'inputManifestHash',
+        updated_at = now()
+  where id = v_run.id
+  returning *
+    into v_run;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_data_product_run_create',
+    v_actor,
+    'data_product_runs',
+    v_run.id,
+    null,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'coverageMode', v_run.coverage_mode,
+      'eligibleInputCount', v_run.eligible_input_count,
+      'includedInputCount', v_run.included_input_count
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'runId', v_run.id,
+      'coverageMode', v_run.coverage_mode,
+      'eligibleInputCount', v_run.eligible_input_count,
+      'includedInputCount', v_run.included_input_count,
+      'inputManifestHash', v_run.input_manifest_hash
+    ),
+    'reused', false
+  );
+exception
+  when unique_violation then
+    return public.data_product_error('invalid_process_selection', 400, 'process selection contains duplicate inputs');
+  when not_null_violation then
+    return public.data_product_error('invalid_run_request', 400, 'Data product run request is invalid');
+  when invalid_text_representation then
+    return public.data_product_error('invalid_process_selection', 400, 'process ids and versions must be valid');
+end;
+$$;
+
+create or replace function public.cmd_data_product_package_mark_ready(
+  p_run_id uuid,
+  p_package_version text,
+  p_snapshot_id uuid,
+  p_source_result_id uuid,
+  p_package_result_hash text,
+  p_default_impact_category text,
+  p_result_rows jsonb default '[]'::jsonb,
+  p_artifacts jsonb default '[]'::jsonb,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_run public.data_product_runs%rowtype;
+  v_package public.data_product_packages%rowtype;
+begin
+  if not public.data_product_can_write() then
+    return public.data_product_error('not_data_product_manager', 403, 'Data product manager or service role is required');
+  end if;
+
+  if jsonb_typeof(coalesce(p_result_rows, '[]'::jsonb)) <> 'array' then
+    return public.data_product_error('invalid_result_rows', 400, 'result rows must be a JSON array');
+  end if;
+
+  if jsonb_typeof(coalesce(p_artifacts, '[]'::jsonb)) <> 'array' then
+    return public.data_product_error('invalid_artifacts', 400, 'artifacts must be a JSON array');
+  end if;
+
+  select *
+    into v_run
+  from public.data_product_runs
+  where id = p_run_id
+  for update;
+
+  if v_run.id is null then
+    return public.data_product_error('run_not_found', 404, 'Data product run not found');
+  end if;
+
+  insert into public.data_product_packages (
+    run_id,
+    package_version,
+    coverage_mode,
+    eligibility_definition,
+    eligibility_resolved_at,
+    eligible_input_count,
+    included_input_count,
+    input_manifest_hash,
+    snapshot_id,
+    source_result_id,
+    package_result_hash,
+    lcia_method_set,
+    postprocess_mode,
+    postprocess_status,
+    default_impact_category,
+    status,
+    created_by
+  )
+  values (
+    v_run.id,
+    nullif(trim(coalesce(p_package_version, '')), ''),
+    v_run.coverage_mode,
+    v_run.eligibility_definition,
+    v_run.eligibility_resolved_at,
+    v_run.eligible_input_count,
+    v_run.included_input_count,
+    v_run.input_manifest_hash,
+    p_snapshot_id,
+    p_source_result_id,
+    nullif(trim(coalesce(p_package_result_hash, '')), ''),
+    v_run.lcia_method_set,
+    v_run.postprocess_mode,
+    v_run.postprocess_status,
+    nullif(trim(coalesce(p_default_impact_category, v_run.default_impact_category, '')), ''),
+    'preview_ready',
+    coalesce(v_actor, v_run.created_by)
+  )
+  returning *
+    into v_package;
+
+  insert into public.data_product_package_items (
+    package_id,
+    process_id,
+    process_version,
+    state_code,
+    ordinal
+  )
+  select
+    v_package.id,
+    process_id,
+    process_version,
+    state_code,
+    ordinal
+  from public.data_product_run_inputs
+  where run_id = v_run.id
+  order by ordinal;
+
+  insert into public.data_product_lcia_results (
+    package_id,
+    process_id,
+    process_version,
+    impact_category_id,
+    impact_category_version,
+    impact_label_snapshot,
+    value,
+    unit,
+    source_result_id,
+    source_artifact_sha256
+  )
+  select
+    v_package.id,
+    (row.value->>'process_id')::uuid,
+    coalesce(row.value->>'process_version', row.value->>'version')::character(9),
+    row.value->>'impact_category_id',
+    nullif(row.value->>'impact_category_version', ''),
+    nullif(row.value->>'impact_label_snapshot', ''),
+    (row.value->>'value')::numeric,
+    nullif(row.value->>'unit', ''),
+    nullif(row.value->>'source_result_id', '')::uuid,
+    nullif(row.value->>'source_artifact_sha256', '')
+  from jsonb_array_elements(coalesce(p_result_rows, '[]'::jsonb)) as row(value);
+
+  insert into public.data_product_artifacts (
+    run_id,
+    package_id,
+    artifact_type,
+    storage_ref,
+    sha256,
+    byte_size,
+    format,
+    persistence_mode,
+    is_persisted,
+    source_result_id,
+    snapshot_id,
+    worker_job_id
+  )
+  select
+    v_run.id,
+    v_package.id,
+    artifact.value->>'artifact_type',
+    artifact.value->>'storage_ref',
+    nullif(artifact.value->>'sha256', ''),
+    nullif(artifact.value->>'byte_size', '')::bigint,
+    nullif(artifact.value->>'format', ''),
+    coalesce(nullif(artifact.value->>'persistence_mode', ''), 'copied'),
+    coalesce((artifact.value->>'is_persisted')::boolean, false),
+    nullif(artifact.value->>'source_result_id', '')::uuid,
+    nullif(artifact.value->>'snapshot_id', '')::uuid,
+    nullif(artifact.value->>'worker_job_id', '')::uuid
+  from jsonb_array_elements(coalesce(p_artifacts, '[]'::jsonb)) as artifact(value);
+
+  update public.data_product_runs
+    set status = 'computed',
+        updated_at = now()
+  where id = v_run.id;
+
+  if v_actor is not null then
+    insert into public.command_audit_log (
+      command,
+      actor_user_id,
+      target_table,
+      target_id,
+      target_version,
+      payload
+    )
+    values (
+      'cmd_data_product_package_mark_ready',
+      v_actor,
+      'data_product_packages',
+      v_package.id,
+      v_package.package_version,
+      coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+        'runId', v_run.id,
+        'resultRowCount', jsonb_array_length(coalesce(p_result_rows, '[]'::jsonb)),
+        'artifactCount', jsonb_array_length(coalesce(p_artifacts, '[]'::jsonb))
+      )
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'packageId', v_package.id,
+      'packageVersion', v_package.package_version,
+      'status', v_package.status,
+      'includedInputCount', v_package.included_input_count
+    )
+  );
+exception
+  when unique_violation then
+    return public.data_product_error('package_conflict', 409, 'Data product package already exists or contains duplicate result rows');
+  when foreign_key_violation then
+    return public.data_product_error('package_reference_invalid', 400, 'Data product package references invalid run, process, snapshot, result, or job rows');
+  when invalid_text_representation then
+    return public.data_product_error('invalid_package_payload', 400, 'Data product package payload contains invalid ids or numeric values');
+  when not_null_violation then
+    return public.data_product_error('invalid_package_payload', 400, 'Data product package payload is missing required fields');
+  when check_violation then
+    return public.data_product_error('invalid_package_payload', 400, 'Data product package payload violates schema constraints');
+end;
+$$;
+
+create or replace function public.cmd_data_product_package_publish(
+  p_package_id uuid,
+  p_display_default_impact_category text default null::text,
+  p_reason text default null::text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_package public.data_product_packages%rowtype;
+  v_current_manifest jsonb;
+  v_default_impact text;
+  v_previous_id uuid;
+  v_publication public.data_product_publications%rowtype;
+begin
+  if not public.data_product_is_manager() then
+    return public.data_product_error('not_data_product_manager', 403, 'Data product manager role is required');
+  end if;
+
+  if v_actor is null then
+    return public.data_product_error('auth_required', 401, 'Authentication required');
+  end if;
+
+  select *
+    into v_package
+  from public.data_product_packages
+  where id = p_package_id
+  for update;
+
+  if v_package.id is null or v_package.status <> 'preview_ready' then
+    return public.data_product_error('package_not_ready', 400, 'Package must be preview_ready before publish');
+  end if;
+
+  if v_package.coverage_mode <> 'global_eligible'
+     or v_package.included_input_count <> v_package.eligible_input_count then
+    return public.data_product_error('package_not_global_eligible', 400, 'Only full global eligible packages can publish as global latest');
+  end if;
+
+  v_current_manifest := public.data_product_current_eligible_manifest();
+
+  if v_package.eligible_input_count <> (v_current_manifest->>'eligibleInputCount')::integer
+     or v_package.input_manifest_hash <> v_current_manifest->>'inputManifestHash' then
+    return public.data_product_error('package_stale_eligibility', 409, 'Eligible process set changed after package creation');
+  end if;
+
+  if not exists (
+    select 1
+    from public.data_product_lcia_results
+    where package_id = v_package.id
+  ) then
+    return public.data_product_error('package_not_ready', 400, 'Package has no materialized LCIA result rows');
+  end if;
+
+  v_default_impact := coalesce(
+    nullif(trim(p_display_default_impact_category), ''),
+    v_package.default_impact_category
+  );
+
+  if v_default_impact is null
+     or not exists (
+       select 1
+       from public.data_product_lcia_results
+       where package_id = v_package.id
+         and impact_category_id = v_default_impact
+     ) then
+    return public.data_product_error('default_impact_missing', 400, 'Default impact category is not present in package rows');
+  end if;
+
+  if not exists (
+    select 1
+    from public.data_product_artifacts
+    where package_id = v_package.id
+      and is_persisted = true
+  )
+  or exists (
+    select 1
+    from public.data_product_artifacts
+    where package_id = v_package.id
+      and is_persisted = false
+  ) then
+    return public.data_product_error('artifact_not_persisted', 400, 'Package artifacts must be pinned or copied before publish');
+  end if;
+
+  lock table public.data_product_publications in exclusive mode;
+
+  update public.data_product_publications
+    set is_current = false,
+        status = 'superseded',
+        updated_at = now()
+  where publication_series_key = 'global'
+    and publication_channel = 'public'
+    and visibility_scope = 'public'
+    and is_current = true
+  returning id
+    into v_previous_id;
+
+  insert into public.data_product_publications (
+    package_id,
+    publication_series_key,
+    publication_channel,
+    visibility_scope,
+    is_current,
+    status,
+    display_default_impact_category,
+    published_by,
+    published_at,
+    reason
+  )
+  values (
+    v_package.id,
+    'global',
+    'public',
+    'public',
+    true,
+    'current',
+    v_default_impact,
+    v_actor,
+    now(),
+    nullif(trim(coalesce(p_reason, '')), '')
+  )
+  returning *
+    into v_publication;
+
+  update public.lca_results
+    set is_pinned = true
+  where id = v_package.source_result_id
+     or id in (
+       select source_result_id
+       from public.data_product_lcia_results
+       where package_id = v_package.id
+         and source_result_id is not null
+     )
+     or id in (
+       select source_result_id
+       from public.data_product_artifacts
+       where package_id = v_package.id
+         and source_result_id is not null
+     );
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_data_product_package_publish',
+    v_actor,
+    'data_product_publications',
+    v_publication.id,
+    v_package.package_version,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'packageId', v_package.id,
+      'previousPublicationId', v_previous_id,
+      'displayDefaultImpactCategory', v_default_impact
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'publicationId', v_publication.id,
+      'packageId', v_package.id,
+      'previousPublicationId', v_previous_id,
+      'isCurrent', v_publication.is_current
+    )
+  );
+exception
+  when unique_violation then
+    return public.data_product_error('latest_conflict', 409, 'Another current publication already exists');
+end;
+$$;
+
+create or replace function public.cmd_data_product_package_unpublish(
+  p_publication_id uuid,
+  p_reason text default null::text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_publication public.data_product_publications%rowtype;
+begin
+  if not public.data_product_is_manager() then
+    return public.data_product_error('not_data_product_manager', 403, 'Data product manager role is required');
+  end if;
+
+  if v_actor is null then
+    return public.data_product_error('auth_required', 401, 'Authentication required');
+  end if;
+
+  update public.data_product_publications
+    set is_current = false,
+        status = 'unpublished',
+        unpublished_by = v_actor,
+        unpublished_at = now(),
+        reason = coalesce(nullif(trim(p_reason), ''), reason),
+        updated_at = now()
+  where id = p_publication_id
+  returning *
+    into v_publication;
+
+  if v_publication.id is null then
+    return public.data_product_error('publication_not_found', 404, 'Publication not found');
+  end if;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_data_product_package_unpublish',
+    v_actor,
+    'data_product_publications',
+    v_publication.id,
+    null,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object('reason', p_reason)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'publicationId', v_publication.id,
+      'packageId', v_publication.package_id,
+      'status', v_publication.status
+    )
+  );
+end;
+$$;
+
+create or replace function public.get_data_product_package_preview(
+  p_package_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_package public.data_product_packages%rowtype;
+  v_rows jsonb;
+begin
+  if not public.data_product_is_manager() then
+    return public.data_product_error('not_data_product_manager', 403, 'Data product manager role is required');
+  end if;
+
+  select *
+    into v_package
+  from public.data_product_packages
+  where id = p_package_id;
+
+  if v_package.id is null then
+    return public.data_product_error('package_not_found', 404, 'Package not found');
+  end if;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'processId', process_id,
+        'processVersion', process_version,
+        'impactCategoryId', impact_category_id,
+        'impactCategoryVersion', impact_category_version,
+        'impactLabel', impact_label_snapshot,
+        'value', value,
+        'unit', unit
+      )
+      order by process_id, process_version, impact_category_id
+    ),
+    '[]'::jsonb
+  )
+    into v_rows
+  from public.data_product_lcia_results
+  where package_id = v_package.id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'summary', jsonb_build_object(
+        'packageId', v_package.id,
+        'packageVersion', v_package.package_version,
+        'status', v_package.status,
+        'coverageMode', v_package.coverage_mode,
+        'eligibleInputCount', v_package.eligible_input_count,
+        'includedInputCount', v_package.included_input_count,
+        'defaultImpactCategory', v_package.default_impact_category
+      ),
+      'rows', v_rows,
+      'rowCount', jsonb_array_length(v_rows)
+    )
+  );
+end;
+$$;
+
+create or replace function public.get_published_process_lcia_results(
+  p_process_id uuid,
+  p_process_version text,
+  p_impact_category_id text default null::text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_publication public.data_product_publications%rowtype;
+  v_package public.data_product_packages%rowtype;
+  v_rows jsonb;
+begin
+  select *
+    into v_publication
+  from public.data_product_publications
+  where publication_series_key = 'global'
+    and publication_channel = 'public'
+    and visibility_scope = 'public'
+    and is_current = true
+    and status = 'current'
+  order by published_at desc nulls last, created_at desc
+  limit 1;
+
+  if v_publication.id is null then
+    return jsonb_build_object(
+      'ok', true,
+      'data', jsonb_build_object(
+        'publication', null,
+        'package', null,
+        'rows', '[]'::jsonb,
+        'rowCount', 0
+      )
+    );
+  end if;
+
+  select *
+    into v_package
+  from public.data_product_packages
+  where id = v_publication.package_id
+    and status = 'preview_ready';
+
+  if v_package.id is null then
+    return jsonb_build_object(
+      'ok', true,
+      'data', jsonb_build_object(
+        'publication', null,
+        'package', null,
+        'rows', '[]'::jsonb,
+        'rowCount', 0
+      )
+    );
+  end if;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'processId', process_id,
+        'processVersion', process_version,
+        'impactCategoryId', impact_category_id,
+        'impactCategoryVersion', impact_category_version,
+        'impactLabel', impact_label_snapshot,
+        'value', value,
+        'unit', unit
+      )
+      order by impact_category_id
+    ),
+    '[]'::jsonb
+  )
+    into v_rows
+  from public.data_product_lcia_results
+  where package_id = v_package.id
+    and process_id = p_process_id
+    and process_version = p_process_version::character(9)
+    and (
+      p_impact_category_id is null
+      or impact_category_id = p_impact_category_id
+    );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'publication', jsonb_build_object(
+        'publicationId', v_publication.id,
+        'publicationSeriesKey', v_publication.publication_series_key,
+        'publicationChannel', v_publication.publication_channel,
+        'visibilityScope', v_publication.visibility_scope,
+        'displayDefaultImpactCategory', v_publication.display_default_impact_category,
+        'publishedAt', v_publication.published_at
+      ),
+      'package', jsonb_build_object(
+        'packageId', v_package.id,
+        'packageVersion', v_package.package_version,
+        'defaultImpactCategory', v_package.default_impact_category
+      ),
+      'rows', v_rows,
+      'rowCount', jsonb_array_length(v_rows)
+    )
+  );
+end;
+$$;
+
+revoke all on function public.data_product_is_service_request() from public;
+revoke all on function public.data_product_is_manager() from public;
+revoke all on function public.data_product_can_write() from public;
+revoke all on function public.data_product_error(text, integer, text) from public;
+revoke all on function public.data_product_current_eligible_manifest() from public;
+revoke all on function public.data_product_selected_manifest(uuid) from public;
+revoke all on function public.data_product_prevent_ready_package_content_update() from public;
+
+revoke all on function public.cmd_data_product_run_create(text, jsonb, text, text, jsonb, text, jsonb) from public;
+revoke all on function public.cmd_data_product_package_mark_ready(uuid, text, uuid, uuid, text, text, jsonb, jsonb, jsonb) from public;
+revoke all on function public.cmd_data_product_package_publish(uuid, text, text, jsonb) from public;
+revoke all on function public.cmd_data_product_package_unpublish(uuid, text, jsonb) from public;
+revoke all on function public.get_data_product_package_preview(uuid) from public;
+revoke all on function public.get_published_process_lcia_results(uuid, text, text) from public;
+
+grant execute on function public.cmd_data_product_run_create(text, jsonb, text, text, jsonb, text, jsonb) to authenticated;
+grant execute on function public.cmd_data_product_package_mark_ready(uuid, text, uuid, uuid, text, text, jsonb, jsonb, jsonb) to authenticated, service_role;
+grant execute on function public.cmd_data_product_package_publish(uuid, text, text, jsonb) to authenticated;
+grant execute on function public.cmd_data_product_package_unpublish(uuid, text, jsonb) to authenticated;
+grant execute on function public.get_data_product_package_preview(uuid) to authenticated;
+grant execute on function public.get_published_process_lcia_results(uuid, text, text) to anon, authenticated, service_role;
+
+grant execute on function public.data_product_is_service_request() to service_role;
+grant execute on function public.data_product_is_manager() to authenticated, service_role;
+grant execute on function public.data_product_can_write() to authenticated, service_role;

--- a/supabase/migrations/20260623075159_data_product_publication_mvp.sql
+++ b/supabase/migrations/20260623075159_data_product_publication_mvp.sql
@@ -1,6 +1,6 @@
--- Data product calculation/publication MVP.
--- This migration intentionally keeps data product package facts separate from
--- process publication state and from transient LCA query caches.
+-- LCIA result package build/publication MVP.
+-- Worker execution state stays in public.worker_jobs. This migration only adds
+-- the durable LCIA result package and public/latest publication facts.
 
 alter table public.roles
   drop constraint if exists roles_role_check;
@@ -42,17 +42,17 @@ insert into public.worker_job_kinds (
   user_visible,
   description
 ) values (
-  'data_product.package_build',
+  'lcia_result.package_build',
   'calculator',
   'solver',
   'operator',
   0,
   3,
   3600,
-  'data_product.package_build.request.v1',
-  'data_product.package_build.result.v1',
+  'lcia_result.package_build.request.v1',
+  'lcia_result.package_build.result.v1',
   false,
-  'Builds a data product package from a published-only snapshot, materialized LCIA rows, and pinned/copied artifacts.'
+  'Builds an immutable LCIA result package from a published-only data-product snapshot and pinned/copied result artifacts.'
 ) on conflict (job_kind) do update
 set worker_runtime = excluded.worker_runtime,
     worker_queue = excluded.worker_queue,
@@ -66,194 +66,75 @@ set worker_runtime = excluded.worker_runtime,
     description = excluded.description,
     updated_at = now();
 
-create table if not exists public.data_product_runs (
+create table if not exists public.lcia_result_packages (
   id uuid primary key default gen_random_uuid(),
-  name text not null,
-  input_scope jsonb not null default '{}'::jsonb,
-  input_status_filter jsonb not null default '{"state_code":{"between":[100,199]}}'::jsonb,
-  coverage_mode text not null,
-  eligibility_definition jsonb not null default '{}'::jsonb,
-  eligibility_resolved_at timestamptz not null default now(),
-  eligible_input_count integer not null default 0,
-  included_input_count integer not null default 0,
-  input_manifest_hash text not null,
-  lcia_method_set jsonb not null default '[]'::jsonb,
-  default_impact_category text,
-  postprocess_mode text not null default 'skipped',
-  postprocess_status text not null default 'skipped',
-  status text not null default 'created',
-  worker_job_id uuid references public.worker_jobs(id) on delete set null,
-  idempotency_key text,
-  created_by uuid not null,
-  created_at timestamptz not null default now(),
-  updated_at timestamptz not null default now(),
-  constraint data_product_runs_counts_chk check (
-    eligible_input_count >= 0 and included_input_count >= 0
-  ),
-  constraint data_product_runs_coverage_chk check (
-    coverage_mode in ('subset', 'global_eligible')
-  ),
-  constraint data_product_runs_lcia_method_set_chk check (
-    jsonb_typeof(lcia_method_set) = 'array'
-  ),
-  constraint data_product_runs_status_chk check (
-    status in ('created', 'queued', 'computing', 'computed', 'failed', 'deprecated')
-  )
-);
-
-create unique index if not exists data_product_runs_idempotency_uidx
-  on public.data_product_runs (created_by, idempotency_key)
-  where idempotency_key is not null;
-
-create table if not exists public.data_product_run_inputs (
-  run_id uuid not null references public.data_product_runs(id) on delete cascade,
-  process_id uuid not null,
-  process_version character(9) not null,
-  state_code integer not null,
-  ordinal integer not null,
-  created_at timestamptz not null default now(),
-  primary key (run_id, process_id, process_version),
-  constraint data_product_run_inputs_process_fk
-    foreign key (process_id, process_version)
-    references public.processes(id, version)
-    on delete restrict,
-  constraint data_product_run_inputs_state_chk check (
-    state_code between 100 and 199
-  )
-);
-
-create table if not exists public.data_product_packages (
-  id uuid primary key default gen_random_uuid(),
-  run_id uuid not null references public.data_product_runs(id) on delete restrict,
+  build_id uuid not null,
+  build_worker_job_id uuid not null references public.worker_jobs(id) on delete restrict,
   package_version text not null,
   coverage_mode text not null,
-  eligibility_definition jsonb not null,
+  input_status_filter jsonb not null default '{"state_code":{"between":[100,199]}}'::jsonb,
+  eligibility_definition jsonb not null default '{}'::jsonb,
   eligibility_resolved_at timestamptz not null,
   eligible_input_count integer not null,
   included_input_count integer not null,
   input_manifest_hash text not null,
-  snapshot_id uuid references public.lca_network_snapshots(id) on delete restrict,
-  source_result_id uuid references public.lca_results(id) on delete set null,
-  package_result_hash text not null,
+  input_manifest jsonb not null,
+  snapshot_id uuid not null references public.lca_network_snapshots(id) on delete restrict,
+  result_id uuid not null references public.lca_results(id) on delete restrict,
+  latest_all_unit_result_id uuid references public.lca_latest_all_unit_results(id) on delete set null,
+  result_artifact_ref jsonb not null default '{}'::jsonb,
+  query_artifact_ref jsonb not null default '{}'::jsonb,
+  artifact_manifest jsonb not null default '{}'::jsonb,
+  package_result_hash text,
   lcia_method_set jsonb not null default '[]'::jsonb,
-  postprocess_mode text not null default 'skipped',
-  postprocess_status text not null default 'skipped',
+  available_impact_categories jsonb not null default '[]'::jsonb,
+  postprocess_manifest jsonb not null default '{"postprocess_mode":"skipped"}'::jsonb,
   default_impact_category text,
   status text not null default 'preview_ready',
   created_by uuid not null,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
-  constraint data_product_packages_counts_chk check (
+  constraint lcia_result_packages_counts_chk check (
     eligible_input_count >= 0 and included_input_count >= 0
   ),
-  constraint data_product_packages_coverage_chk check (
+  constraint lcia_result_packages_coverage_chk check (
     coverage_mode in ('subset', 'global_eligible')
   ),
-  constraint data_product_packages_status_chk check (
-    status in ('preview_ready', 'deprecated', 'failed')
+  constraint lcia_result_packages_input_manifest_object_chk check (
+    jsonb_typeof(input_manifest) = 'object'
   ),
-  constraint data_product_packages_lcia_method_set_chk check (
+  constraint lcia_result_packages_artifact_refs_object_chk check (
+    jsonb_typeof(result_artifact_ref) = 'object'
+    and jsonb_typeof(query_artifact_ref) = 'object'
+    and jsonb_typeof(artifact_manifest) = 'object'
+    and jsonb_typeof(postprocess_manifest) = 'object'
+  ),
+  constraint lcia_result_packages_lcia_method_set_chk check (
     jsonb_typeof(lcia_method_set) = 'array'
-  )
-);
-
-create unique index if not exists data_product_packages_package_version_uidx
-  on public.data_product_packages (package_version);
-
-create index if not exists data_product_packages_run_idx
-  on public.data_product_packages (run_id, created_at desc);
-
-create table if not exists public.data_product_package_items (
-  package_id uuid not null references public.data_product_packages(id) on delete cascade,
-  process_id uuid not null,
-  process_version character(9) not null,
-  state_code integer not null,
-  ordinal integer not null,
-  created_at timestamptz not null default now(),
-  primary key (package_id, process_id, process_version),
-  constraint data_product_package_items_process_fk
-    foreign key (process_id, process_version)
-    references public.processes(id, version)
-    on delete restrict,
-  constraint data_product_package_items_state_chk check (
-    state_code between 100 and 199
-  )
-);
-
-create table if not exists public.data_product_lcia_results (
-  id uuid primary key default gen_random_uuid(),
-  package_id uuid not null references public.data_product_packages(id) on delete cascade,
-  process_id uuid not null,
-  process_version character(9) not null,
-  impact_category_id text not null,
-  impact_category_version text,
-  impact_label_snapshot text,
-  value numeric not null,
-  unit text,
-  source_result_id uuid references public.lca_results(id) on delete set null,
-  source_artifact_sha256 text,
-  created_at timestamptz not null default now(),
-  constraint data_product_lcia_results_package_item_fk
-    foreign key (package_id, process_id, process_version)
-    references public.data_product_package_items(package_id, process_id, process_version)
-    on delete cascade
-);
-
-create unique index if not exists data_product_lcia_results_unique_row_uidx
-  on public.data_product_lcia_results (
-    package_id,
-    process_id,
-    process_version,
-    impact_category_id
-  );
-
-create index if not exists data_product_lcia_results_public_lookup_idx
-  on public.data_product_lcia_results (
-    process_id,
-    process_version,
-    impact_category_id
-  );
-
-create table if not exists public.data_product_artifacts (
-  id uuid primary key default gen_random_uuid(),
-  run_id uuid references public.data_product_runs(id) on delete set null,
-  package_id uuid references public.data_product_packages(id) on delete cascade,
-  artifact_type text not null,
-  storage_ref text not null,
-  sha256 text,
-  byte_size bigint,
-  format text,
-  persistence_mode text not null,
-  is_persisted boolean not null default false,
-  source_result_id uuid references public.lca_results(id) on delete set null,
-  snapshot_id uuid references public.lca_network_snapshots(id) on delete set null,
-  worker_job_id uuid references public.worker_jobs(id) on delete set null,
-  created_at timestamptz not null default now(),
-  constraint data_product_artifacts_size_chk check (
-    byte_size is null or byte_size >= 0
   ),
-  constraint data_product_artifacts_persistence_chk check (
-    persistence_mode in ('pinned', 'copied')
+  constraint lcia_result_packages_available_impacts_chk check (
+    jsonb_typeof(available_impact_categories) = 'array'
   ),
-  constraint data_product_artifacts_type_chk check (
-    artifact_type in (
-      'snapshot',
-      'snapshot_index',
-      'source_result',
-      'query_sidecar',
-      'input_manifest',
-      'postprocess_manifest',
-      'package_result_manifest'
-    )
+  constraint lcia_result_packages_status_chk check (
+    status in ('preview_ready', 'deprecated', 'failed')
   )
 );
 
-create index if not exists data_product_artifacts_package_idx
-  on public.data_product_artifacts (package_id, artifact_type);
+create unique index if not exists lcia_result_packages_build_uidx
+  on public.lcia_result_packages (build_id);
 
-create table if not exists public.data_product_publications (
+create unique index if not exists lcia_result_packages_build_worker_job_uidx
+  on public.lcia_result_packages (build_worker_job_id);
+
+create unique index if not exists lcia_result_packages_package_version_uidx
+  on public.lcia_result_packages (package_version);
+
+create index if not exists lcia_result_packages_created_idx
+  on public.lcia_result_packages (created_at desc);
+
+create table if not exists public.lcia_result_publications (
   id uuid primary key default gen_random_uuid(),
-  package_id uuid not null references public.data_product_packages(id) on delete restrict,
+  package_id uuid not null references public.lcia_result_packages(id) on delete restrict,
   publication_series_key text not null default 'global',
   publication_channel text not null default 'public',
   visibility_scope text not null default 'public',
@@ -267,56 +148,48 @@ create table if not exists public.data_product_publications (
   reason text,
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
-  constraint data_product_publications_channel_chk check (
+  constraint lcia_result_publications_channel_chk check (
     publication_channel = 'public'
   ),
-  constraint data_product_publications_visibility_chk check (
+  constraint lcia_result_publications_visibility_chk check (
     visibility_scope = 'public'
   ),
-  constraint data_product_publications_status_chk check (
+  constraint lcia_result_publications_status_chk check (
     status in ('current', 'superseded', 'unpublished')
   )
 );
 
-create unique index if not exists data_product_publications_current_uidx
-  on public.data_product_publications (
+create unique index if not exists lcia_result_publications_current_uidx
+  on public.lcia_result_publications (
     publication_series_key,
     publication_channel,
     visibility_scope
   )
   where is_current = true;
 
-create index if not exists data_product_publications_package_idx
-  on public.data_product_publications (package_id, created_at desc);
+create index if not exists lcia_result_publications_package_idx
+  on public.lcia_result_publications (package_id, created_at desc);
 
-alter table public.data_product_runs enable row level security;
-alter table public.data_product_run_inputs enable row level security;
-alter table public.data_product_packages enable row level security;
-alter table public.data_product_package_items enable row level security;
-alter table public.data_product_lcia_results enable row level security;
-alter table public.data_product_artifacts enable row level security;
-alter table public.data_product_publications enable row level security;
+alter table public.lcia_result_packages enable row level security;
+alter table public.lcia_result_publications enable row level security;
 
-grant all on table public.data_product_runs to service_role;
-grant all on table public.data_product_run_inputs to service_role;
-grant all on table public.data_product_packages to service_role;
-grant all on table public.data_product_package_items to service_role;
-grant all on table public.data_product_lcia_results to service_role;
-grant all on table public.data_product_artifacts to service_role;
-grant all on table public.data_product_publications to service_role;
+revoke all on table public.lcia_result_packages from anon, authenticated;
+revoke all on table public.lcia_result_publications from anon, authenticated;
+grant all on table public.lcia_result_packages to service_role;
+grant all on table public.lcia_result_publications to service_role;
 
-create or replace function public.data_product_is_service_request()
+create or replace function public.lcia_result_is_service_request()
 returns boolean
 language sql
 stable
 security definer
 set search_path = public, pg_temp
 as $$
-  select coalesce(current_setting('request.jwt.claim.role', true), '') = 'service_role'
-     or current_user = 'service_role'
+  select current_user = 'service_role'
+      or coalesce(util.is_service_request(), false)
 $$;
 
-create or replace function public.data_product_is_manager()
+create or replace function public.lcia_result_is_manager()
 returns boolean
 language sql
 stable
@@ -329,18 +202,7 @@ as $$
   )
 $$;
 
-create or replace function public.data_product_can_write()
-returns boolean
-language sql
-stable
-security definer
-set search_path = public, pg_temp
-as $$
-  select public.data_product_is_manager()
-      or public.data_product_is_service_request()
-$$;
-
-create or replace function public.data_product_error(
+create or replace function public.lcia_result_error(
   p_code text,
   p_status integer,
   p_message text
@@ -358,7 +220,7 @@ as $$
   )
 $$;
 
-create or replace function public.data_product_current_eligible_manifest()
+create or replace function public.lcia_result_current_eligible_manifest()
 returns jsonb
 language sql
 stable
@@ -366,7 +228,7 @@ security definer
 set search_path = public, pg_temp
 as $$
   with eligible as (
-    select id, version
+    select id, version, state_code
     from public.processes
     where state_code between 100 and 199
     order by id, version
@@ -379,7 +241,18 @@ as $$
           string_agg(id::text || ':' || version, ',' order by id, version),
           ''
         ) || '|published:100-199:v1'
-      ) as input_manifest_hash
+      ) as input_manifest_hash,
+      coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'id', id,
+            'version', version,
+            'stateCode', state_code
+          )
+          order by id, version
+        ),
+        '[]'::jsonb
+      ) as processes
     from eligible
   )
   select jsonb_build_object(
@@ -389,38 +262,13 @@ as $$
       jsonb_build_object('between', jsonb_build_array(100, 199))
     ),
     'eligibleInputCount', eligible_count,
-    'inputManifestHash', input_manifest_hash
-  )
-  from aggregated
-$$;
-
-create or replace function public.data_product_selected_manifest(p_run_id uuid)
-returns jsonb
-language sql
-stable
-security definer
-set search_path = public, pg_temp
-as $$
-  with selected as (
-    select process_id, process_version
-    from public.data_product_run_inputs
-    where run_id = p_run_id
-    order by process_id, process_version
-  ),
-  aggregated as (
-    select
-      count(*)::integer as included_count,
-      md5(
-        coalesce(
-          string_agg(process_id::text || ':' || process_version, ',' order by process_id, process_version),
-          ''
-        ) || '|published:100-199:v1'
-      ) as input_manifest_hash
-    from selected
-  )
-  select jsonb_build_object(
-    'includedInputCount', included_count,
-    'inputManifestHash', input_manifest_hash
+    'includedInputCount', eligible_count,
+    'inputManifestHash', input_manifest_hash,
+    'inputManifest', jsonb_build_object(
+      'predicateVersion', 'published-state-code-100-199:v1',
+      'selectionMode', 'all_eligible',
+      'processes', processes
+    )
   )
   from aggregated
 $$;
@@ -564,7 +412,7 @@ exception
 end;
 $$;
 
-create or replace function public.data_product_prevent_ready_package_content_update()
+create or replace function public.lcia_result_prevent_ready_package_content_update()
 returns trigger
 language plpgsql
 set search_path = public, pg_temp
@@ -572,22 +420,30 @@ as $$
 begin
   if old.status = 'preview_ready'
      and (
-       old.run_id is distinct from new.run_id
+       old.build_id is distinct from new.build_id
+       or old.build_worker_job_id is distinct from new.build_worker_job_id
+       or old.package_version is distinct from new.package_version
        or old.coverage_mode is distinct from new.coverage_mode
+       or old.input_status_filter is distinct from new.input_status_filter
        or old.eligibility_definition is distinct from new.eligibility_definition
        or old.eligibility_resolved_at is distinct from new.eligibility_resolved_at
        or old.eligible_input_count is distinct from new.eligible_input_count
        or old.included_input_count is distinct from new.included_input_count
        or old.input_manifest_hash is distinct from new.input_manifest_hash
+       or old.input_manifest is distinct from new.input_manifest
        or old.snapshot_id is distinct from new.snapshot_id
-       or old.source_result_id is distinct from new.source_result_id
+       or old.result_id is distinct from new.result_id
+       or old.latest_all_unit_result_id is distinct from new.latest_all_unit_result_id
+       or old.result_artifact_ref is distinct from new.result_artifact_ref
+       or old.query_artifact_ref is distinct from new.query_artifact_ref
+       or old.artifact_manifest is distinct from new.artifact_manifest
        or old.package_result_hash is distinct from new.package_result_hash
        or old.lcia_method_set is distinct from new.lcia_method_set
-       or old.postprocess_mode is distinct from new.postprocess_mode
-       or old.postprocess_status is distinct from new.postprocess_status
+       or old.available_impact_categories is distinct from new.available_impact_categories
+       or old.postprocess_manifest is distinct from new.postprocess_manifest
        or old.default_impact_category is distinct from new.default_impact_category
      ) then
-    raise exception 'data_product_package_immutable'
+    raise exception 'lcia_result_package_immutable'
       using errcode = '23514';
   end if;
 
@@ -596,15 +452,15 @@ begin
 end;
 $$;
 
-drop trigger if exists data_product_packages_prevent_ready_update
-  on public.data_product_packages;
+drop trigger if exists lcia_result_packages_prevent_ready_update
+  on public.lcia_result_packages;
 
-create trigger data_product_packages_prevent_ready_update
-before update on public.data_product_packages
+create trigger lcia_result_packages_prevent_ready_update
+before update on public.lcia_result_packages
 for each row
-execute function public.data_product_prevent_ready_package_content_update();
+execute function public.lcia_result_prevent_ready_package_content_update();
 
-create or replace function public.cmd_data_product_run_create(
+create or replace function public.cmd_lcia_result_build_request(
   p_name text,
   p_processes jsonb default null::jsonb,
   p_coverage_mode text default 'global_eligible'::text,
@@ -621,124 +477,65 @@ as $$
 declare
   v_actor uuid := auth.uid();
   v_coverage_mode text := lower(trim(coalesce(p_coverage_mode, 'global_eligible')));
+  v_build_id uuid;
+  v_idempotency_key text;
   v_current_manifest jsonb;
-  v_existing public.data_product_runs%rowtype;
-  v_run public.data_product_runs%rowtype;
-  v_selected_count integer;
-  v_invalid_count integer;
-  v_selected_manifest jsonb;
+  v_input_manifest jsonb;
+  v_input_manifest_hash text;
+  v_eligible_input_count integer;
+  v_included_input_count integer;
+  v_invalid_count integer := 0;
+  v_duplicate_count integer := 0;
+  v_request_hash text;
+  v_worker_payload jsonb;
+  v_worker_job jsonb;
 begin
-  if not public.data_product_is_manager() then
-    return public.data_product_error('not_data_product_manager', 403, 'Data product manager role is required');
+  if v_actor is null then
+    return public.lcia_result_error('auth_required', 401, 'Authentication required');
   end if;
 
-  if v_actor is null then
-    return public.data_product_error('auth_required', 401, 'Authentication required');
+  if not public.lcia_result_is_manager() then
+    return public.lcia_result_error('not_data_product_manager', 403, 'Data product manager role is required');
   end if;
 
   if v_coverage_mode not in ('subset', 'global_eligible') then
-    return public.data_product_error('invalid_coverage_mode', 400, 'coverage_mode must be subset or global_eligible');
+    return public.lcia_result_error('invalid_coverage_mode', 400, 'coverage_mode must be subset or global_eligible');
   end if;
 
   if v_coverage_mode = 'global_eligible'
      and p_processes is not null
      and jsonb_array_length(p_processes) > 0 then
-    return public.data_product_error('invalid_coverage_mode', 400, 'global_eligible runs are resolved from the current published input predicate');
+    return public.lcia_result_error('invalid_coverage_mode', 400, 'global_eligible builds are resolved from the current published input predicate');
   end if;
 
   if jsonb_typeof(coalesce(p_lcia_method_set, '[]'::jsonb)) <> 'array' then
-    return public.data_product_error('invalid_lcia_method_set', 400, 'lcia_method_set must be a JSON array');
+    return public.lcia_result_error('invalid_lcia_method_set', 400, 'lcia_method_set must be a JSON array');
   end if;
 
   if p_processes is not null and jsonb_typeof(p_processes) <> 'array' then
-    return public.data_product_error('invalid_process_selection', 400, 'process selection must be a JSON array');
+    return public.lcia_result_error('invalid_process_selection', 400, 'process selection must be a JSON array');
   end if;
 
-  if p_idempotency_key is not null then
-    select *
-      into v_existing
-    from public.data_product_runs
-    where created_by = v_actor
-      and idempotency_key = p_idempotency_key
-    order by created_at desc
-    limit 1;
+  v_current_manifest := public.lcia_result_current_eligible_manifest();
+  v_eligible_input_count := (v_current_manifest->>'eligibleInputCount')::integer;
 
-    if v_existing.id is not null then
-      return jsonb_build_object(
-        'ok', true,
-        'data', jsonb_build_object(
-          'runId', v_existing.id,
-          'coverageMode', v_existing.coverage_mode,
-          'eligibleInputCount', v_existing.eligible_input_count,
-          'includedInputCount', v_existing.included_input_count,
-          'inputManifestHash', v_existing.input_manifest_hash
-        ),
-        'reused', true
-      );
-    end if;
-  end if;
-
-  v_current_manifest := public.data_product_current_eligible_manifest();
-
-  insert into public.data_product_runs (
-    name,
-    input_scope,
-    input_status_filter,
-    coverage_mode,
-    eligibility_definition,
-    eligibility_resolved_at,
-    eligible_input_count,
-    included_input_count,
-    input_manifest_hash,
-    lcia_method_set,
-    default_impact_category,
-    status,
-    idempotency_key,
-    created_by
-  )
-  values (
-    nullif(trim(coalesce(p_name, '')), ''),
-    jsonb_build_object('selectionMode', case when p_processes is null or jsonb_array_length(p_processes) = 0 then 'all_eligible' else 'manual' end),
-    v_current_manifest->'inputStatusFilter',
-    v_coverage_mode,
-    v_current_manifest - 'eligibleInputCount' - 'inputManifestHash',
-    now(),
-    (v_current_manifest->>'eligibleInputCount')::integer,
-    0,
-    'pending',
-    coalesce(p_lcia_method_set, '[]'::jsonb),
-    nullif(trim(coalesce(p_default_impact_category, '')), ''),
-    'created',
-    nullif(trim(coalesce(p_idempotency_key, '')), ''),
-    v_actor
-  )
-  returning *
-    into v_run;
-
-  if p_processes is null or jsonb_array_length(p_processes) = 0 then
-    insert into public.data_product_run_inputs (
-      run_id,
-      process_id,
-      process_version,
-      state_code,
-      ordinal
-    )
-    select
-      v_run.id,
-      p.id,
-      p.version,
-      p.state_code,
-      row_number() over (order by p.id, p.version)::integer
-    from public.processes as p
-    where p.state_code between 100 and 199
-    order by p.id, p.version;
+  if v_coverage_mode = 'global_eligible' then
+    v_input_manifest := v_current_manifest->'inputManifest';
+    v_input_manifest_hash := v_current_manifest->>'inputManifestHash';
+    v_included_input_count := v_eligible_input_count;
   else
     with requested as (
       select
         (item.value->>'id')::uuid as process_id,
         coalesce(item.value->>'version', item.value->>'process_version')::character(9) as process_version,
         item.ordinality::integer as ordinal
-      from jsonb_array_elements(p_processes) with ordinality as item(value, ordinality)
+      from jsonb_array_elements(coalesce(p_processes, '[]'::jsonb)) with ordinality as item(value, ordinality)
+    ),
+    duplicate_rows as (
+      select process_id, process_version, count(*)::integer as duplicate_count
+      from requested
+      group by process_id, process_version
+      having count(*) > 1
     ),
     resolved as (
       select
@@ -750,64 +547,124 @@ begin
       left join public.processes as p
         on p.id = r.process_id
        and p.version = r.process_version
-    )
-    insert into public.data_product_run_inputs (
-      run_id,
-      process_id,
-      process_version,
-      state_code,
-      ordinal
+    ),
+    aggregated as (
+      select
+        count(*) filter (where state_code between 100 and 199)::integer as included_count,
+        count(*) filter (where state_code is null or state_code not between 100 and 199)::integer as invalid_count,
+        coalesce((select sum(duplicate_count - 1)::integer from duplicate_rows), 0) as duplicate_count,
+        md5(
+          coalesce(
+            string_agg(
+              process_id::text || ':' || process_version,
+              ','
+              order by process_id, process_version
+            ) filter (where state_code between 100 and 199),
+            ''
+          ) || '|published:100-199:v1'
+        ) as manifest_hash,
+        coalesce(
+          jsonb_agg(
+            jsonb_build_object(
+              'id', process_id,
+              'version', process_version,
+              'stateCode', state_code
+            )
+            order by ordinal
+          ) filter (where state_code between 100 and 199),
+          '[]'::jsonb
+        ) as selected_processes
+      from resolved
     )
     select
-      v_run.id,
-      process_id,
-      process_version,
-      state_code,
-      ordinal
-    from resolved
-    where state_code between 100 and 199;
+      included_count,
+      invalid_count,
+      duplicate_count,
+      manifest_hash,
+      jsonb_build_object(
+        'predicateVersion', 'published-state-code-100-199:v1',
+        'selectionMode', 'manual',
+        'processes', selected_processes
+      )
+    into
+      v_included_input_count,
+      v_invalid_count,
+      v_duplicate_count,
+      v_input_manifest_hash,
+      v_input_manifest
+    from aggregated;
 
-    with requested as (
-      select
-        (item.value->>'id')::uuid as process_id,
-        coalesce(item.value->>'version', item.value->>'process_version')::character(9) as process_version
-      from jsonb_array_elements(p_processes) as item(value)
-    )
-    select count(*)::integer
-      into v_invalid_count
-    from requested as r
-    left join public.processes as p
-      on p.id = r.process_id
-     and p.version = r.process_version
-    where p.id is null
-       or p.state_code is null
-       or p.state_code not between 100 and 199;
+    if v_duplicate_count > 0 then
+      return public.lcia_result_error('invalid_process_selection', 400, 'process selection contains duplicate inputs');
+    end if;
 
     if v_invalid_count > 0 then
-      delete from public.data_product_runs where id = v_run.id;
-      return public.data_product_error('input_not_eligible', 400, 'All data product inputs must be published process rows');
+      return public.lcia_result_error('input_not_eligible', 400, 'All LCIA result package inputs must be published process rows');
     end if;
   end if;
 
-  select count(*)::integer
-    into v_selected_count
-  from public.data_product_run_inputs
-  where run_id = v_run.id;
-
-  if v_selected_count = 0 then
-    delete from public.data_product_runs where id = v_run.id;
-    return public.data_product_error('input_empty', 400, 'Data product run requires at least one eligible process');
+  if coalesce(v_included_input_count, 0) = 0 then
+    return public.lcia_result_error('input_empty', 400, 'LCIA result package build requires at least one eligible process');
   end if;
 
-  v_selected_manifest := public.data_product_selected_manifest(v_run.id);
+  v_idempotency_key := 'lcia_result.package_build:' || coalesce(
+    nullif(trim(coalesce(p_idempotency_key, '')), ''),
+    gen_random_uuid()::text
+  );
 
-  update public.data_product_runs
-    set included_input_count = v_selected_count,
-        input_manifest_hash = v_selected_manifest->>'inputManifestHash',
-        updated_at = now()
-  where id = v_run.id
-  returning *
-    into v_run;
+  if nullif(trim(coalesce(p_idempotency_key, '')), '') is not null then
+    v_build_id := (
+      substr(md5(v_actor::text || ':' || p_idempotency_key), 1, 8) || '-' ||
+      substr(md5(v_actor::text || ':' || p_idempotency_key), 9, 4) || '-' ||
+      substr(md5(v_actor::text || ':' || p_idempotency_key), 13, 4) || '-' ||
+      substr(md5(v_actor::text || ':' || p_idempotency_key), 17, 4) || '-' ||
+      substr(md5(v_actor::text || ':' || p_idempotency_key), 21, 12)
+    )::uuid;
+  else
+    v_build_id := gen_random_uuid();
+  end if;
+
+  v_request_hash := md5(
+    v_input_manifest_hash || '|' ||
+    coalesce(p_default_impact_category, '') || '|' ||
+    coalesce(p_lcia_method_set::text, '[]')
+  );
+
+  v_worker_payload := jsonb_build_object(
+    'type', 'lcia_result_package_build',
+    'build_id', v_build_id,
+    'requested_by', v_actor,
+    'name', nullif(trim(coalesce(p_name, '')), ''),
+    'coverage_mode', v_coverage_mode,
+    'input_status_filter', v_current_manifest->'inputStatusFilter',
+    'eligibility_definition', v_current_manifest - 'eligibleInputCount' - 'includedInputCount' - 'inputManifestHash' - 'inputManifest',
+    'eligibility_resolved_at', now(),
+    'eligible_input_count', v_eligible_input_count,
+    'included_input_count', v_included_input_count,
+    'input_manifest_hash', v_input_manifest_hash,
+    'input_manifest', v_input_manifest,
+    'lcia_method_set', coalesce(p_lcia_method_set, '[]'::jsonb),
+    'default_impact_category', nullif(trim(coalesce(p_default_impact_category, '')), ''),
+    'postprocess_manifest', jsonb_build_object(
+      'postprocess_mode', 'skipped',
+      'postprocess_reason', 'MVP does not aggregate process results'
+    )
+  );
+
+  v_worker_job := jsonb_build_object(
+    'jobKind', 'lcia_result.package_build',
+    'payload', v_worker_payload,
+    'payloadSchemaVersion', 'lcia_result.package_build.request.v1',
+    'subjectType', 'lcia_result_build',
+    'subjectId', v_build_id,
+    'subjectVersion', null,
+    'requestedBy', v_actor,
+    'requesterType', 'operator',
+    'idempotencyKey', v_idempotency_key,
+    'requestHash', v_request_hash,
+    'queueKey', v_build_id,
+    'visibility', 'operator'
+  );
 
   insert into public.command_audit_log (
     command,
@@ -818,48 +675,49 @@ begin
     payload
   )
   values (
-    'cmd_data_product_run_create',
+    'cmd_lcia_result_build_request',
     v_actor,
-    'data_product_runs',
-    v_run.id,
+    'worker_jobs',
+    v_build_id,
     null,
     coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
-      'coverageMode', v_run.coverage_mode,
-      'eligibleInputCount', v_run.eligible_input_count,
-      'includedInputCount', v_run.included_input_count
+      'coverageMode', v_coverage_mode,
+      'eligibleInputCount', v_eligible_input_count,
+      'includedInputCount', v_included_input_count,
+      'inputManifestHash', v_input_manifest_hash
     )
   );
 
   return jsonb_build_object(
     'ok', true,
     'data', jsonb_build_object(
-      'runId', v_run.id,
-      'coverageMode', v_run.coverage_mode,
-      'eligibleInputCount', v_run.eligible_input_count,
-      'includedInputCount', v_run.included_input_count,
-      'inputManifestHash', v_run.input_manifest_hash
+      'buildId', v_build_id,
+      'coverageMode', v_coverage_mode,
+      'eligibleInputCount', v_eligible_input_count,
+      'includedInputCount', v_included_input_count,
+      'inputManifestHash', v_input_manifest_hash,
+      'workerJob', v_worker_job
     ),
     'reused', false
   );
 exception
-  when unique_violation then
-    return public.data_product_error('invalid_process_selection', 400, 'process selection contains duplicate inputs');
-  when not_null_violation then
-    return public.data_product_error('invalid_run_request', 400, 'Data product run request is invalid');
   when invalid_text_representation then
-    return public.data_product_error('invalid_process_selection', 400, 'process ids and versions must be valid');
+    return public.lcia_result_error('invalid_process_selection', 400, 'process ids and versions must be valid');
 end;
 $$;
 
-create or replace function public.cmd_data_product_package_mark_ready(
-  p_run_id uuid,
+create or replace function public.cmd_lcia_result_package_mark_ready(
+  p_build_worker_job_id uuid,
   p_package_version text,
   p_snapshot_id uuid,
-  p_source_result_id uuid,
-  p_package_result_hash text,
-  p_default_impact_category text,
-  p_result_rows jsonb default '[]'::jsonb,
-  p_artifacts jsonb default '[]'::jsonb,
+  p_result_id uuid,
+  p_latest_all_unit_result_id uuid default null::uuid,
+  p_result_artifact_ref jsonb default '{}'::jsonb,
+  p_query_artifact_ref jsonb default '{}'::jsonb,
+  p_artifact_manifest jsonb default '{}'::jsonb,
+  p_available_impact_categories jsonb default '[]'::jsonb,
+  p_default_impact_category text default null::text,
+  p_package_result_hash text default null::text,
   p_audit jsonb default '{}'::jsonb
 )
 returns jsonb
@@ -868,170 +726,155 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_actor uuid := auth.uid();
-  v_run public.data_product_runs%rowtype;
-  v_package public.data_product_packages%rowtype;
+  v_job public.worker_jobs%rowtype;
+  v_result public.lca_results%rowtype;
+  v_latest public.lca_latest_all_unit_results%rowtype;
+  v_package public.lcia_result_packages%rowtype;
+  v_result_artifact_ref jsonb;
+  v_query_artifact_ref jsonb;
+  v_default_impact text;
 begin
-  if not public.data_product_can_write() then
-    return public.data_product_error('not_data_product_manager', 403, 'Data product manager or service role is required');
+  if not public.lcia_result_is_service_request() then
+    return public.lcia_result_error('service_role_required', 403, 'Service role is required to mark LCIA result packages ready');
   end if;
 
-  if jsonb_typeof(coalesce(p_result_rows, '[]'::jsonb)) <> 'array' then
-    return public.data_product_error('invalid_result_rows', 400, 'result rows must be a JSON array');
+  if jsonb_typeof(coalesce(p_result_artifact_ref, '{}'::jsonb)) <> 'object'
+     or jsonb_typeof(coalesce(p_query_artifact_ref, '{}'::jsonb)) <> 'object'
+     or jsonb_typeof(coalesce(p_artifact_manifest, '{}'::jsonb)) <> 'object' then
+    return public.lcia_result_error('invalid_artifact_payload', 400, 'artifact payloads must be JSON objects');
   end if;
 
-  if jsonb_typeof(coalesce(p_artifacts, '[]'::jsonb)) <> 'array' then
-    return public.data_product_error('invalid_artifacts', 400, 'artifacts must be a JSON array');
+  if jsonb_typeof(coalesce(p_available_impact_categories, '[]'::jsonb)) <> 'array' then
+    return public.lcia_result_error('invalid_available_impact_categories', 400, 'available impact categories must be a JSON array');
   end if;
 
   select *
-    into v_run
-  from public.data_product_runs
-  where id = p_run_id
+    into v_job
+  from public.worker_jobs
+  where id = p_build_worker_job_id
   for update;
 
-  if v_run.id is null then
-    return public.data_product_error('run_not_found', 404, 'Data product run not found');
+  if v_job.id is null or v_job.job_kind <> 'lcia_result.package_build' then
+    return public.lcia_result_error('build_worker_job_not_found', 404, 'LCIA result package build worker job not found');
   end if;
 
-  insert into public.data_product_packages (
-    run_id,
+  select *
+    into v_result
+  from public.lca_results
+  where id = p_result_id;
+
+  if v_result.id is null then
+    return public.lcia_result_error('result_not_found', 404, 'LCIA result artifact row not found');
+  end if;
+
+  if p_latest_all_unit_result_id is not null then
+    select *
+      into v_latest
+    from public.lca_latest_all_unit_results
+    where id = p_latest_all_unit_result_id;
+
+    if v_latest.id is null then
+      return public.lcia_result_error('latest_all_unit_result_not_found', 404, 'Latest all-unit LCIA result row not found');
+    end if;
+  end if;
+
+  v_result_artifact_ref := case
+    when coalesce(p_result_artifact_ref, '{}'::jsonb) <> '{}'::jsonb then p_result_artifact_ref
+    else jsonb_strip_nulls(
+      jsonb_build_object(
+        'artifactUrl', v_result.artifact_url,
+        'artifactSha256', v_result.artifact_sha256,
+        'artifactByteSize', v_result.artifact_byte_size,
+        'artifactFormat', v_result.artifact_format
+      )
+    )
+  end;
+
+  v_query_artifact_ref := case
+    when coalesce(p_query_artifact_ref, '{}'::jsonb) <> '{}'::jsonb then p_query_artifact_ref
+    when v_latest.id is not null then jsonb_strip_nulls(
+      jsonb_build_object(
+        'artifactUrl', v_latest.query_artifact_url,
+        'artifactSha256', v_latest.query_artifact_sha256,
+        'artifactByteSize', v_latest.query_artifact_byte_size,
+        'artifactFormat', v_latest.query_artifact_format
+      )
+    )
+    else '{}'::jsonb
+  end;
+
+  if v_result_artifact_ref = '{}'::jsonb then
+    return public.lcia_result_error('result_artifact_missing', 400, 'LCIA result package requires a persisted result artifact reference');
+  end if;
+
+  v_default_impact := coalesce(
+    nullif(trim(coalesce(p_default_impact_category, '')), ''),
+    nullif(trim(coalesce(v_job.payload_json->>'default_impact_category', '')), '')
+  );
+
+  insert into public.lcia_result_packages (
+    build_id,
+    build_worker_job_id,
     package_version,
     coverage_mode,
+    input_status_filter,
     eligibility_definition,
     eligibility_resolved_at,
     eligible_input_count,
     included_input_count,
     input_manifest_hash,
+    input_manifest,
     snapshot_id,
-    source_result_id,
+    result_id,
+    latest_all_unit_result_id,
+    result_artifact_ref,
+    query_artifact_ref,
+    artifact_manifest,
     package_result_hash,
     lcia_method_set,
-    postprocess_mode,
-    postprocess_status,
+    available_impact_categories,
+    postprocess_manifest,
     default_impact_category,
     status,
     created_by
   )
   values (
-    v_run.id,
+    (v_job.payload_json->>'build_id')::uuid,
+    v_job.id,
     nullif(trim(coalesce(p_package_version, '')), ''),
-    v_run.coverage_mode,
-    v_run.eligibility_definition,
-    v_run.eligibility_resolved_at,
-    v_run.eligible_input_count,
-    v_run.included_input_count,
-    v_run.input_manifest_hash,
+    v_job.payload_json->>'coverage_mode',
+    coalesce(v_job.payload_json->'input_status_filter', '{"state_code":{"between":[100,199]}}'::jsonb),
+    coalesce(v_job.payload_json->'eligibility_definition', '{}'::jsonb),
+    coalesce((v_job.payload_json->>'eligibility_resolved_at')::timestamptz, now()),
+    coalesce((v_job.payload_json->>'eligible_input_count')::integer, 0),
+    coalesce((v_job.payload_json->>'included_input_count')::integer, 0),
+    nullif(v_job.payload_json->>'input_manifest_hash', ''),
+    coalesce(v_job.payload_json->'input_manifest', '{}'::jsonb),
     p_snapshot_id,
-    p_source_result_id,
+    v_result.id,
+    v_latest.id,
+    v_result_artifact_ref,
+    v_query_artifact_ref,
+    coalesce(p_artifact_manifest, '{}'::jsonb),
     nullif(trim(coalesce(p_package_result_hash, '')), ''),
-    v_run.lcia_method_set,
-    v_run.postprocess_mode,
-    v_run.postprocess_status,
-    nullif(trim(coalesce(p_default_impact_category, v_run.default_impact_category, '')), ''),
+    coalesce(v_job.payload_json->'lcia_method_set', '[]'::jsonb),
+    coalesce(p_available_impact_categories, '[]'::jsonb),
+    coalesce(v_job.payload_json->'postprocess_manifest', '{"postprocess_mode":"skipped"}'::jsonb),
+    v_default_impact,
     'preview_ready',
-    coalesce(v_actor, v_run.created_by)
+    v_job.requested_by
   )
   returning *
     into v_package;
 
-  insert into public.data_product_package_items (
-    package_id,
-    process_id,
-    process_version,
-    state_code,
-    ordinal
-  )
-  select
-    v_package.id,
-    process_id,
-    process_version,
-    state_code,
-    ordinal
-  from public.data_product_run_inputs
-  where run_id = v_run.id
-  order by ordinal;
-
-  insert into public.data_product_lcia_results (
-    package_id,
-    process_id,
-    process_version,
-    impact_category_id,
-    impact_category_version,
-    impact_label_snapshot,
-    value,
-    unit,
-    source_result_id,
-    source_artifact_sha256
-  )
-  select
-    v_package.id,
-    (row.value->>'process_id')::uuid,
-    coalesce(row.value->>'process_version', row.value->>'version')::character(9),
-    row.value->>'impact_category_id',
-    nullif(row.value->>'impact_category_version', ''),
-    nullif(row.value->>'impact_label_snapshot', ''),
-    (row.value->>'value')::numeric,
-    nullif(row.value->>'unit', ''),
-    nullif(row.value->>'source_result_id', '')::uuid,
-    nullif(row.value->>'source_artifact_sha256', '')
-  from jsonb_array_elements(coalesce(p_result_rows, '[]'::jsonb)) as row(value);
-
-  insert into public.data_product_artifacts (
-    run_id,
-    package_id,
-    artifact_type,
-    storage_ref,
-    sha256,
-    byte_size,
-    format,
-    persistence_mode,
-    is_persisted,
-    source_result_id,
-    snapshot_id,
-    worker_job_id
-  )
-  select
-    v_run.id,
-    v_package.id,
-    artifact.value->>'artifact_type',
-    artifact.value->>'storage_ref',
-    nullif(artifact.value->>'sha256', ''),
-    nullif(artifact.value->>'byte_size', '')::bigint,
-    nullif(artifact.value->>'format', ''),
-    coalesce(nullif(artifact.value->>'persistence_mode', ''), 'copied'),
-    coalesce((artifact.value->>'is_persisted')::boolean, false),
-    nullif(artifact.value->>'source_result_id', '')::uuid,
-    nullif(artifact.value->>'snapshot_id', '')::uuid,
-    nullif(artifact.value->>'worker_job_id', '')::uuid
-  from jsonb_array_elements(coalesce(p_artifacts, '[]'::jsonb)) as artifact(value);
-
-  update public.data_product_runs
-    set status = 'computed',
-        updated_at = now()
-  where id = v_run.id;
-
-  if v_actor is not null then
-    insert into public.command_audit_log (
-      command,
-      actor_user_id,
-      target_table,
-      target_id,
-      target_version,
-      payload
-    )
-    values (
-      'cmd_data_product_package_mark_ready',
-      v_actor,
-      'data_product_packages',
-      v_package.id,
-      v_package.package_version,
-      coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
-        'runId', v_run.id,
-        'resultRowCount', jsonb_array_length(coalesce(p_result_rows, '[]'::jsonb)),
-        'artifactCount', jsonb_array_length(coalesce(p_artifacts, '[]'::jsonb))
-      )
-    );
+  if v_job.status in ('queued', 'running', 'waiting', 'stale') then
+    update public.worker_jobs
+      set result_ref = coalesce(result_ref, '{}'::jsonb) || jsonb_build_object(
+            'packageId', v_package.id,
+            'packageVersion', v_package.package_version
+          ),
+          updated_at = now()
+    where id = v_job.id;
   end if;
 
   return jsonb_build_object(
@@ -1040,24 +883,25 @@ begin
       'packageId', v_package.id,
       'packageVersion', v_package.package_version,
       'status', v_package.status,
+      'buildWorkerJobId', v_package.build_worker_job_id,
       'includedInputCount', v_package.included_input_count
     )
   );
 exception
   when unique_violation then
-    return public.data_product_error('package_conflict', 409, 'Data product package already exists or contains duplicate result rows');
+    return public.lcia_result_error('package_conflict', 409, 'LCIA result package already exists for this build or package version');
   when foreign_key_violation then
-    return public.data_product_error('package_reference_invalid', 400, 'Data product package references invalid run, process, snapshot, result, or job rows');
+    return public.lcia_result_error('package_reference_invalid', 400, 'LCIA result package references invalid worker, snapshot, or result rows');
   when invalid_text_representation then
-    return public.data_product_error('invalid_package_payload', 400, 'Data product package payload contains invalid ids or numeric values');
+    return public.lcia_result_error('invalid_package_payload', 400, 'LCIA result package payload contains invalid ids or numeric values');
   when not_null_violation then
-    return public.data_product_error('invalid_package_payload', 400, 'Data product package payload is missing required fields');
+    return public.lcia_result_error('invalid_package_payload', 400, 'LCIA result package payload is missing required fields');
   when check_violation then
-    return public.data_product_error('invalid_package_payload', 400, 'Data product package payload violates schema constraints');
+    return public.lcia_result_error('invalid_package_payload', 400, 'LCIA result package payload violates schema constraints');
 end;
 $$;
 
-create or replace function public.cmd_data_product_package_publish(
+create or replace function public.cmd_lcia_result_package_publish(
   p_package_id uuid,
   p_display_default_impact_category text default null::text,
   p_reason text default null::text,
@@ -1070,48 +914,40 @@ set search_path = public, pg_temp
 as $$
 declare
   v_actor uuid := auth.uid();
-  v_package public.data_product_packages%rowtype;
+  v_package public.lcia_result_packages%rowtype;
   v_current_manifest jsonb;
   v_default_impact text;
   v_previous_id uuid;
-  v_publication public.data_product_publications%rowtype;
+  v_publication public.lcia_result_publications%rowtype;
 begin
-  if not public.data_product_is_manager() then
-    return public.data_product_error('not_data_product_manager', 403, 'Data product manager role is required');
+  if v_actor is null then
+    return public.lcia_result_error('auth_required', 401, 'Authentication required');
   end if;
 
-  if v_actor is null then
-    return public.data_product_error('auth_required', 401, 'Authentication required');
+  if not public.lcia_result_is_manager() then
+    return public.lcia_result_error('not_data_product_manager', 403, 'Data product manager role is required');
   end if;
 
   select *
     into v_package
-  from public.data_product_packages
+  from public.lcia_result_packages
   where id = p_package_id
   for update;
 
   if v_package.id is null or v_package.status <> 'preview_ready' then
-    return public.data_product_error('package_not_ready', 400, 'Package must be preview_ready before publish');
+    return public.lcia_result_error('package_not_ready', 400, 'Package must be preview_ready before publish');
   end if;
 
   if v_package.coverage_mode <> 'global_eligible'
      or v_package.included_input_count <> v_package.eligible_input_count then
-    return public.data_product_error('package_not_global_eligible', 400, 'Only full global eligible packages can publish as global latest');
+    return public.lcia_result_error('package_not_global_eligible', 400, 'Only full global eligible packages can publish as global latest');
   end if;
 
-  v_current_manifest := public.data_product_current_eligible_manifest();
+  v_current_manifest := public.lcia_result_current_eligible_manifest();
 
   if v_package.eligible_input_count <> (v_current_manifest->>'eligibleInputCount')::integer
      or v_package.input_manifest_hash <> v_current_manifest->>'inputManifestHash' then
-    return public.data_product_error('package_stale_eligibility', 409, 'Eligible process set changed after package creation');
-  end if;
-
-  if not exists (
-    select 1
-    from public.data_product_lcia_results
-    where package_id = v_package.id
-  ) then
-    return public.data_product_error('package_not_ready', 400, 'Package has no materialized LCIA result rows');
+    return public.lcia_result_error('package_stale_eligibility', 409, 'Eligible process set changed after package creation');
   end if;
 
   v_default_impact := coalesce(
@@ -1119,34 +955,26 @@ begin
     v_package.default_impact_category
   );
 
-  if v_default_impact is null
-     or not exists (
+  if v_default_impact is null then
+    return public.lcia_result_error('default_impact_missing', 400, 'Default impact category is required before publication');
+  end if;
+
+  if jsonb_array_length(v_package.available_impact_categories) > 0
+     and not exists (
        select 1
-       from public.data_product_lcia_results
-       where package_id = v_package.id
-         and impact_category_id = v_default_impact
+       from jsonb_array_elements_text(v_package.available_impact_categories) as impact(value)
+       where impact.value = v_default_impact
      ) then
-    return public.data_product_error('default_impact_missing', 400, 'Default impact category is not present in package rows');
+    return public.lcia_result_error('default_impact_missing', 400, 'Default impact category is not present in the package impact category list');
   end if;
 
-  if not exists (
-    select 1
-    from public.data_product_artifacts
-    where package_id = v_package.id
-      and is_persisted = true
-  )
-  or exists (
-    select 1
-    from public.data_product_artifacts
-    where package_id = v_package.id
-      and is_persisted = false
-  ) then
-    return public.data_product_error('artifact_not_persisted', 400, 'Package artifacts must be pinned or copied before publish');
+  if v_package.result_artifact_ref = '{}'::jsonb then
+    return public.lcia_result_error('result_artifact_missing', 400, 'Package result artifact is required before publication');
   end if;
 
-  lock table public.data_product_publications in exclusive mode;
+  lock table public.lcia_result_publications in exclusive mode;
 
-  update public.data_product_publications
+  update public.lcia_result_publications
     set is_current = false,
         status = 'superseded',
         updated_at = now()
@@ -1157,7 +985,7 @@ begin
   returning id
     into v_previous_id;
 
-  insert into public.data_product_publications (
+  insert into public.lcia_result_publications (
     package_id,
     publication_series_key,
     publication_channel,
@@ -1186,19 +1014,7 @@ begin
 
   update public.lca_results
     set is_pinned = true
-  where id = v_package.source_result_id
-     or id in (
-       select source_result_id
-       from public.data_product_lcia_results
-       where package_id = v_package.id
-         and source_result_id is not null
-     )
-     or id in (
-       select source_result_id
-       from public.data_product_artifacts
-       where package_id = v_package.id
-         and source_result_id is not null
-     );
+  where id = v_package.result_id;
 
   insert into public.command_audit_log (
     command,
@@ -1209,9 +1025,9 @@ begin
     payload
   )
   values (
-    'cmd_data_product_package_publish',
+    'cmd_lcia_result_package_publish',
     v_actor,
-    'data_product_publications',
+    'lcia_result_publications',
     v_publication.id,
     v_package.package_version,
     coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
@@ -1232,11 +1048,11 @@ begin
   );
 exception
   when unique_violation then
-    return public.data_product_error('latest_conflict', 409, 'Another current publication already exists');
+    return public.lcia_result_error('latest_conflict', 409, 'Another current publication already exists');
 end;
 $$;
 
-create or replace function public.cmd_data_product_package_unpublish(
+create or replace function public.cmd_lcia_result_publication_unpublish(
   p_publication_id uuid,
   p_reason text default null::text,
   p_audit jsonb default '{}'::jsonb
@@ -1248,17 +1064,17 @@ set search_path = public, pg_temp
 as $$
 declare
   v_actor uuid := auth.uid();
-  v_publication public.data_product_publications%rowtype;
+  v_publication public.lcia_result_publications%rowtype;
 begin
-  if not public.data_product_is_manager() then
-    return public.data_product_error('not_data_product_manager', 403, 'Data product manager role is required');
-  end if;
-
   if v_actor is null then
-    return public.data_product_error('auth_required', 401, 'Authentication required');
+    return public.lcia_result_error('auth_required', 401, 'Authentication required');
   end if;
 
-  update public.data_product_publications
+  if not public.lcia_result_is_manager() then
+    return public.lcia_result_error('not_data_product_manager', 403, 'Data product manager role is required');
+  end if;
+
+  update public.lcia_result_publications
     set is_current = false,
         status = 'unpublished',
         unpublished_by = v_actor,
@@ -1270,7 +1086,7 @@ begin
     into v_publication;
 
   if v_publication.id is null then
-    return public.data_product_error('publication_not_found', 404, 'Publication not found');
+    return public.lcia_result_error('publication_not_found', 404, 'Publication not found');
   end if;
 
   insert into public.command_audit_log (
@@ -1282,9 +1098,9 @@ begin
     payload
   )
   values (
-    'cmd_data_product_package_unpublish',
+    'cmd_lcia_result_publication_unpublish',
     v_actor,
-    'data_product_publications',
+    'lcia_result_publications',
     v_publication.id,
     null,
     coalesce(p_audit, '{}'::jsonb) || jsonb_build_object('reason', p_reason)
@@ -1301,7 +1117,7 @@ begin
 end;
 $$;
 
-create or replace function public.get_data_product_package_preview(
+create or replace function public.get_lcia_result_package_preview(
   p_package_id uuid
 )
 returns jsonb
@@ -1310,40 +1126,20 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_package public.data_product_packages%rowtype;
-  v_rows jsonb;
+  v_package public.lcia_result_packages%rowtype;
 begin
-  if not public.data_product_is_manager() then
-    return public.data_product_error('not_data_product_manager', 403, 'Data product manager role is required');
+  if not public.lcia_result_is_manager() then
+    return public.lcia_result_error('not_data_product_manager', 403, 'Data product manager role is required');
   end if;
 
   select *
     into v_package
-  from public.data_product_packages
+  from public.lcia_result_packages
   where id = p_package_id;
 
   if v_package.id is null then
-    return public.data_product_error('package_not_found', 404, 'Package not found');
+    return public.lcia_result_error('package_not_found', 404, 'Package not found');
   end if;
-
-  select coalesce(
-    jsonb_agg(
-      jsonb_build_object(
-        'processId', process_id,
-        'processVersion', process_version,
-        'impactCategoryId', impact_category_id,
-        'impactCategoryVersion', impact_category_version,
-        'impactLabel', impact_label_snapshot,
-        'value', value,
-        'unit', unit
-      )
-      order by process_id, process_version, impact_category_id
-    ),
-    '[]'::jsonb
-  )
-    into v_rows
-  from public.data_product_lcia_results
-  where package_id = v_package.id;
 
   return jsonb_build_object(
     'ok', true,
@@ -1355,16 +1151,20 @@ begin
         'coverageMode', v_package.coverage_mode,
         'eligibleInputCount', v_package.eligible_input_count,
         'includedInputCount', v_package.included_input_count,
-        'defaultImpactCategory', v_package.default_impact_category
+        'inputManifestHash', v_package.input_manifest_hash,
+        'defaultImpactCategory', v_package.default_impact_category,
+        'availableImpactCategories', v_package.available_impact_categories
       ),
-      'rows', v_rows,
-      'rowCount', jsonb_array_length(v_rows)
+      'resultArtifact', v_package.result_artifact_ref,
+      'queryArtifact', v_package.query_artifact_ref,
+      'artifactManifest', v_package.artifact_manifest,
+      'inputManifest', v_package.input_manifest
     )
   );
 end;
 $$;
 
-create or replace function public.get_published_process_lcia_results(
+create or replace function public.get_published_lcia_result_package(
   p_process_id uuid,
   p_process_version text,
   p_impact_category_id text default null::text
@@ -1375,13 +1175,13 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_publication public.data_product_publications%rowtype;
-  v_package public.data_product_packages%rowtype;
-  v_rows jsonb;
+  v_publication public.lcia_result_publications%rowtype;
+  v_package public.lcia_result_packages%rowtype;
+  v_process_in_package boolean := false;
 begin
   select *
     into v_publication
-  from public.data_product_publications
+  from public.lcia_result_publications
   where publication_series_key = 'global'
     and publication_channel = 'public'
     and visibility_scope = 'public'
@@ -1396,7 +1196,8 @@ begin
       'data', jsonb_build_object(
         'publication', null,
         'package', null,
-        'rows', '[]'::jsonb,
+        'resultArtifact', null,
+        'queryArtifact', null,
         'rowCount', 0
       )
     );
@@ -1404,7 +1205,7 @@ begin
 
   select *
     into v_package
-  from public.data_product_packages
+  from public.lcia_result_packages
   where id = v_publication.package_id
     and status = 'preview_ready';
 
@@ -1414,36 +1215,40 @@ begin
       'data', jsonb_build_object(
         'publication', null,
         'package', null,
-        'rows', '[]'::jsonb,
+        'resultArtifact', null,
+        'queryArtifact', null,
         'rowCount', 0
       )
     );
   end if;
 
-  select coalesce(
-    jsonb_agg(
-      jsonb_build_object(
-        'processId', process_id,
-        'processVersion', process_version,
-        'impactCategoryId', impact_category_id,
-        'impactCategoryVersion', impact_category_version,
-        'impactLabel', impact_label_snapshot,
-        'value', value,
-        'unit', unit
-      )
-      order by impact_category_id
-    ),
-    '[]'::jsonb
+  select exists (
+    select 1
+    from jsonb_array_elements(coalesce(v_package.input_manifest->'processes', '[]'::jsonb)) as process(value)
+    where process.value->>'id' = p_process_id::text
+      and process.value->>'version' = p_process_version
   )
-    into v_rows
-  from public.data_product_lcia_results
-  where package_id = v_package.id
-    and process_id = p_process_id
-    and process_version = p_process_version::character(9)
-    and (
-      p_impact_category_id is null
-      or impact_category_id = p_impact_category_id
+    into v_process_in_package;
+
+  if not v_process_in_package then
+    return jsonb_build_object(
+      'ok', true,
+      'data', jsonb_build_object(
+        'publication', jsonb_build_object(
+          'publicationId', v_publication.id,
+          'publicationSeriesKey', v_publication.publication_series_key,
+          'publicationChannel', v_publication.publication_channel,
+          'visibilityScope', v_publication.visibility_scope,
+          'displayDefaultImpactCategory', v_publication.display_default_impact_category,
+          'publishedAt', v_publication.published_at
+        ),
+        'package', null,
+        'resultArtifact', null,
+        'queryArtifact', null,
+        'rowCount', 0
+      )
     );
+  end if;
 
   return jsonb_build_object(
     'ok', true,
@@ -1459,37 +1264,42 @@ begin
       'package', jsonb_build_object(
         'packageId', v_package.id,
         'packageVersion', v_package.package_version,
-        'defaultImpactCategory', v_package.default_impact_category
+        'defaultImpactCategory', v_package.default_impact_category,
+        'availableImpactCategories', v_package.available_impact_categories
       ),
-      'rows', v_rows,
-      'rowCount', jsonb_array_length(v_rows)
+      'process', jsonb_build_object(
+        'processId', p_process_id,
+        'processVersion', p_process_version,
+        'impactCategoryId', p_impact_category_id
+      ),
+      'resultArtifact', v_package.result_artifact_ref,
+      'queryArtifact', v_package.query_artifact_ref,
+      'artifactManifest', v_package.artifact_manifest,
+      'rowCount', 1
     )
   );
 end;
 $$;
 
-revoke all on function public.data_product_is_service_request() from public;
-revoke all on function public.data_product_is_manager() from public;
-revoke all on function public.data_product_can_write() from public;
-revoke all on function public.data_product_error(text, integer, text) from public;
-revoke all on function public.data_product_current_eligible_manifest() from public;
-revoke all on function public.data_product_selected_manifest(uuid) from public;
-revoke all on function public.data_product_prevent_ready_package_content_update() from public;
+revoke all on function public.lcia_result_is_service_request() from public;
+revoke all on function public.lcia_result_is_manager() from public;
+revoke all on function public.lcia_result_error(text, integer, text) from public;
+revoke all on function public.lcia_result_current_eligible_manifest() from public;
+revoke all on function public.lcia_result_prevent_ready_package_content_update() from public;
 
-revoke all on function public.cmd_data_product_run_create(text, jsonb, text, text, jsonb, text, jsonb) from public;
-revoke all on function public.cmd_data_product_package_mark_ready(uuid, text, uuid, uuid, text, text, jsonb, jsonb, jsonb) from public;
-revoke all on function public.cmd_data_product_package_publish(uuid, text, text, jsonb) from public;
-revoke all on function public.cmd_data_product_package_unpublish(uuid, text, jsonb) from public;
-revoke all on function public.get_data_product_package_preview(uuid) from public;
-revoke all on function public.get_published_process_lcia_results(uuid, text, text) from public;
+revoke all on function public.cmd_lcia_result_build_request(text, jsonb, text, text, jsonb, text, jsonb) from public;
+revoke all on function public.cmd_lcia_result_package_mark_ready(uuid, text, uuid, uuid, uuid, jsonb, jsonb, jsonb, jsonb, text, text, jsonb) from public;
+revoke all on function public.cmd_lcia_result_package_publish(uuid, text, text, jsonb) from public;
+revoke all on function public.cmd_lcia_result_publication_unpublish(uuid, text, jsonb) from public;
+revoke all on function public.get_lcia_result_package_preview(uuid) from public;
+revoke all on function public.get_published_lcia_result_package(uuid, text, text) from public;
 
-grant execute on function public.cmd_data_product_run_create(text, jsonb, text, text, jsonb, text, jsonb) to authenticated;
-grant execute on function public.cmd_data_product_package_mark_ready(uuid, text, uuid, uuid, text, text, jsonb, jsonb, jsonb) to authenticated, service_role;
-grant execute on function public.cmd_data_product_package_publish(uuid, text, text, jsonb) to authenticated;
-grant execute on function public.cmd_data_product_package_unpublish(uuid, text, jsonb) to authenticated;
-grant execute on function public.get_data_product_package_preview(uuid) to authenticated;
-grant execute on function public.get_published_process_lcia_results(uuid, text, text) to anon, authenticated, service_role;
+grant execute on function public.cmd_lcia_result_build_request(text, jsonb, text, text, jsonb, text, jsonb) to authenticated;
+grant execute on function public.cmd_lcia_result_package_mark_ready(uuid, text, uuid, uuid, uuid, jsonb, jsonb, jsonb, jsonb, text, text, jsonb) to service_role;
+grant execute on function public.cmd_lcia_result_package_publish(uuid, text, text, jsonb) to authenticated;
+grant execute on function public.cmd_lcia_result_publication_unpublish(uuid, text, jsonb) to authenticated;
+grant execute on function public.get_lcia_result_package_preview(uuid) to authenticated;
+grant execute on function public.get_published_lcia_result_package(uuid, text, text) to anon, authenticated, service_role;
 
-grant execute on function public.data_product_is_service_request() to service_role;
-grant execute on function public.data_product_is_manager() to authenticated, service_role;
-grant execute on function public.data_product_can_write() to authenticated, service_role;
+grant execute on function public.lcia_result_is_service_request() to service_role;
+grant execute on function public.lcia_result_is_manager() to authenticated, service_role;

--- a/supabase/migrations/20260623133000_lcia_result_latest_manifest.sql
+++ b/supabase/migrations/20260623133000_lcia_result_latest_manifest.sql
@@ -1,0 +1,56 @@
+create or replace function public.lcia_result_current_eligible_manifest()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  with eligible as (
+    select distinct on (id)
+      id,
+      version,
+      state_code
+    from public.processes
+    where state_code between 100 and 199
+      and json ? 'processDataSet'
+    order by id, version desc, modified_at desc
+  ),
+  aggregated as (
+    select
+      count(*)::integer as eligible_count,
+      md5(
+        coalesce(
+          string_agg(id::text || ':' || version, ',' order by id, version),
+          ''
+        ) || '|published:100-199:latest-per-id:v1'
+      ) as input_manifest_hash,
+      coalesce(
+        jsonb_agg(
+          jsonb_build_object(
+            'id', id,
+            'version', version,
+            'stateCode', state_code
+          )
+          order by id, version
+        ),
+        '[]'::jsonb
+      ) as processes
+    from eligible
+  )
+  select jsonb_build_object(
+    'predicateVersion', 'published-state-code-100-199:latest-per-id:v1',
+    'inputStatusFilter', jsonb_build_object(
+      'state_code',
+      jsonb_build_object('between', jsonb_build_array(100, 199))
+    ),
+    'eligibleInputCount', eligible_count,
+    'includedInputCount', eligible_count,
+    'inputManifestHash', input_manifest_hash,
+    'inputManifest', jsonb_build_object(
+      'predicateVersion', 'published-state-code-100-199:latest-per-id:v1',
+      'selectionMode', 'all_eligible',
+      'processes', processes
+    )
+  )
+  from aggregated
+$$;

--- a/supabase/tests/20260623_data_product_publication_mvp.sql
+++ b/supabase/tests/20260623_data_product_publication_mvp.sql
@@ -1,0 +1,531 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
+select plan(34);
+
+select has_table('public', 'data_product_runs', 'data product runs table exists');
+select has_table('public', 'data_product_run_inputs', 'data product run inputs table exists');
+select has_table('public', 'data_product_packages', 'data product packages table exists');
+select has_table('public', 'data_product_package_items', 'data product package items table exists');
+select has_table('public', 'data_product_lcia_results', 'data product LCIA result rows table exists');
+select has_table('public', 'data_product_artifacts', 'data product artifacts table exists');
+select has_table('public', 'data_product_publications', 'data product publications table exists');
+
+select has_function(
+  'public',
+  'cmd_data_product_run_create',
+  array['text', 'jsonb', 'text', 'text', 'jsonb', 'text', 'jsonb'],
+  'cmd_data_product_run_create exists'
+);
+
+select has_function(
+  'public',
+  'cmd_data_product_package_mark_ready',
+  array['uuid', 'text', 'uuid', 'uuid', 'text', 'text', 'jsonb', 'jsonb', 'jsonb'],
+  'cmd_data_product_package_mark_ready exists'
+);
+
+select has_function(
+  'public',
+  'cmd_data_product_package_publish',
+  array['uuid', 'text', 'text', 'jsonb'],
+  'cmd_data_product_package_publish exists'
+);
+
+select has_function(
+  'public',
+  'get_data_product_package_preview',
+  array['uuid'],
+  'get_data_product_package_preview exists'
+);
+
+select has_function(
+  'public',
+  'get_published_process_lcia_results',
+  array['uuid', 'text', 'text'],
+  'get_published_process_lcia_results exists'
+);
+
+select ok(
+  (select relrowsecurity from pg_class where oid = 'public.data_product_lcia_results'::regclass),
+  'data_product_lcia_results has RLS enabled'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.data_product_lcia_results', 'SELECT'),
+  'authenticated users cannot directly select unpublished data product result rows'
+);
+
+select ok(
+  not has_table_privilege('anon', 'public.data_product_lcia_results', 'SELECT'),
+  'anon users cannot directly select data product result rows'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.roles'::regclass
+      and conname = 'roles_role_check'
+      and pg_get_constraintdef(oid) like '%data_product_manager%'
+  ),
+  'roles check allows data_product_manager'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.lca_network_snapshots'::regclass
+      and conname = 'lca_network_snapshots_scope_chk'
+      and pg_get_constraintdef(oid) like '%data_product%'
+  ),
+  'lca_network_snapshots scope check allows data_product snapshots'
+);
+
+select ok(
+  exists (
+    select 1
+    from public.worker_job_kinds
+    where job_kind = 'data_product.package_build'
+      and worker_queue = 'solver'
+      and default_visibility = 'operator'
+      and payload_schema_version = 'data_product.package_build.request.v1'
+  ),
+  'data_product.package_build worker job kind is registered'
+);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '98230000-0000-4000-8000-000000000001',
+    'authenticated',
+    'authenticated',
+    'data-product-manager@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"98230000-0000-4000-8000-000000000001","email":"data-product-manager@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '98230000-0000-4000-8000-000000000002',
+    'authenticated',
+    'authenticated',
+    'ordinary-user@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"98230000-0000-4000-8000-000000000002","email":"ordinary-user@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into public.users (id, raw_user_meta_data, contact)
+values
+  ('98230000-0000-4000-8000-000000000001', '{"email":"data-product-manager@example.com"}'::jsonb, null),
+  ('98230000-0000-4000-8000-000000000002', '{"email":"ordinary-user@example.com"}'::jsonb, null);
+
+insert into public.teams (id, json, rank, is_public)
+values ('00000000-0000-0000-0000-000000000000', '{"name":"System Team"}'::jsonb, 0, false)
+on conflict (id) do nothing;
+
+insert into public.roles (user_id, team_id, role)
+values ('98230000-0000-4000-8000-000000000001', '00000000-0000-0000-0000-000000000000', 'data_product_manager');
+
+alter table public.processes disable trigger "process_extract_md_trigger_insert";
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+
+insert into public.processes (id, version, json, user_id, state_code)
+values
+  ('98230000-0000-4000-8000-000000000101', '01.00.000', '{"processDataSet":{"name":"eligible-1"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 100),
+  ('98230000-0000-4000-8000-000000000102', '01.00.000', '{"processDataSet":{"name":"eligible-2"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 100),
+  ('98230000-0000-4000-8000-000000000103', '01.00.000', '{"processDataSet":{"name":"draft"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 0);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000002', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+
+select is(
+  public.cmd_data_product_run_create(
+    p_name => 'ordinary user run',
+    p_processes => null,
+    p_coverage_mode => 'global_eligible',
+    p_default_impact_category => 'climate-change',
+    p_lcia_method_set => '[]'::jsonb,
+    p_idempotency_key => 'pgtap-data-product-ordinary-user',
+    p_audit => '{}'::jsonb
+  )->>'code',
+  'not_data_product_manager',
+  'ordinary authenticated users cannot create data product runs'
+);
+
+select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000001', true);
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+
+select is(
+  public.cmd_data_product_run_create(
+    p_name => 'draft input run',
+    p_processes => jsonb_build_array(jsonb_build_object('id', '98230000-0000-4000-8000-000000000103', 'version', '01.00.000')),
+    p_coverage_mode => 'subset',
+    p_default_impact_category => 'climate-change',
+    p_lcia_method_set => '[]'::jsonb,
+    p_idempotency_key => 'pgtap-data-product-draft-input',
+    p_audit => '{}'::jsonb
+  )->>'code',
+  'input_not_eligible',
+  'data product run creation rejects draft process input'
+);
+
+select is(
+  public.cmd_data_product_run_create(
+    p_name => 'global run with manual input',
+    p_processes => jsonb_build_array(jsonb_build_object('id', '98230000-0000-4000-8000-000000000101', 'version', '01.00.000')),
+    p_coverage_mode => 'global_eligible',
+    p_default_impact_category => 'climate-change',
+    p_lcia_method_set => '[]'::jsonb,
+    p_idempotency_key => 'pgtap-data-product-global-manual-input',
+    p_audit => '{}'::jsonb
+  )->>'code',
+  'invalid_coverage_mode',
+  'global eligible run creation rejects manual process subsets'
+);
+
+create temporary table data_product_test_ids (
+  label text primary key,
+  id uuid not null
+) on commit drop;
+
+grant all on data_product_test_ids to public;
+
+insert into data_product_test_ids (label, id)
+select
+  'run',
+  (result->'data'->>'runId')::uuid
+from (
+  select public.cmd_data_product_run_create(
+    p_name => 'global published run',
+    p_processes => null,
+    p_coverage_mode => 'global_eligible',
+    p_default_impact_category => 'climate-change',
+    p_lcia_method_set => jsonb_build_array(jsonb_build_object('method', 'EF', 'version', 'v1')),
+    p_idempotency_key => 'pgtap-data-product-global-run',
+    p_audit => '{}'::jsonb
+  ) as result
+) as created;
+
+select is(
+  (
+    select coverage_mode || ':' || eligible_input_count::text || ':' || included_input_count::text
+    from public.data_product_runs
+    where id = (select id from data_product_test_ids where label = 'run')
+  ),
+  'global_eligible:2:2',
+  'global eligible run captures only published predicate inputs'
+);
+
+select ok(
+  not exists (
+    select 1
+    from public.data_product_run_inputs
+    where run_id = (select id from data_product_test_ids where label = 'run')
+      and state_code = 0
+  ),
+  'global eligible run does not include draft process inputs'
+);
+
+reset role;
+set local role service_role;
+select set_config('request.jwt.claim.sub', '', true);
+select set_config('request.jwt.claim.role', 'service_role', true);
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+insert into public.lca_network_snapshots (
+  id,
+  scope,
+  process_filter,
+  provider_matching_rule,
+  source_hash,
+  status,
+  created_at,
+  updated_at
+) values (
+  '98230000-0000-4000-8000-000000000201',
+  'data_product',
+  '{"process_states":[100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199],"include_user_id":null}'::jsonb,
+  'split_by_evidence_hybrid',
+  'pgtap-data-product-source',
+  'ready',
+  now(),
+  now()
+);
+
+insert into public.lca_results (
+  id,
+  job_id,
+  snapshot_id,
+  payload,
+  diagnostics,
+  artifact_url,
+  artifact_sha256,
+  artifact_byte_size,
+  artifact_format
+) values (
+  '98230000-0000-4000-8000-000000000202',
+  '98230000-0000-4000-8000-000000000203',
+  '98230000-0000-4000-8000-000000000201',
+  '{}'::jsonb,
+  '{}'::jsonb,
+  'storage://lca_results/pgtap/data-product.h5',
+  repeat('a', 64),
+  1024,
+  'hdf5:v1'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000001', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+
+select is(
+  public.cmd_data_product_package_publish(
+    p_package_id => '98230000-0000-4000-8000-000000000301',
+    p_display_default_impact_category => 'climate-change',
+    p_reason => 'missing package',
+    p_audit => '{}'::jsonb
+  )->>'code',
+  'package_not_ready',
+  'publish rejects missing packages'
+);
+
+insert into data_product_test_ids (label, id)
+select
+  'package',
+  (result->'data'->>'packageId')::uuid
+from (
+  select public.cmd_data_product_package_mark_ready(
+    p_run_id => (select id from data_product_test_ids where label = 'run'),
+    p_package_version => '2026.06.001',
+    p_snapshot_id => '98230000-0000-4000-8000-000000000201',
+    p_source_result_id => '98230000-0000-4000-8000-000000000202',
+    p_package_result_hash => 'pgtap-package-result-hash',
+    p_default_impact_category => 'climate-change',
+    p_result_rows => jsonb_build_array(
+      jsonb_build_object(
+        'process_id', '98230000-0000-4000-8000-000000000101',
+        'process_version', '01.00.000',
+        'impact_category_id', 'climate-change',
+        'impact_label_snapshot', 'Climate change',
+        'value', 12.5,
+        'unit', 'kg CO2 eq',
+        'source_result_id', '98230000-0000-4000-8000-000000000202',
+        'source_artifact_sha256', repeat('a', 64)
+      ),
+      jsonb_build_object(
+        'process_id', '98230000-0000-4000-8000-000000000102',
+        'process_version', '01.00.000',
+        'impact_category_id', 'climate-change',
+        'impact_label_snapshot', 'Climate change',
+        'value', 25.0,
+        'unit', 'kg CO2 eq',
+        'source_result_id', '98230000-0000-4000-8000-000000000202',
+        'source_artifact_sha256', repeat('a', 64)
+      )
+    ),
+    p_artifacts => jsonb_build_array(
+      jsonb_build_object(
+        'artifact_type', 'source_result',
+        'storage_ref', 'storage://lca_results/pgtap/data-product.h5',
+        'sha256', repeat('a', 64),
+        'byte_size', 1024,
+        'format', 'hdf5:v1',
+        'persistence_mode', 'pinned',
+        'is_persisted', true,
+        'source_result_id', '98230000-0000-4000-8000-000000000202',
+        'snapshot_id', '98230000-0000-4000-8000-000000000201'
+      ),
+      jsonb_build_object(
+        'artifact_type', 'snapshot_index',
+        'storage_ref', 'storage://lca_results/pgtap/snapshot-index.json',
+        'sha256', repeat('b', 64),
+        'byte_size', 2048,
+        'format', 'snapshot-index:v1',
+        'persistence_mode', 'copied',
+        'is_persisted', true,
+        'snapshot_id', '98230000-0000-4000-8000-000000000201'
+      )
+    ),
+    p_audit => '{}'::jsonb
+  ) as result
+) as ready;
+
+select is(
+  (
+    select status || ':' || included_input_count::text || ':' || default_impact_category
+    from public.data_product_packages
+    where id = (select id from data_product_test_ids where label = 'package')
+  ),
+  'preview_ready:2:climate-change',
+  'package mark ready creates an immutable preview package'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.data_product_lcia_results
+    where package_id = (select id from data_product_test_ids where label = 'package')
+  ),
+  '2',
+  'package mark ready materializes LCIA result rows'
+);
+
+select is(
+  public.cmd_data_product_package_publish(
+    p_package_id => (select id from data_product_test_ids where label = 'package'),
+    p_display_default_impact_category => 'missing-impact',
+    p_reason => 'bad default impact',
+    p_audit => '{}'::jsonb
+  )->>'code',
+  'default_impact_missing',
+  'publish rejects a default impact category that does not exist in package rows'
+);
+
+insert into data_product_test_ids (label, id)
+select
+  'publication',
+  (result->'data'->>'publicationId')::uuid
+from (
+  select public.cmd_data_product_package_publish(
+    p_package_id => (select id from data_product_test_ids where label = 'package'),
+    p_display_default_impact_category => 'climate-change',
+    p_reason => 'publish pgtap package',
+    p_audit => '{}'::jsonb
+  ) as result
+) as published;
+
+select is(
+  (
+    select status || ':' || is_current::text || ':' || publication_series_key || ':' || publication_channel || ':' || visibility_scope
+    from public.data_product_publications
+    where id = (select id from data_product_test_ids where label = 'publication')
+  ),
+  'current:true:global:public:public',
+  'publish creates current global public publication'
+);
+
+select is(
+  (
+    select is_pinned::text
+    from public.lca_results
+    where id = '98230000-0000-4000-8000-000000000202'
+  ),
+  'true',
+  'publish pins the source lca_result'
+);
+
+select is(
+  public.get_data_product_package_preview(
+    p_package_id => (select id from data_product_test_ids where label = 'package')
+  )->'data'->'summary'->>'packageId',
+  (select id::text from data_product_test_ids where label = 'package'),
+  'manager can preview unpublished or published package rows through RPC'
+);
+
+select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000002', true);
+
+select is(
+  public.get_data_product_package_preview(
+    p_package_id => (select id from data_product_test_ids where label = 'package')
+  )->>'code',
+  'not_data_product_manager',
+  'ordinary users cannot preview package rows'
+);
+
+reset role;
+set local role anon;
+select set_config('request.jwt.claim.sub', '', true);
+select set_config('request.jwt.claim.role', 'anon', true);
+select set_config('request.jwt.claims', '{"role":"anon"}', true);
+
+select is(
+  jsonb_array_length(
+    public.get_published_process_lcia_results(
+      p_process_id => '98230000-0000-4000-8000-000000000101',
+      p_process_version => '01.00.000',
+      p_impact_category_id => 'climate-change'
+    )->'data'->'rows'
+  )::text,
+  '1',
+  'anon public read returns current published process LCIA result rows'
+);
+
+select is(
+  public.get_published_process_lcia_results(
+    p_process_id => '98230000-0000-4000-8000-000000000103',
+    p_process_version => '01.00.000',
+    p_impact_category_id => 'climate-change'
+  )->'data'->>'rowCount',
+  '0',
+  'public read returns an empty row set for processes outside the current package'
+);
+
+select is(
+  (
+    select count(*)::text
+    from public.data_product_publications
+    where publication_series_key = 'global'
+      and publication_channel = 'public'
+      and visibility_scope = 'public'
+      and is_current
+  ),
+  '1',
+  'partial unique current publication leaves exactly one current global public row'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/20260623_data_product_publication_mvp.sql
+++ b/supabase/tests/20260623_data_product_publication_mvp.sql
@@ -20,7 +20,7 @@ begin
 end;
 $$;
 
-select plan(32);
+select plan(34);
 
 select has_table('public', 'lcia_result_packages', 'LCIA result packages table exists');
 select has_table('public', 'lcia_result_publications', 'LCIA result publications table exists');
@@ -181,8 +181,25 @@ select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_
 insert into public.processes (id, version, json, user_id, state_code)
 values
   ('98230000-0000-4000-8000-000000000101', '01.00.000', '{"processDataSet":{"name":"eligible-1"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 100),
+  ('98230000-0000-4000-8000-000000000101', '01.00.001', '{"processDataSet":{"name":"eligible-1-latest"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 100),
   ('98230000-0000-4000-8000-000000000102', '01.00.000', '{"processDataSet":{"name":"eligible-2"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 100),
   ('98230000-0000-4000-8000-000000000103', '01.00.000', '{"processDataSet":{"name":"draft"}}'::jsonb, '98230000-0000-4000-8000-000000000001', 0);
+
+select is(
+  (public.lcia_result_current_eligible_manifest()->>'eligibleInputCount')::integer,
+  2,
+  'global eligible manifest counts latest published process versions only'
+);
+
+select is(
+  (
+    select process.value->>'version'
+    from jsonb_array_elements(public.lcia_result_current_eligible_manifest()->'inputManifest'->'processes') as process(value)
+    where process.value->>'id' = '98230000-0000-4000-8000-000000000101'
+  ),
+  '01.00.001',
+  'global eligible manifest keeps the latest published version per process id'
+);
 
 set local role authenticated;
 select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000002', true);
@@ -498,7 +515,7 @@ select set_config('request.jwt.claims', '{"role":"anon"}', true);
 select is(
   public.get_published_lcia_result_package(
     '98230000-0000-4000-8000-000000000101',
-    '01.00.000',
+    '01.00.001',
     'climate-change'
   )->'data'->'resultArtifact'->>'artifactUrl',
   's3://bucket/lcia-result.json',

--- a/supabase/tests/20260623_data_product_publication_mvp.sql
+++ b/supabase/tests/20260623_data_product_publication_mvp.sql
@@ -20,64 +20,64 @@ begin
 end;
 $$;
 
-select plan(34);
+select plan(32);
 
-select has_table('public', 'data_product_runs', 'data product runs table exists');
-select has_table('public', 'data_product_run_inputs', 'data product run inputs table exists');
-select has_table('public', 'data_product_packages', 'data product packages table exists');
-select has_table('public', 'data_product_package_items', 'data product package items table exists');
-select has_table('public', 'data_product_lcia_results', 'data product LCIA result rows table exists');
-select has_table('public', 'data_product_artifacts', 'data product artifacts table exists');
-select has_table('public', 'data_product_publications', 'data product publications table exists');
+select has_table('public', 'lcia_result_packages', 'LCIA result packages table exists');
+select has_table('public', 'lcia_result_publications', 'LCIA result publications table exists');
+select ok(to_regclass('public.data_product_runs') is null, 'data_product_runs table is not created');
+select ok(to_regclass('public.data_product_run_inputs') is null, 'data_product_run_inputs table is not created');
+select ok(to_regclass('public.data_product_packages') is null, 'data_product_packages table is not created');
+select ok(to_regclass('public.data_product_lcia_results') is null, 'data_product_lcia_results table is not created');
+select ok(to_regclass('public.data_product_artifacts') is null, 'data_product_artifacts table is not created');
 
 select has_function(
   'public',
-  'cmd_data_product_run_create',
+  'cmd_lcia_result_build_request',
   array['text', 'jsonb', 'text', 'text', 'jsonb', 'text', 'jsonb'],
-  'cmd_data_product_run_create exists'
+  'cmd_lcia_result_build_request exists'
 );
 
 select has_function(
   'public',
-  'cmd_data_product_package_mark_ready',
-  array['uuid', 'text', 'uuid', 'uuid', 'text', 'text', 'jsonb', 'jsonb', 'jsonb'],
-  'cmd_data_product_package_mark_ready exists'
+  'cmd_lcia_result_package_mark_ready',
+  array['uuid', 'text', 'uuid', 'uuid', 'uuid', 'jsonb', 'jsonb', 'jsonb', 'jsonb', 'text', 'text', 'jsonb'],
+  'cmd_lcia_result_package_mark_ready exists'
 );
 
 select has_function(
   'public',
-  'cmd_data_product_package_publish',
+  'cmd_lcia_result_package_publish',
   array['uuid', 'text', 'text', 'jsonb'],
-  'cmd_data_product_package_publish exists'
+  'cmd_lcia_result_package_publish exists'
 );
 
 select has_function(
   'public',
-  'get_data_product_package_preview',
+  'get_lcia_result_package_preview',
   array['uuid'],
-  'get_data_product_package_preview exists'
+  'get_lcia_result_package_preview exists'
 );
 
 select has_function(
   'public',
-  'get_published_process_lcia_results',
+  'get_published_lcia_result_package',
   array['uuid', 'text', 'text'],
-  'get_published_process_lcia_results exists'
+  'get_published_lcia_result_package exists'
 );
 
 select ok(
-  (select relrowsecurity from pg_class where oid = 'public.data_product_lcia_results'::regclass),
-  'data_product_lcia_results has RLS enabled'
+  (select relrowsecurity from pg_class where oid = 'public.lcia_result_packages'::regclass),
+  'lcia_result_packages has RLS enabled'
 );
 
 select ok(
-  not has_table_privilege('authenticated', 'public.data_product_lcia_results', 'SELECT'),
-  'authenticated users cannot directly select unpublished data product result rows'
+  not has_table_privilege('authenticated', 'public.lcia_result_packages', 'SELECT'),
+  'authenticated users cannot directly select unpublished LCIA result packages'
 );
 
 select ok(
-  not has_table_privilege('anon', 'public.data_product_lcia_results', 'SELECT'),
-  'anon users cannot directly select data product result rows'
+  not has_table_privilege('anon', 'public.lcia_result_publications', 'SELECT'),
+  'anon users cannot directly select LCIA result publications'
 );
 
 select ok(
@@ -106,12 +106,12 @@ select ok(
   exists (
     select 1
     from public.worker_job_kinds
-    where job_kind = 'data_product.package_build'
+    where job_kind = 'lcia_result.package_build'
       and worker_queue = 'solver'
       and default_visibility = 'operator'
-      and payload_schema_version = 'data_product.package_build.request.v1'
+      and payload_schema_version = 'lcia_result.package_build.request.v1'
   ),
-  'data_product.package_build worker job kind is registered'
+  'lcia_result.package_build worker job kind is registered'
 );
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
@@ -190,117 +190,169 @@ select set_config('request.jwt.claim.role', 'authenticated', true);
 select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
 
 select is(
-  public.cmd_data_product_run_create(
-    p_name => 'ordinary user run',
+  public.cmd_lcia_result_build_request(
+    p_name => 'ordinary user build',
     p_processes => null,
     p_coverage_mode => 'global_eligible',
     p_default_impact_category => 'climate-change',
     p_lcia_method_set => '[]'::jsonb,
-    p_idempotency_key => 'pgtap-data-product-ordinary-user',
+    p_idempotency_key => 'pgtap-lcia-result-ordinary-user',
     p_audit => '{}'::jsonb
   )->>'code',
   'not_data_product_manager',
-  'ordinary authenticated users cannot create data product runs'
+  'ordinary authenticated users cannot request LCIA result builds'
 );
 
 select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000001', true);
 select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
 
 select is(
-  public.cmd_data_product_run_create(
-    p_name => 'draft input run',
+  public.cmd_lcia_result_build_request(
+    p_name => 'draft input build',
     p_processes => jsonb_build_array(jsonb_build_object('id', '98230000-0000-4000-8000-000000000103', 'version', '01.00.000')),
     p_coverage_mode => 'subset',
     p_default_impact_category => 'climate-change',
     p_lcia_method_set => '[]'::jsonb,
-    p_idempotency_key => 'pgtap-data-product-draft-input',
+    p_idempotency_key => 'pgtap-lcia-result-draft-input',
     p_audit => '{}'::jsonb
   )->>'code',
   'input_not_eligible',
-  'data product run creation rejects draft process input'
+  'LCIA result build request rejects draft process input'
 );
 
 select is(
-  public.cmd_data_product_run_create(
-    p_name => 'global run with manual input',
+  public.cmd_lcia_result_build_request(
+    p_name => 'global build with manual input',
     p_processes => jsonb_build_array(jsonb_build_object('id', '98230000-0000-4000-8000-000000000101', 'version', '01.00.000')),
     p_coverage_mode => 'global_eligible',
     p_default_impact_category => 'climate-change',
     p_lcia_method_set => '[]'::jsonb,
-    p_idempotency_key => 'pgtap-data-product-global-manual-input',
+    p_idempotency_key => 'pgtap-lcia-result-global-manual-input',
     p_audit => '{}'::jsonb
   )->>'code',
   'invalid_coverage_mode',
-  'global eligible run creation rejects manual process subsets'
+  'global eligible build request rejects manual process subsets'
 );
 
-create temporary table data_product_test_ids (
+create temporary table lcia_result_test_ids (
   label text primary key,
   id uuid not null
 ) on commit drop;
 
-grant all on data_product_test_ids to public;
+grant all on lcia_result_test_ids to public;
 
-insert into data_product_test_ids (label, id)
+insert into lcia_result_test_ids (label, id)
 select
-  'run',
-  (result->'data'->>'runId')::uuid
+  'build',
+  (result->'data'->>'buildId')::uuid
 from (
-  select public.cmd_data_product_run_create(
-    p_name => 'global published run',
+  select public.cmd_lcia_result_build_request(
+    p_name => 'global published LCIA result build',
     p_processes => null,
     p_coverage_mode => 'global_eligible',
     p_default_impact_category => 'climate-change',
     p_lcia_method_set => jsonb_build_array(jsonb_build_object('method', 'EF', 'version', 'v1')),
-    p_idempotency_key => 'pgtap-data-product-global-run',
+    p_idempotency_key => 'pgtap-lcia-result-global-build',
     p_audit => '{}'::jsonb
   ) as result
 ) as created;
 
 select is(
   (
-    select coverage_mode || ':' || eligible_input_count::text || ':' || included_input_count::text
-    from public.data_product_runs
-    where id = (select id from data_product_test_ids where label = 'run')
+    public.cmd_lcia_result_build_request(
+      p_name => 'global published LCIA result build',
+      p_processes => null,
+      p_coverage_mode => 'global_eligible',
+      p_default_impact_category => 'climate-change',
+      p_lcia_method_set => jsonb_build_array(jsonb_build_object('method', 'EF', 'version', 'v1')),
+      p_idempotency_key => 'pgtap-lcia-result-global-build',
+      p_audit => '{}'::jsonb
+    )->'data'->'workerJob'->>'jobKind'
   ),
-  'global_eligible:2:2',
-  'global eligible run captures only published predicate inputs'
+  'lcia_result.package_build',
+  'build request returns the LCIA result worker job kind'
 );
 
-select ok(
-  not exists (
-    select 1
-    from public.data_product_run_inputs
-    where run_id = (select id from data_product_test_ids where label = 'run')
-      and state_code = 0
-  ),
-  'global eligible run does not include draft process inputs'
+select is(
+  (
+    public.cmd_lcia_result_build_request(
+      p_name => 'global published LCIA result build',
+      p_processes => null,
+      p_coverage_mode => 'global_eligible',
+      p_default_impact_category => 'climate-change',
+      p_lcia_method_set => jsonb_build_array(jsonb_build_object('method', 'EF', 'version', 'v1')),
+      p_idempotency_key => 'pgtap-lcia-result-global-build',
+      p_audit => '{}'::jsonb
+    )->'data'->>'includedInputCount'
+  )::integer,
+  2,
+  'build request resolves only published eligible process inputs'
 );
 
 reset role;
-set local role service_role;
-select set_config('request.jwt.claim.sub', '', true);
-select set_config('request.jwt.claim.role', 'service_role', true);
-select set_config('request.jwt.claims', '{"role":"service_role"}', true);
 
-insert into public.lca_network_snapshots (
+insert into public.worker_jobs (
   id,
-  scope,
-  process_filter,
-  provider_matching_rule,
-  source_hash,
-  status,
-  created_at,
-  updated_at
-) values (
-  '98230000-0000-4000-8000-000000000201',
+  job_kind,
+  worker_runtime,
+  worker_queue,
+  subject_type,
+  subject_id,
+  requester_type,
+  requested_by,
+  idempotency_key,
+  request_hash,
+  visibility,
+  payload_schema_version,
+  payload_json
+)
+select
+  '98230000-0000-4000-8000-000000000301'::uuid,
+  'lcia_result.package_build',
+  'calculator',
+  'solver',
+  'lcia_result_build',
+  id,
+  'operator',
+  '98230000-0000-4000-8000-000000000001',
+  'pgtap-lcia-result-worker-job',
+  'manifest-hash',
+  'operator',
+  'lcia_result.package_build.request.v1',
+  jsonb_build_object(
+    'type', 'lcia_result_package_build',
+    'build_id', id,
+    'requested_by', '98230000-0000-4000-8000-000000000001',
+    'coverage_mode', 'global_eligible',
+    'input_status_filter', jsonb_build_object('state_code', jsonb_build_object('between', jsonb_build_array(100, 199))),
+    'eligibility_definition', jsonb_build_object('predicateVersion', 'published-state-code-100-199:v1'),
+    'eligibility_resolved_at', now(),
+    'eligible_input_count', 2,
+    'included_input_count', 2,
+    'input_manifest_hash', public.lcia_result_current_eligible_manifest()->>'inputManifestHash',
+    'input_manifest', public.lcia_result_current_eligible_manifest()->'inputManifest',
+    'lcia_method_set', jsonb_build_array(jsonb_build_object('method', 'EF', 'version', 'v1')),
+    'default_impact_category', 'climate-change',
+    'postprocess_manifest', jsonb_build_object('postprocess_mode', 'skipped')
+  )
+from lcia_result_test_ids
+where label = 'build';
+
+insert into lcia_result_test_ids (label, id)
+values
+  ('worker_job', '98230000-0000-4000-8000-000000000301'),
+  ('snapshot', '98230000-0000-4000-8000-000000000401'),
+  ('result', '98230000-0000-4000-8000-000000000501'),
+  ('latest_all_unit', '98230000-0000-4000-8000-000000000601');
+
+insert into public.lca_network_snapshots (id, scope, process_filter, source_hash, status, created_by)
+values (
+  (select id from lcia_result_test_ids where label = 'snapshot'),
   'data_product',
-  '{"process_states":[100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151,152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199],"include_user_id":null}'::jsonb,
-  'split_by_evidence_hybrid',
-  'pgtap-data-product-source',
+  '{"state_code":{"between":[100,199]}}'::jsonb,
+  'pgtap-snapshot-hash',
   'ready',
-  now(),
-  now()
+  '98230000-0000-4000-8000-000000000001'
 );
 
 insert into public.lca_results (
@@ -312,220 +364,183 @@ insert into public.lca_results (
   artifact_url,
   artifact_sha256,
   artifact_byte_size,
-  artifact_format
-) values (
-  '98230000-0000-4000-8000-000000000202',
-  '98230000-0000-4000-8000-000000000203',
-  '98230000-0000-4000-8000-000000000201',
+  artifact_format,
+  worker_job_id,
+  is_pinned
+)
+values (
+  (select id from lcia_result_test_ids where label = 'result'),
+  (select id from lcia_result_test_ids where label = 'worker_job'),
+  (select id from lcia_result_test_ids where label = 'snapshot'),
   '{}'::jsonb,
   '{}'::jsonb,
-  'storage://lca_results/pgtap/data-product.h5',
+  's3://bucket/lcia-result.json',
   repeat('a', 64),
-  1024,
-  'hdf5:v1'
+  123,
+  'application/json',
+  (select id from lcia_result_test_ids where label = 'worker_job'),
+  false
 );
 
-reset role;
-set local role authenticated;
-select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000001', true);
-select set_config('request.jwt.claim.role', 'authenticated', true);
-select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
-
-select is(
-  public.cmd_data_product_package_publish(
-    p_package_id => '98230000-0000-4000-8000-000000000301',
-    p_display_default_impact_category => 'climate-change',
-    p_reason => 'missing package',
-    p_audit => '{}'::jsonb
-  )->>'code',
-  'package_not_ready',
-  'publish rejects missing packages'
+insert into public.lca_latest_all_unit_results (
+  id,
+  snapshot_id,
+  job_id,
+  result_id,
+  query_artifact_url,
+  query_artifact_sha256,
+  query_artifact_byte_size,
+  query_artifact_format,
+  status,
+  worker_job_id
+)
+values (
+  (select id from lcia_result_test_ids where label = 'latest_all_unit'),
+  (select id from lcia_result_test_ids where label = 'snapshot'),
+  (select id from lcia_result_test_ids where label = 'worker_job'),
+  (select id from lcia_result_test_ids where label = 'result'),
+  's3://bucket/query-sidecar.json',
+  repeat('b', 64),
+  456,
+  'application/json',
+  'ready',
+  (select id from lcia_result_test_ids where label = 'worker_job')
 );
 
-insert into data_product_test_ids (label, id)
+set local role service_role;
+select set_config('request.jwt.claim.role', 'service_role', true);
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+insert into lcia_result_test_ids (label, id)
 select
   'package',
   (result->'data'->>'packageId')::uuid
 from (
-  select public.cmd_data_product_package_mark_ready(
-    p_run_id => (select id from data_product_test_ids where label = 'run'),
-    p_package_version => '2026.06.001',
-    p_snapshot_id => '98230000-0000-4000-8000-000000000201',
-    p_source_result_id => '98230000-0000-4000-8000-000000000202',
-    p_package_result_hash => 'pgtap-package-result-hash',
-    p_default_impact_category => 'climate-change',
-    p_result_rows => jsonb_build_array(
-      jsonb_build_object(
-        'process_id', '98230000-0000-4000-8000-000000000101',
-        'process_version', '01.00.000',
-        'impact_category_id', 'climate-change',
-        'impact_label_snapshot', 'Climate change',
-        'value', 12.5,
-        'unit', 'kg CO2 eq',
-        'source_result_id', '98230000-0000-4000-8000-000000000202',
-        'source_artifact_sha256', repeat('a', 64)
-      ),
-      jsonb_build_object(
-        'process_id', '98230000-0000-4000-8000-000000000102',
-        'process_version', '01.00.000',
-        'impact_category_id', 'climate-change',
-        'impact_label_snapshot', 'Climate change',
-        'value', 25.0,
-        'unit', 'kg CO2 eq',
-        'source_result_id', '98230000-0000-4000-8000-000000000202',
-        'source_artifact_sha256', repeat('a', 64)
-      )
-    ),
-    p_artifacts => jsonb_build_array(
-      jsonb_build_object(
-        'artifact_type', 'source_result',
-        'storage_ref', 'storage://lca_results/pgtap/data-product.h5',
-        'sha256', repeat('a', 64),
-        'byte_size', 1024,
-        'format', 'hdf5:v1',
-        'persistence_mode', 'pinned',
-        'is_persisted', true,
-        'source_result_id', '98230000-0000-4000-8000-000000000202',
-        'snapshot_id', '98230000-0000-4000-8000-000000000201'
-      ),
-      jsonb_build_object(
-        'artifact_type', 'snapshot_index',
-        'storage_ref', 'storage://lca_results/pgtap/snapshot-index.json',
-        'sha256', repeat('b', 64),
-        'byte_size', 2048,
-        'format', 'snapshot-index:v1',
-        'persistence_mode', 'copied',
-        'is_persisted', true,
-        'snapshot_id', '98230000-0000-4000-8000-000000000201'
-      )
-    ),
+  select public.cmd_lcia_result_package_mark_ready(
+    p_build_worker_job_id => (select id from lcia_result_test_ids where label = 'worker_job'),
+    p_package_version => '2026-06-public',
+    p_snapshot_id => (select id from lcia_result_test_ids where label = 'snapshot'),
+    p_result_id => (select id from lcia_result_test_ids where label = 'result'),
+    p_latest_all_unit_result_id => (select id from lcia_result_test_ids where label = 'latest_all_unit'),
+    p_available_impact_categories => jsonb_build_array('climate-change', 'acidification'),
+    p_artifact_manifest => jsonb_build_object('persistenceMode', 'pinned'),
     p_audit => '{}'::jsonb
   ) as result
-) as ready;
+) as marked;
 
 select is(
-  (
-    select status || ':' || included_input_count::text || ':' || default_impact_category
-    from public.data_product_packages
-    where id = (select id from data_product_test_ids where label = 'package')
-  ),
-  'preview_ready:2:climate-change',
-  'package mark ready creates an immutable preview package'
+  (select status from public.lcia_result_packages where id = (select id from lcia_result_test_ids where label = 'package')),
+  'preview_ready',
+  'service role can mark an LCIA result package preview_ready'
 );
 
 select is(
-  (
-    select count(*)::text
-    from public.data_product_lcia_results
-    where package_id = (select id from data_product_test_ids where label = 'package')
-  ),
-  '2',
-  'package mark ready materializes LCIA result rows'
+  (select build_worker_job_id from public.lcia_result_packages where id = (select id from lcia_result_test_ids where label = 'package')),
+  (select id from lcia_result_test_ids where label = 'worker_job'),
+  'package keeps the producing worker_jobs reference'
 );
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000002', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
 
 select is(
-  public.cmd_data_product_package_publish(
-    p_package_id => (select id from data_product_test_ids where label = 'package'),
-    p_display_default_impact_category => 'missing-impact',
-    p_reason => 'bad default impact',
-    p_audit => '{}'::jsonb
-  )->>'code',
-  'default_impact_missing',
-  'publish rejects a default impact category that does not exist in package rows'
+  public.get_lcia_result_package_preview((select id from lcia_result_test_ids where label = 'package'))->>'code',
+  'not_data_product_manager',
+  'ordinary users cannot preview unpublished LCIA result packages'
 );
 
-insert into data_product_test_ids (label, id)
+select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000001', true);
+select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+
+select is(
+  public.get_lcia_result_package_preview(
+    (select id from lcia_result_test_ids where label = 'package')
+  )->'data'->'summary'->>'packageVersion',
+  '2026-06-public',
+  'manager can preview LCIA result package metadata'
+);
+
+insert into lcia_result_test_ids (label, id)
 select
   'publication',
   (result->'data'->>'publicationId')::uuid
 from (
-  select public.cmd_data_product_package_publish(
-    p_package_id => (select id from data_product_test_ids where label = 'package'),
+  select public.cmd_lcia_result_package_publish(
+    p_package_id => (select id from lcia_result_test_ids where label = 'package'),
     p_display_default_impact_category => 'climate-change',
     p_reason => 'publish pgtap package',
     p_audit => '{}'::jsonb
   ) as result
 ) as published;
 
-select is(
-  (
-    select status || ':' || is_current::text || ':' || publication_series_key || ':' || publication_channel || ':' || visibility_scope
-    from public.data_product_publications
-    where id = (select id from data_product_test_ids where label = 'publication')
-  ),
-  'current:true:global:public:public',
-  'publish creates current global public publication'
-);
-
-select is(
-  (
-    select is_pinned::text
-    from public.lca_results
-    where id = '98230000-0000-4000-8000-000000000202'
-  ),
-  'true',
-  'publish pins the source lca_result'
-);
-
-select is(
-  public.get_data_product_package_preview(
-    p_package_id => (select id from data_product_test_ids where label = 'package')
-  )->'data'->'summary'->>'packageId',
-  (select id::text from data_product_test_ids where label = 'package'),
-  'manager can preview unpublished or published package rows through RPC'
-);
-
-select set_config('request.jwt.claim.sub', '98230000-0000-4000-8000-000000000002', true);
-
-select is(
-  public.get_data_product_package_preview(
-    p_package_id => (select id from data_product_test_ids where label = 'package')
-  )->>'code',
-  'not_data_product_manager',
-  'ordinary users cannot preview package rows'
-);
-
 reset role;
+
+select ok(
+  (
+    select is_current
+    from public.lcia_result_publications
+    where id = (select id from lcia_result_test_ids where label = 'publication')
+  ),
+  'manager can publish a package as current global public latest'
+);
+
+select ok(
+  (select is_pinned from public.lca_results where id = (select id from lcia_result_test_ids where label = 'result')),
+  'published LCIA result is pinned against result GC'
+);
+
 set local role anon;
-select set_config('request.jwt.claim.sub', '', true);
 select set_config('request.jwt.claim.role', 'anon', true);
 select set_config('request.jwt.claims', '{"role":"anon"}', true);
 
 select is(
-  jsonb_array_length(
-    public.get_published_process_lcia_results(
-      p_process_id => '98230000-0000-4000-8000-000000000101',
-      p_process_version => '01.00.000',
-      p_impact_category_id => 'climate-change'
-    )->'data'->'rows'
-  )::text,
-  '1',
-  'anon public read returns current published process LCIA result rows'
+  public.get_published_lcia_result_package(
+    '98230000-0000-4000-8000-000000000101',
+    '01.00.000',
+    'climate-change'
+  )->'data'->'resultArtifact'->>'artifactUrl',
+  's3://bucket/lcia-result.json',
+  'anon can read only the current public LCIA package artifact reference'
 );
 
-select is(
-  public.get_published_process_lcia_results(
-    p_process_id => '98230000-0000-4000-8000-000000000103',
-    p_process_version => '01.00.000',
-    p_impact_category_id => 'climate-change'
-  )->'data'->>'rowCount',
-  '0',
-  'public read returns an empty row set for processes outside the current package'
+reset role;
+
+select throws_ok(
+  $$
+    update public.lcia_result_packages
+    set input_manifest_hash = 'mutated'
+    where id = (select id from lcia_result_test_ids where label = 'package')
+  $$,
+  '23514',
+  null,
+  'preview_ready package content is immutable'
 );
 
-select is(
-  (
-    select count(*)::text
-    from public.data_product_publications
-    where publication_series_key = 'global'
-      and publication_channel = 'public'
-      and visibility_scope = 'public'
-      and is_current
-  ),
-  '1',
-  'partial unique current publication leaves exactly one current global public row'
+select throws_ok(
+  $$
+    insert into public.lcia_result_publications (
+      package_id,
+      publication_series_key,
+      publication_channel,
+      visibility_scope,
+      is_current,
+      status
+    )
+    values (
+      (select id from lcia_result_test_ids where label = 'package'),
+      'global',
+      'public',
+      'public',
+      true,
+      'current'
+    )
+  $$,
+  '23505',
+  null,
+  'only one global public publication can be current'
 );
 
 select * from finish();
-
 rollback;


### PR DESCRIPTION
## Promotion Contract

- base branch: `main`
- source branch: `promote/data-product-dev-to-main-20260624`
- source snapshot: current `dev` through `13ef7dc`
- root workspace integration expected: Yes. After merge, update the root workspace submodule pointer once the promoted `main` SHA is release-eligible.

## Summary

Promotes the data product publication database changes from `dev` to `main`, including:

- data product publication MVP schema and RLS/function support
- simplified LCIA result publication schema
- latest published process selection for LCIA result manifests

## Included PRs

- #219
- #220

## Validation

- Feature PR validation was completed on #219 and #220.
- #220 verified the dev manifest as 2037 rows / 2037 distinct ids / 0 duplicates and completed a dev package build.
- This PR is a fixed `dev -> main` promotion branch; GitHub checks should validate the promoted snapshot.

## Follow-up

- Apply/promote the database migration path according to the Supabase deployment workflow.
- Coordinate root workspace submodule integration after Next and Edge promotions are also on `main`.