### PR TITLE
fix: expose lcia preview package references

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-23"
-lastReviewedCommit: "f216783f244b13ca5790d2883dae54072af9f5b3"
+lastReviewedAt: "2026-06-24"
+lastReviewedCommit: "27153f6ef2c2d7feb7d83653042c78d9a41d94fe"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-23
-lastReviewedCommit: f216783f244b13ca5790d2883dae54072af9f5b3
+lastReviewedAt: 2026-06-24
+lastReviewedCommit: 27153f6ef2c2d7feb7d83653042c78d9a41d94fe
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-23
-lastReviewedCommit: f216783f244b13ca5790d2883dae54072af9f5b3
+lastReviewedAt: 2026-06-24
+lastReviewedCommit: 27153f6ef2c2d7feb7d83653042c78d9a41d94fe
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-23
-lastReviewedCommit: f216783f244b13ca5790d2883dae54072af9f5b3
+lastReviewedAt: 2026-06-24
+lastReviewedCommit: 27153f6ef2c2d7feb7d83653042c78d9a41d94fe
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260624023636_expose_lcia_preview_snapshot_refs.sql
+++ b/supabase/migrations/20260624023636_expose_lcia_preview_snapshot_refs.sql
@@ -1,0 +1,52 @@
+create or replace function public.get_lcia_result_package_preview(
+  p_package_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_package public.lcia_result_packages%rowtype;
+begin
+  if not public.lcia_result_is_manager() then
+    return public.lcia_result_error('not_data_product_manager', 403, 'Data product manager role is required');
+  end if;
+
+  select *
+    into v_package
+  from public.lcia_result_packages
+  where id = p_package_id;
+
+  if v_package.id is null then
+    return public.lcia_result_error('package_not_found', 404, 'Package not found');
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'summary', jsonb_build_object(
+        'packageId', v_package.id,
+        'packageVersion', v_package.package_version,
+        'status', v_package.status,
+        'coverageMode', v_package.coverage_mode,
+        'snapshotId', v_package.snapshot_id,
+        'resultId', v_package.result_id,
+        'latestAllUnitResultId', v_package.latest_all_unit_result_id,
+        'eligibleInputCount', v_package.eligible_input_count,
+        'includedInputCount', v_package.included_input_count,
+        'inputManifestHash', v_package.input_manifest_hash,
+        'defaultImpactCategory', v_package.default_impact_category,
+        'availableImpactCategories', v_package.available_impact_categories
+      ),
+      'resultArtifact', v_package.result_artifact_ref,
+      'queryArtifact', v_package.query_artifact_ref,
+      'artifactManifest', v_package.artifact_manifest,
+      'inputManifest', v_package.input_manifest
+    )
+  );
+end;
+$$;
+
+revoke all on function public.get_lcia_result_package_preview(uuid) from public;
+grant execute on function public.get_lcia_result_package_preview(uuid) to authenticated;

--- a/supabase/tests/20260623_data_product_publication_mvp.sql
+++ b/supabase/tests/20260623_data_product_publication_mvp.sql
@@ -20,7 +20,7 @@ begin
 end;
 $$;
 
-select plan(34);
+select plan(35);
 
 select has_table('public', 'lcia_result_packages', 'LCIA result packages table exists');
 select has_table('public', 'lcia_result_publications', 'LCIA result publications table exists');
@@ -477,6 +477,14 @@ select is(
   )->'data'->'summary'->>'packageVersion',
   '2026-06-public',
   'manager can preview LCIA result package metadata'
+);
+
+select is(
+  public.get_lcia_result_package_preview(
+    (select id from lcia_result_test_ids where label = 'package')
+  )->'data'->'summary'->>'snapshotId',
+  (select id::text from lcia_result_test_ids where label = 'snapshot'),
+  'manager preview exposes stable snapshot reference for row-level result projection'
 );
 
 insert into lcia_result_test_ids (label, id)


### PR DESCRIPTION
## Summary

Closes #218

This follow-up exposes stable LCIA package references from `public.get_lcia_result_package_preview(uuid)` so Edge/UI preview flows can use the database-provided `snapshotId`, `resultId`, and `latestAllUnitResultId` instead of relying only on artifact metadata.

## Changes

- Add migration `20260624023636_expose_lcia_preview_snapshot_refs.sql` to replace the preview RPC with the additional summary fields.
- Extend `20260623_data_product_publication_mvp.sql` from 34 to 35 assertions, covering the exposed `snapshotId`.
- Refresh docpact review metadata for the governed repo docs touched by the prior database-engine work.

## Validation

- `supabase start`
- `supabase db reset`
- `supabase migration list --local`
- `supabase test db supabase/tests/20260623_data_product_publication_mvp.sql` → 35 tests passed
- `scripts/docpact validate-config --root . --strict`
- `scripts/docpact lint --root . --files '.docpact/config.yaml,AGENTS.md,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,supabase/tests/20260623_data_product_publication_mvp.sql,supabase/migrations/20260624023636_expose_lcia_preview_snapshot_refs.sql' --mode enforce`

## Deployment Notes

Preview-branch proof should run on this PR. Persistent `dev`, production `main`, and root workspace submodule integration remain separate follow-up phases after merge/promote.
