### PR TITLE
promote: database-engine dev to main for TIDAS schema runner

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-24"
-lastReviewedCommit: "27153f6ef2c2d7feb7d83653042c78d9a41d94fe"
+lastReviewedAt: "2026-06-26"
+lastReviewedCommit: "8fff106adf1e559b5fd4df6ad8ac578e8c8e57de"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .env.supabase*.local
 
+_artifacts/
+.docpact/runs/
+
 __pycache__/
 *.pyc
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-24
-lastReviewedCommit: 27153f6ef2c2d7feb7d83653042c78d9a41d94fe
+lastReviewedAt: 2026-06-26
+lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-24
-lastReviewedCommit: 27153f6ef2c2d7feb7d83653042c78d9a41d94fe
+lastReviewedAt: 2026-06-26
+lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-24
-lastReviewedCommit: 27153f6ef2c2d7feb7d83653042c78d9a41d94fe
+lastReviewedAt: 2026-06-26
+lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,7 +34,29 @@ related:
 
 This directory contains the command-line helpers used for remote schema export, workspace refresh, change-copying, and migration generation.
 
+## Layout
+
+Durable helper entry points remain at the top level of this directory.
+One-off or dated data remediation runners live under:
+
+- `scripts/data_migrations/<topic>_<yyyymm>/`
+
+Those runners should keep their own `README.md` with dry-run, apply, and validation examples.
+Local migration outputs and audit JSONL files should be written under `_artifacts/`, which is intentionally ignored by Git.
+
 ## Script List
+
+### `data_migrations/tidas_schema_202606/runner.py`
+
+Plans, applies, and validates the TIDAS schema 2026-06 JSON data remediation for remote database rows.
+
+Usage:
+
+```bash
+python scripts/data_migrations/tidas_schema_202606/runner.py plan --environment dev --run-id tidas-schema-202606-dev --out _artifacts/tidas-schema-202606/dev-plan.jsonl --dry-run
+```
+
+See `scripts/data_migrations/tidas_schema_202606/README.md` for the complete command surface and safety notes.
 
 ### `export_remote_schema.py`
 

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -34,7 +34,29 @@ related:
 
 这个目录包含用于远程 schema 导出、workspace 刷新、修改复制和 migration 生成的命令行脚本。
 
+## 目录结构
+
+长期维护的 helper 入口保留在本目录顶层。
+一次性或按日期归档的数据修复 runner 放在：
+
+- `scripts/data_migrations/<topic>_<yyyymm>/`
+
+这类 runner 应在自己的 `README.md` 中保留 dry-run、apply 和 validate 示例。
+本地迁移输出和审计 JSONL 文件应写入 `_artifacts/`，该目录已被 Git 忽略。
+
 ## 脚本列表
+
+### `data_migrations/tidas_schema_202606/runner.py`
+
+用于对远程数据库中的 TIDAS schema 2026-06 JSON 数据修复进行 plan、apply 和 validate。
+
+用法：
+
+```bash
+python scripts/data_migrations/tidas_schema_202606/runner.py plan --environment dev --run-id tidas-schema-202606-dev --out _artifacts/tidas-schema-202606/dev-plan.jsonl --dry-run
+```
+
+完整命令面和安全说明见 `scripts/data_migrations/tidas_schema_202606/README.md`。
 
 ### `export_remote_schema.py`
 

--- a/scripts/data_migrations/__init__.py
+++ b/scripts/data_migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Dated data migration runners."""

--- a/scripts/data_migrations/tidas_schema_202606/README.md
+++ b/scripts/data_migrations/tidas_schema_202606/README.md
@@ -1,0 +1,74 @@
+# TIDAS Schema 2026-06 Data Migration Runner
+
+This directory contains the dated data remediation runner used for the TIDAS schema 2026-06 JSON migration.
+
+## Scope
+
+The runner can scan, plan, apply, and validate JSON changes for these dataset tables:
+
+- `flowproperties`
+- `unitgroups`
+- `contacts`
+- `sources`
+- `lciamethods`
+- `lifecyclemodels`
+- `flows`
+- `processes`
+
+It handles path-aware `@type` normalization, dataset and reference version normalization, lifecycle reference repair, location-code cleanup, root-key alias normalization, and empty JSON row deletion when explicitly planned.
+
+## Safety Rules
+
+- Run `plan` before `apply`.
+- Use `--dry-run` for command validation and preflight counts.
+- Write audit output under `_artifacts/`; that directory is ignored by Git.
+- Do not commit raw production audit exports or row-level investigation artifacts.
+- Use `--suppress-user-triggers` only when the migration is intentionally bypassing user-facing table triggers for controlled operator repair.
+
+## Commands
+
+Plan without writing rows:
+
+```bash
+python scripts/data_migrations/tidas_schema_202606/runner.py plan \
+  --environment dev \
+  --run-id tidas-schema-202606-dev-plan \
+  --out _artifacts/tidas-schema-202606/dev-plan.jsonl \
+  --dry-run
+```
+
+Apply a small batch with row-level audit output:
+
+```bash
+python scripts/data_migrations/tidas_schema_202606/runner.py apply \
+  --environment dev \
+  --run-id tidas-schema-202606-dev-apply \
+  --out _artifacts/tidas-schema-202606/dev-apply.jsonl \
+  --batch-size 50 \
+  --suppress-user-triggers
+```
+
+Validate remaining required-rule violations:
+
+```bash
+python scripts/data_migrations/tidas_schema_202606/runner.py validate \
+  --environment dev \
+  --run-id tidas-schema-202606-dev-validate \
+  --out _artifacts/tidas-schema-202606/dev-validate.jsonl
+```
+
+Use `--database-url` to target an explicit connection string instead of resolving it from the environment profile.
+
+## Local Validation
+
+Run the unit tests after changing the runner:
+
+```bash
+python -m unittest tests/data_migrations/test_tidas_schema_202606.py
+```
+
+Run a syntax check for the runner and tests:
+
+```bash
+python -m py_compile scripts/data_migrations/tidas_schema_202606/runner.py tests/data_migrations/test_tidas_schema_202606.py
+```

--- a/scripts/data_migrations/tidas_schema_202606/__init__.py
+++ b/scripts/data_migrations/tidas_schema_202606/__init__.py
@@ -1,0 +1,1 @@
+"""TIDAS schema 2026-06 data migration runner package."""

--- a/scripts/data_migrations/tidas_schema_202606/runner.py
+++ b/scripts/data_migrations/tidas_schema_202606/runner.py
@@ -1,0 +1,1571 @@
+from __future__ import annotations
+
+import argparse
+import collections
+import copy
+from dataclasses import dataclass
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import psycopg
+    from psycopg.rows import dict_row
+except Exception:  # pragma: no cover - only needed for pure unit tests
+    psycopg = None
+    dict_row = None
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts._db_workflow import resolve_db_url
+
+
+VERSION_RE = re.compile(r"^\d{2}\.\d{2}(\.\d{3})?$")
+INTEGER_RE = re.compile(r"^-?(0|[1-9]\d*)$")
+REAL_RE = re.compile(r"^[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?$")
+UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
+
+TABLE_ROOTS = {
+    "flows": "flowDataSet",
+    "processes": "processDataSet",
+    "flowproperties": "flowPropertyDataSet",
+    "unitgroups": "unitGroupDataSet",
+    "contacts": "contactDataSet",
+    "sources": "sourceDataSet",
+    "lciamethods": "LCIAMethodDataSet",
+    "lifecyclemodels": "lifeCycleModelDataSet",
+}
+ROOT_ALIASES = {
+    "flows": ("f:flowDataSet",),
+    "flowproperties": ("fp:flowPropertyDataSet",),
+}
+DEFAULT_TABLES = (
+    "flowproperties",
+    "unitgroups",
+    "contacts",
+    "sources",
+    "lciamethods",
+    "lifecyclemodels",
+    "flows",
+    "processes",
+)
+
+TYPE_ENUM = {
+    "source data set",
+    "process data set",
+    "flow data set",
+    "flow property data set",
+    "unit group data set",
+    "contact data set",
+    "LCIA method data set",
+    "other external file",
+}
+DATASET_TYPE_BY_TABLE = {
+    "flows": "flow data set",
+    "processes": "process data set",
+    "flowproperties": "flow property data set",
+    "unitgroups": "unit group data set",
+    "contacts": "contact data set",
+    "sources": "source data set",
+    "lciamethods": "LCIA method data set",
+}
+TABLE_BY_DATASET_TYPE = {
+    "source data set": "sources",
+    "process data set": "processes",
+    "flow data set": "flows",
+    "flow property data set": "flowproperties",
+    "unit group data set": "unitgroups",
+    "contact data set": "contacts",
+    "LCIA method data set": "lciamethods",
+}
+APPROVED_INITIAL_DATASET_VERSION = "01.00.000"
+SELF_DATASET_TYPE = "__self__"
+APPROVED_REFERENCE_TYPE_BY_FIELD = {
+    "referenceToComplianceSystem": "source data set",
+    "referenceToDataSetFormat": "source data set",
+    "referenceToPersonOrEntityEnteringTheData": "contact data set",
+    "referenceToPersonOrEntityEnteringTheDataSet": "contact data set",
+    "referenceToPersonOrEntityGeneratingTheDataSet": "contact data set",
+    "referenceToOwnershipOfDataSet": "contact data set",
+    "referenceToCommissioner": "contact data set",
+    "referenceToDataSetUseApproval": "contact data set",
+    "referenceToNameOfReviewerAndInstitution": "contact data set",
+    "referenceToReferenceUnitGroup": "unit group data set",
+    "referenceToPrecedingDataSetVersion": SELF_DATASET_TYPE,
+    "referenceToFlowPropertyDataSet": "flow property data set",
+}
+
+DEFAULT_TYPE_ALIASES = {
+    "source dataset": "source data set",
+    "source data set": "source data set",
+    "process dataset": "process data set",
+    "process data set": "process data set",
+    "flow dataset": "flow data set",
+    "flow data set": "flow data set",
+    "flowproperty data set": "flow property data set",
+    "flowproperties data set": "flow property data set",
+    "flow property dataset": "flow property data set",
+    "flow property data set": "flow property data set",
+    "unitgroup data set": "unit group data set",
+    "unit group dataset": "unit group data set",
+    "unit group data set": "unit group data set",
+    "contact": "contact data set",
+    "contact dataset": "contact data set",
+    "contact data set": "contact data set",
+    "lcia method data": "LCIA method data set",
+    "lcia method dataset": "LCIA method data set",
+    "lcia method data set": "LCIA method data set",
+    "other external file": "other external file",
+}
+
+LCIA_SCOPE_VALUES = {
+    "Substance properties, physical and chemical",
+    "Substance properties, biological",
+    "Model for Transport and Fate",
+    "Model for Exposure",
+    "Model for Effect",
+    "Model for Damage",
+    "Characterisation factors",
+    "Application of model",
+    "Normalisation",
+    "Weighting",
+    "Documentation",
+}
+LCIA_METHOD_VALUES = {
+    "Recollection / Validation of data",
+    "Recalculation",
+    "Cross-check with other source",
+    "Cross-check with other LCIA method(ology)",
+    "Expert judgement",
+}
+
+LOCATION_FIXES = {"CN-HK": "HK", "CN-MO": "MO", "CN-TW": "TW"}
+SQL_VERSION_RE = r"^[0-9]{2}\.[0-9]{2}(\.[0-9]{3})?$"
+
+
+@dataclass(frozen=True)
+class LciaReviewMap:
+    scope: dict[str, str]
+    method: dict[str, str]
+
+
+@dataclass
+class MigrationResult:
+    document: dict[str, Any]
+    status: str
+    changes: list[dict[str, Any]]
+    issues: list[dict[str, Any]]
+
+
+VersionIndex = dict[str, dict[str, set[str]]]
+
+
+def normalize_version(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if VERSION_RE.fullmatch(stripped):
+        return stripped
+    if re.fullmatch(r"v?\d+", stripped, flags=re.IGNORECASE):
+        number = int(re.findall(r"\d+", stripped)[0])
+        return f"{number:02d}.00.000"
+    if re.fullmatch(r"v?\d+\.\d+", stripped, flags=re.IGNORECASE):
+        major, minor = [int(part) for part in re.findall(r"\d+", stripped)[:2]]
+        return f"{major:02d}.{minor:02d}.000"
+    if re.fullmatch(r"v?\d+\.\d+\.\d+", stripped, flags=re.IGNORECASE):
+        major, minor, patch = [int(part) for part in re.findall(r"\d+", stripped)[:3]]
+        return f"{major:02d}.{minor:02d}.{patch:03d}"
+    if stripped.count(",") == 1:
+        return normalize_version(stripped.replace(",", ".", 1))
+    return None
+
+
+def _json_hash(document: Any) -> str:
+    payload = json.dumps(document, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.md5(payload.encode("utf-8")).hexdigest()
+
+
+def _dataset_version(table: str, document: dict[str, Any]) -> str | None:
+    return (
+        document.get(TABLE_ROOTS[table], {})
+        .get("administrativeInformation", {})
+        .get("publicationAndOwnership", {})
+        .get("common:dataSetVersion")
+    )
+
+
+def _path(parent: str, key: str | int) -> str:
+    if isinstance(key, int):
+        return f"{parent}[{key}]"
+    escaped = key.replace('"', '\\"')
+    return f'{parent}."{escaped}"'
+
+
+def _path_field_name(path: str) -> str | None:
+    matches = re.findall(r'"((?:[^"\\]|\\.)*)"', path)
+    if not matches:
+        return None
+    return matches[-1].replace('\\"', '"')
+
+
+def _approved_reference_type(table: str, path: str) -> str | None:
+    field_name = _path_field_name(path)
+    if not field_name:
+        return None
+    target = APPROVED_REFERENCE_TYPE_BY_FIELD.get(field_name.removeprefix("common:"))
+    if target == SELF_DATASET_TYPE:
+        return DATASET_TYPE_BY_TABLE.get(table)
+    return target
+
+
+def _iter_nodes(node: Any, path: str = "$") -> Iterable[tuple[Any, str]]:
+    yield node, path
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from _iter_nodes(value, _path(path, key))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            yield from _iter_nodes(value, _path(path, index))
+
+
+def _merged_type_aliases(type_aliases: dict[str, str] | None) -> dict[str, str]:
+    merged = dict(DEFAULT_TYPE_ALIASES)
+    for key, value in (type_aliases or {}).items():
+        merged[key.strip().lower()] = value
+    return merged
+
+
+def _record_change(
+    changes: list[dict[str, Any]],
+    *,
+    rule: str,
+    path: str,
+    old: Any,
+    new: Any,
+) -> None:
+    changes.append({"rule": rule, "path": path, "old": old, "new": new})
+
+
+def _record_issue(
+    issues: list[dict[str, Any]],
+    *,
+    rule: str,
+    path: str,
+    value: Any,
+    message: str,
+) -> None:
+    issues.append({"rule": rule, "path": path, "value": value, "message": message})
+
+
+def _version_collision(
+    *,
+    version_index: VersionIndex | None,
+    table: str,
+    row_id: str | None,
+    current_version: str | None,
+    target_version: str,
+) -> bool:
+    if not version_index or not row_id:
+        return False
+    known_versions = version_index.get(table, {}).get(row_id, set())
+    return target_version in known_versions and target_version != (current_version or "").strip()
+
+
+def _migrate_root_key(
+    *,
+    table: str,
+    document: dict[str, Any],
+    changes: list[dict[str, Any]],
+    issues: list[dict[str, Any]],
+) -> None:
+    root_key = TABLE_ROOTS[table]
+    if root_key in document:
+        return
+    aliases = [alias for alias in ROOT_ALIASES.get(table, ()) if alias in document]
+    if len(aliases) != 1:
+        return
+    alias = aliases[0]
+    root = document[alias]
+    if not isinstance(root, dict):
+        _record_issue(
+            issues,
+            rule="A9_dataset_root_key",
+            path=f'$."{alias}"',
+            value=root,
+            message="prefixed dataset root is not an object",
+        )
+        return
+    document[root_key] = document.pop(alias)
+    _record_change(
+        changes,
+        rule="A9_dataset_root_key",
+        path="$",
+        old=alias,
+        new=root_key,
+    )
+
+
+def _migrate_dataset_version(
+    *,
+    table: str,
+    document: dict[str, Any],
+    current_version: str | None,
+    row_id: str | None,
+    version_index: VersionIndex | None,
+    changes: list[dict[str, Any]],
+    issues: list[dict[str, Any]],
+) -> None:
+    root_key = TABLE_ROOTS[table]
+    root = document.get(root_key)
+    if not isinstance(root, dict):
+        _record_issue(
+            issues,
+            rule="A2_dataset_version",
+            path=f'$."{root_key}"',
+            value=root,
+            message="dataset root is missing or not an object",
+        )
+        return
+    administrative = root.setdefault("administrativeInformation", {})
+    if not isinstance(administrative, dict):
+        _record_issue(
+            issues,
+            rule="A2_dataset_version",
+            path=f'$."{root_key}"."administrativeInformation"',
+            value=administrative,
+            message="administrativeInformation is not an object",
+        )
+        return
+    publication = administrative.setdefault("publicationAndOwnership", {})
+    if not isinstance(publication, dict):
+        _record_issue(
+            issues,
+            rule="A2_dataset_version",
+            path=f'$."{root_key}"."administrativeInformation"."publicationAndOwnership"',
+            value=publication,
+            message="publicationAndOwnership is not an object",
+        )
+        return
+    path = f'$."{root_key}"."administrativeInformation"."publicationAndOwnership"."common:dataSetVersion"'
+    if "common:dataSetVersion" not in publication:
+        if current_version and VERSION_RE.fullmatch(current_version.strip()):
+            publication["common:dataSetVersion"] = current_version.strip()
+            _record_change(
+                changes,
+                rule="A2_dataset_version",
+                path=path,
+                old=None,
+                new=current_version.strip(),
+            )
+        elif (
+            current_version is not None
+            and not current_version.strip()
+            and row_id
+            and not _version_collision(
+                version_index=version_index,
+                table=table,
+                row_id=row_id,
+                current_version=current_version,
+                target_version=APPROVED_INITIAL_DATASET_VERSION,
+            )
+        ):
+            publication["common:dataSetVersion"] = APPROVED_INITIAL_DATASET_VERSION
+            _record_change(
+                changes,
+                rule="A2_dataset_version",
+                path=path,
+                old=None,
+                new=APPROVED_INITIAL_DATASET_VERSION,
+            )
+        else:
+            _record_issue(
+                issues,
+                rule="A2_dataset_version",
+                path=path,
+                value=None,
+                message="missing common:dataSetVersion and no canonical table version fallback",
+            )
+        return
+
+    value = publication["common:dataSetVersion"]
+    normalized = normalize_version(value)
+    if normalized is None:
+        if (
+            isinstance(value, str)
+            and not value.strip()
+            and current_version is not None
+            and not current_version.strip()
+            and row_id
+            and not _version_collision(
+                version_index=version_index,
+                table=table,
+                row_id=row_id,
+                current_version=current_version,
+                target_version=APPROVED_INITIAL_DATASET_VERSION,
+            )
+        ):
+            publication["common:dataSetVersion"] = APPROVED_INITIAL_DATASET_VERSION
+            _record_change(
+                changes,
+                rule="A2_dataset_version",
+                path=path,
+                old=value,
+                new=APPROVED_INITIAL_DATASET_VERSION,
+            )
+            return
+        _record_issue(
+            issues,
+            rule="A2_dataset_version",
+            path=path,
+            value=value,
+            message="dataset version cannot be normalized safely",
+        )
+    elif normalized != value:
+        if _version_collision(
+            version_index=version_index,
+            table=table,
+            row_id=row_id,
+            current_version=current_version,
+            target_version=normalized,
+        ):
+            _record_issue(
+                issues,
+                rule="A2_dataset_version",
+                path=path,
+                value=value,
+                message="dataset version normalization would collide with an existing row version",
+            )
+            return
+        publication["common:dataSetVersion"] = normalized
+        _record_change(
+            changes,
+            rule="A2_dataset_version",
+            path=path,
+            old=value,
+            new=normalized,
+        )
+
+
+def _migrate_global_reference(
+    *,
+    table: str,
+    node: dict[str, Any],
+    path: str,
+    type_aliases: dict[str, str],
+    version_index: VersionIndex | None,
+    changes: list[dict[str, Any]],
+    issues: list[dict[str, Any]],
+) -> None:
+    value = node.get("@type")
+    if isinstance(value, str):
+        if value not in TYPE_ENUM:
+            normalized_type = _approved_reference_type(table, path)
+            if normalized_type is None:
+                normalized_type = type_aliases.get(value.strip().lower())
+            if normalized_type in TYPE_ENUM:
+                node["@type"] = normalized_type
+                _record_change(
+                    changes,
+                    rule="A1_reference_type",
+                    path=_path(path, "@type"),
+                    old=value,
+                    new=normalized_type,
+                )
+            else:
+                _record_issue(
+                    issues,
+                    rule="A1_reference_type",
+                    path=_path(path, "@type"),
+                    value=value,
+                    message="reference @type is not in the TIDAS 2026-06 enum and has no approved alias",
+                )
+    version = node.get("@version")
+    if isinstance(version, str):
+        normalized_version = normalize_version(version)
+        if normalized_version is None:
+            resolved_version = _resolve_reference_version(node, version_index)
+            if resolved_version is not None:
+                node["@version"] = resolved_version
+                _record_change(
+                    changes,
+                    rule="A2_reference_version",
+                    path=_path(path, "@version"),
+                    old=version,
+                    new=resolved_version,
+                )
+                return
+            _record_issue(
+                issues,
+                rule="A2_reference_version",
+                path=_path(path, "@version"),
+                value=version,
+                message="reference @version cannot be normalized safely",
+            )
+        elif normalized_version != version:
+            node["@version"] = normalized_version
+            _record_change(
+                changes,
+                rule="A2_reference_version",
+                path=_path(path, "@version"),
+                old=version,
+                new=normalized_version,
+            )
+
+
+def _resolve_reference_version(
+    node: dict[str, Any],
+    version_index: VersionIndex | None,
+) -> str | None:
+    if not version_index:
+        return None
+    ref_type = node.get("@type")
+    ref_id = node.get("@refObjectId")
+    if not isinstance(ref_type, str) or not isinstance(ref_id, str):
+        return None
+    target_table = TABLE_BY_DATASET_TYPE.get(ref_type)
+    if target_table is None:
+        return None
+    versions = version_index.get(target_table, {}).get(ref_id)
+    if not versions:
+        return None
+    canonical_versions = [version for version in versions if VERSION_RE.fullmatch(version)]
+    if not canonical_versions:
+        return None
+    return max(canonical_versions, key=_version_sort_key)
+
+
+def _version_sort_key(version: str) -> tuple[int, int, int]:
+    major, minor, *rest = [int(part) for part in version.split(".")]
+    patch = rest[0] if rest else -1
+    return major, minor, patch
+
+
+def _migrate_lcia_review_values(
+    *,
+    node: dict[str, Any],
+    path: str,
+    review_map: LciaReviewMap,
+    changes: list[dict[str, Any]],
+    issues: list[dict[str, Any]],
+) -> None:
+    for key, allowed, mapping, rule in (
+        ("common:scope", LCIA_SCOPE_VALUES, review_map.scope, "A4_lcia_review_scope"),
+        ("common:method", LCIA_METHOD_VALUES, review_map.method, "A4_lcia_review_method"),
+    ):
+        value = node.get(key)
+        values = value if isinstance(value, list) else [value] if isinstance(value, dict) else []
+        for index, item in enumerate(values):
+            item_path = _path(path, key)
+            if isinstance(value, list):
+                item_path = _path(item_path, index)
+            if not isinstance(item, dict) or "@name" not in item:
+                continue
+            name = item["@name"]
+            if name in allowed:
+                continue
+            mapped = mapping.get(name)
+            if mapped in allowed:
+                item["@name"] = mapped
+                _record_change(
+                    changes,
+                    rule=rule,
+                    path=_path(item_path, "@name"),
+                    old=name,
+                    new=mapped,
+                )
+            else:
+                _record_issue(
+                    issues,
+                    rule=rule,
+                    path=_path(item_path, "@name"),
+                    value=name,
+                    message="LCIA review value has no approved mapping",
+                )
+
+
+def _migrate_lcia_booleans_and_factor_keys(
+    *,
+    node: dict[str, Any],
+    path: str,
+    changes: list[dict[str, Any]],
+    issues: list[dict[str, Any]],
+) -> None:
+    for key in ("normalisation", "weighting"):
+        value = node.get(key)
+        if value in ("true", "false"):
+            new_value = value == "true"
+            node[key] = new_value
+            _record_change(
+                changes,
+                rule="A6_lcia_boolean",
+                path=_path(path, key),
+                old=value,
+                new=new_value,
+            )
+    if "uncertaintyType" in node:
+        old_value = node["uncertaintyType"]
+        if "uncertaintyDistributionType" in node:
+            _record_issue(
+                issues,
+                rule="A5_lcia_uncertainty_key",
+                path=_path(path, "uncertaintyType"),
+                value=old_value,
+                message="both uncertaintyType and uncertaintyDistributionType are present",
+            )
+        else:
+            node["uncertaintyDistributionType"] = node.pop("uncertaintyType")
+            _record_change(
+                changes,
+                rule="A5_lcia_uncertainty_key",
+                path=_path(path, "uncertaintyType"),
+                old=old_value,
+                new={"uncertaintyDistributionType": old_value},
+            )
+
+
+def _migrate_location(
+    *,
+    node: dict[str, Any],
+    path: str,
+    changes: list[dict[str, Any]],
+) -> None:
+    value = node.get("@location")
+    if value in LOCATION_FIXES:
+        node["@location"] = LOCATION_FIXES[value]
+        _record_change(
+            changes,
+            rule="A7_location_code",
+            path=_path(path, "@location"),
+            old=value,
+            new=LOCATION_FIXES[value],
+        )
+
+
+def _migrate_lifecycle_fields(
+    *,
+    node: dict[str, Any],
+    path: str,
+    unresolved_lifecycle_version: str | None,
+    changes: list[dict[str, Any]],
+    issues: list[dict[str, Any]],
+) -> None:
+    if "referenceToReferenceProcess" in node:
+        value = node["referenceToReferenceProcess"]
+        if isinstance(value, str):
+            if INTEGER_RE.fullmatch(value):
+                node["referenceToReferenceProcess"] = int(value)
+                _record_change(
+                    changes,
+                    rule="B1_lifecycle_reference_process",
+                    path=_path(path, "referenceToReferenceProcess"),
+                    old=value,
+                    new=int(value),
+                )
+            else:
+                _record_issue(
+                    issues,
+                    rule="B1_lifecycle_reference_process",
+                    path=_path(path, "referenceToReferenceProcess"),
+                    value=value,
+                    message="referenceToReferenceProcess cannot be converted without losing lexical identity",
+                )
+
+    for key in ("outputExchange", "downstreamProcess"):
+        value = node.get(key)
+        items = value if isinstance(value, list) else [value] if isinstance(value, dict) else []
+        for index, item in enumerate(items):
+            item_path = _path(path, key)
+            if isinstance(value, list):
+                item_path = _path(item_path, index)
+            if not isinstance(item, dict) or "@version" in item:
+                continue
+            if unresolved_lifecycle_version:
+                item["@version"] = unresolved_lifecycle_version
+                _record_change(
+                    changes,
+                    rule="A8_lifecycle_reference_version",
+                    path=_path(item_path, "@version"),
+                    old=None,
+                    new=unresolved_lifecycle_version,
+                )
+            else:
+                _record_issue(
+                    issues,
+                    rule="A8_lifecycle_reference_version",
+                    path=_path(item_path, "@version"),
+                    value=None,
+                    message="missing lifecycle reference @version and no fallback was configured",
+                )
+
+
+def migrate_document(
+    table: str,
+    document: dict[str, Any],
+    *,
+    type_aliases: dict[str, str] | None,
+    lcia_review_map: LciaReviewMap,
+    unresolved_lifecycle_version: str | None,
+    current_version: str | None = None,
+    row_id: str | None = None,
+    version_index: VersionIndex | None = None,
+) -> MigrationResult:
+    if table not in TABLE_ROOTS:
+        raise ValueError(f"unsupported table: {table}")
+    changes: list[dict[str, Any]] = []
+    issues: list[dict[str, Any]] = []
+    aliases = _merged_type_aliases(type_aliases)
+
+    if document == {}:
+        _record_change(
+            changes,
+            rule="D1_empty_json_delete",
+            path="$",
+            old={},
+            new=None,
+        )
+        return MigrationResult(document=document, status="delete_planned", changes=changes, issues=issues)
+
+    _migrate_root_key(
+        table=table,
+        document=document,
+        changes=changes,
+        issues=issues,
+    )
+
+    _migrate_dataset_version(
+        table=table,
+        document=document,
+        current_version=current_version,
+        row_id=row_id,
+        version_index=version_index,
+        changes=changes,
+        issues=issues,
+    )
+
+    for node, path in list(_iter_nodes(document)):
+        if not isinstance(node, dict):
+            continue
+        if "@type" in node and "@refObjectId" in node:
+            _migrate_global_reference(
+                table=table,
+                node=node,
+                path=path,
+                type_aliases=aliases,
+                version_index=version_index,
+                changes=changes,
+                issues=issues,
+            )
+        _migrate_location(node=node, path=path, changes=changes)
+        if table == "lciamethods":
+            _migrate_lcia_review_values(
+                node=node,
+                path=path,
+                review_map=lcia_review_map,
+                changes=changes,
+                issues=issues,
+            )
+            _migrate_lcia_booleans_and_factor_keys(
+                node=node,
+                path=path,
+                changes=changes,
+                issues=issues,
+            )
+        if table == "lifecyclemodels":
+            _migrate_lifecycle_fields(
+                node=node,
+                path=path,
+                unresolved_lifecycle_version=unresolved_lifecycle_version,
+                changes=changes,
+                issues=issues,
+            )
+
+    if issues:
+        status = "manual_required"
+    elif changes:
+        status = "planned"
+    else:
+        status = "clean"
+    return MigrationResult(document=document, status=status, changes=changes, issues=issues)
+
+
+def validate_required_rules(table: str, document: dict[str, Any]) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    root_key = TABLE_ROOTS[table]
+    doc_version = (
+        document.get(root_key, {})
+        .get("administrativeInformation", {})
+        .get("publicationAndOwnership", {})
+        .get("common:dataSetVersion")
+    )
+    if not isinstance(doc_version, str) or not VERSION_RE.fullmatch(doc_version):
+        _record_issue(
+            issues,
+            rule="A2_dataset_version",
+            path=f'$."{root_key}"."administrativeInformation"."publicationAndOwnership"."common:dataSetVersion"',
+            value=doc_version,
+            message="dataset version is missing or noncanonical",
+        )
+    for node, path in _iter_nodes(document):
+        if not isinstance(node, dict):
+            continue
+        if "@type" in node and "@refObjectId" in node:
+            value = node.get("@type")
+            if value not in TYPE_ENUM:
+                _record_issue(
+                    issues,
+                    rule="A1_reference_type",
+                    path=_path(path, "@type"),
+                    value=value,
+                    message="reference @type is not canonical",
+                )
+            version = node.get("@version")
+            if isinstance(version, str) and not VERSION_RE.fullmatch(version):
+                _record_issue(
+                    issues,
+                    rule="A2_reference_version",
+                    path=_path(path, "@version"),
+                    value=version,
+                    message="reference @version is not canonical",
+                )
+        if node.get("@location") in LOCATION_FIXES:
+            _record_issue(
+                issues,
+                rule="A7_location_code",
+                path=_path(path, "@location"),
+                value=node.get("@location"),
+                message="legacy CN-* location code remains",
+            )
+        if table == "lciamethods":
+            if "uncertaintyType" in node:
+                _record_issue(
+                    issues,
+                    rule="A5_lcia_uncertainty_key",
+                    path=_path(path, "uncertaintyType"),
+                    value=node["uncertaintyType"],
+                    message="legacy uncertaintyType key remains",
+                )
+            for key in ("normalisation", "weighting"):
+                if node.get(key) in ("true", "false"):
+                    _record_issue(
+                        issues,
+                        rule="A6_lcia_boolean",
+                        path=_path(path, key),
+                        value=node.get(key),
+                        message="LCIA boolean remains a string",
+                    )
+        if table == "lifecyclemodels":
+            if "referenceToReferenceProcess" in node and isinstance(
+                node["referenceToReferenceProcess"], str
+            ):
+                _record_issue(
+                    issues,
+                    rule="B1_lifecycle_reference_process",
+                    path=_path(path, "referenceToReferenceProcess"),
+                    value=node["referenceToReferenceProcess"],
+                    message="referenceToReferenceProcess remains a string",
+                )
+            for key in ("outputExchange", "downstreamProcess"):
+                value = node.get(key)
+                items = value if isinstance(value, list) else [value] if isinstance(value, dict) else []
+                for index, item in enumerate(items):
+                    if isinstance(item, dict) and "@version" not in item:
+                        item_path = _path(path, key)
+                        if isinstance(value, list):
+                            item_path = _path(item_path, index)
+                        _record_issue(
+                            issues,
+                            rule="A8_lifecycle_reference_version",
+                            path=_path(item_path, "@version"),
+                            value=None,
+                            message="lifecycle reference @version missing",
+                        )
+    return issues
+
+
+def _parse_yamlish_mapping(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    try:
+        import yaml
+    except Exception as exc:
+        raise RuntimeError("pyyaml is required when using mapping files") from exc
+    with open(path, "r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def load_type_aliases(path: str | None) -> dict[str, str]:
+    data = _parse_yamlish_mapping(path)
+    aliases = data.get("aliases", data)
+    return {str(key): str(value) for key, value in aliases.items()} if aliases else {}
+
+
+def load_lcia_review_map(path: str | None) -> LciaReviewMap:
+    data = _parse_yamlish_mapping(path)
+    return LciaReviewMap(
+        scope={str(key): str(value) for key, value in (data.get("scope") or {}).items()},
+        method={str(key): str(value) for key, value in (data.get("method") or {}).items()},
+    )
+
+
+def parse_tables(value: str | None) -> list[str]:
+    if not value:
+        return list(DEFAULT_TABLES)
+    tables = [item.strip() for item in value.split(",") if item.strip()]
+    unsupported = [table for table in tables if table not in TABLE_ROOTS]
+    if unsupported:
+        raise ValueError(f"unsupported table(s): {', '.join(unsupported)}")
+    return tables
+
+
+def connect(db_url: str):
+    if psycopg is None:
+        raise RuntimeError("psycopg is required for database commands")
+    return psycopg.connect(db_url, row_factory=dict_row, prepare_threshold=None)
+
+
+def _sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _jsonpath_literal(value: str) -> str:
+    return _sql_literal(value)
+
+
+def build_candidate_predicate(table: str) -> str:
+    root_key = TABLE_ROOTS[table]
+    version_path = (
+        f"{{{root_key},administrativeInformation,publicationAndOwnership,common:dataSetVersion}}"
+    )
+    dataset_version = (
+        f"(t.json #>> '{version_path}') is null "
+        f"or not ((t.json #>> '{version_path}') ~ {_sql_literal(SQL_VERSION_RE)})"
+    )
+    allowed_types = " || ".join(
+        f'@."@type" == "{value}"' for value in sorted(TYPE_ENUM)
+    )
+    invalid_ref_type = (
+        '$.** ? (exists(@."@refObjectId") && exists(@."@type") && '
+        f"!({allowed_types}))"
+    )
+    bad_ref_version = (
+        '$.** ? (exists(@."@refObjectId") && exists(@."@type") && exists(@."@version") && '
+        f'!(@."@version" like_regex "{SQL_VERSION_RE}"))'
+    )
+    legacy_location = (
+        '$.** ? (exists(@."@location") && '
+        '(@."@location" == "CN-HK" || @."@location" == "CN-MO" || @."@location" == "CN-TW"))'
+    )
+
+    predicates = [
+        f"({dataset_version})",
+        f"jsonb_path_exists(t.json, {_jsonpath_literal(invalid_ref_type)}::jsonpath)",
+        f"jsonb_path_exists(t.json, {_jsonpath_literal(bad_ref_version)}::jsonpath)",
+        f"jsonb_path_exists(t.json, {_jsonpath_literal(legacy_location)}::jsonpath)",
+    ]
+
+    if table == "lifecyclemodels":
+        # This table is small enough to scan fully, and missing nested @version
+        # markers are easier to assess safely in Python than in jsonpath.
+        predicates.append("true")
+
+    if table == "lciamethods":
+        lcia_legacy = (
+            '$.** ? (exists(@."uncertaintyType") || '
+            '@."normalisation" == "true" || @."normalisation" == "false" || '
+            '@."weighting" == "true" || @."weighting" == "false")'
+        )
+        predicates.append(
+            f"jsonb_path_exists(t.json, {_jsonpath_literal(lcia_legacy)}::jsonpath)"
+        )
+
+    return " or ".join(f"({predicate})" for predicate in predicates)
+
+
+def fetch_rows(
+    conn,
+    table: str,
+    *,
+    after_id: str | None = None,
+    after_version: str | None = None,
+    limit: int = 1000,
+    all_rows: bool = False,
+) -> list[dict[str, Any]]:
+    candidate_predicate = "true" if all_rows else build_candidate_predicate(table)
+    with conn.cursor() as cur:
+        if after_id is None:
+            cur.execute(
+                f"""
+                select id::text as id,
+                       trim(version::text) as version,
+                       t.xmin::text as row_xmin,
+                       json
+                from public.{table} as t
+                where t.json is not null
+                  and ({candidate_predicate})
+                order by t.id, t.version
+                limit %s
+                """,
+                (limit,),
+            )
+        else:
+            cur.execute(
+                f"""
+                select id::text as id,
+                       trim(version::text) as version,
+                       t.xmin::text as row_xmin,
+                       json
+                from public.{table} as t
+                where t.json is not null
+                  and ({candidate_predicate})
+                  and (t.id, t.version) > (%s::uuid, %s::character(9))
+                order by t.id, t.version
+                limit %s
+                """,
+                (after_id, after_version, limit),
+            )
+        return list(cur.fetchall())
+
+
+def collect_version_lookup_ids(
+    *,
+    table: str,
+    rows: Iterable[dict[str, Any]],
+    type_aliases: dict[str, str],
+) -> dict[str, set[str]]:
+    lookup_ids: dict[str, set[str]] = {table: set()}
+    for row in rows:
+        row_id = row.get("id")
+        if isinstance(row_id, str):
+            lookup_ids.setdefault(table, set()).add(row_id)
+        document = row.get("json")
+        if not isinstance(document, dict):
+            continue
+        for node, path in _iter_nodes(document):
+            if not isinstance(node, dict):
+                continue
+            ref_id = node.get("@refObjectId")
+            if not isinstance(ref_id, str) or not UUID_RE.fullmatch(ref_id):
+                continue
+            version = node.get("@version")
+            if not isinstance(version, str) or normalize_version(version) is not None:
+                continue
+            ref_type = node.get("@type")
+            target_type = ref_type if ref_type in TYPE_ENUM else None
+            if target_type is None:
+                target_type = _approved_reference_type(table, path)
+            if target_type is None and isinstance(ref_type, str):
+                target_type = type_aliases.get(ref_type.strip().lower())
+            target_table = TABLE_BY_DATASET_TYPE.get(target_type or "")
+            if target_table:
+                lookup_ids.setdefault(target_table, set()).add(ref_id)
+    return {name: ids for name, ids in lookup_ids.items() if ids}
+
+
+def fetch_version_index(conn, lookup_ids: dict[str, set[str]]) -> VersionIndex:
+    version_index: VersionIndex = {}
+    for table, ids in lookup_ids.items():
+        if not ids:
+            continue
+        table_versions: dict[str, set[str]] = {}
+        with conn.cursor() as cur:
+            cur.execute(
+                f"""
+                select id::text as id,
+                       trim(version::text) as version
+                from public.{table}
+                where id = any(%s::uuid[])
+                order by id, version
+                """,
+                (list(ids),),
+            )
+            for row in cur.fetchall():
+                table_versions.setdefault(row["id"], set()).add(row["version"])
+        version_index[table] = table_versions
+    return version_index
+
+
+def iter_rows(
+    conn, table: str, *, page_size: int, all_rows: bool = False
+) -> Iterable[list[dict[str, Any]]]:
+    after_id: str | None = None
+    after_version: str | None = None
+    while True:
+        rows = fetch_rows(
+            conn,
+            table,
+            after_id=after_id,
+            after_version=after_version,
+            limit=page_size,
+            all_rows=all_rows,
+        )
+        if not rows:
+            return
+        yield rows
+        after_id = rows[-1]["id"]
+        after_version = rows[-1]["version"]
+
+
+def build_row_event(
+    *,
+    run_id: str,
+    phase: str,
+    table: str,
+    row: dict[str, Any],
+    result: MigrationResult,
+    include_hashes: bool,
+    compact: bool,
+) -> dict[str, Any]:
+    old_doc = row["json"]
+    new_version = _dataset_version(table, result.document)
+    event = {
+        "runId": run_id,
+        "phase": phase,
+        "table": table,
+        "id": row["id"],
+        "oldVersion": row["version"],
+        "newVersion": new_version,
+        "status": result.status,
+    }
+    if compact:
+        event["changeCount"] = len(result.changes)
+        event["issueCount"] = len(result.issues)
+        event["changeRules"] = dict(
+            sorted(collections.Counter(change["rule"] for change in result.changes).items())
+        )
+        event["issueRules"] = dict(
+            sorted(collections.Counter(issue["rule"] for issue in result.issues).items())
+        )
+    else:
+        event["changes"] = result.changes
+        event["issues"] = result.issues
+    if include_hashes:
+        event["oldHash"] = _json_hash(old_doc)
+        event["newHash"] = _json_hash(result.document)
+    return event
+
+
+def open_output(path: str | None):
+    if not path:
+        return sys.stdout, False
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    return output_path.open("w", encoding="utf-8"), True
+
+
+def write_event(handle, event: dict[str, Any]) -> None:
+    handle.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+    handle.flush()
+
+
+def iter_plan_results(
+    args, phase: str
+) -> Iterable[tuple[str, dict[str, Any], MigrationResult]]:
+    db_url = resolve_db_url(args.environment, args.database_url)
+    type_aliases = load_type_aliases(args.type_map)
+    lcia_review_map = load_lcia_review_map(args.lcia_review_map)
+    with connect(db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute("set statement_timeout = '5min'")
+        for table in parse_tables(args.tables):
+            pages = 0
+            rows_seen = 0
+            print(
+                json.dumps({"phase": phase, "table": table, "event": "table_start"}, sort_keys=True),
+                file=sys.stderr,
+                flush=True,
+            )
+            for page in iter_rows(conn, table, page_size=args.page_size, all_rows=args.all_rows):
+                pages += 1
+                rows_seen += len(page)
+                version_index = fetch_version_index(
+                    conn,
+                    collect_version_lookup_ids(
+                        table=table,
+                        rows=page,
+                        type_aliases=_merged_type_aliases(type_aliases),
+                    ),
+                )
+                for row in page:
+                    document = copy.deepcopy(row["json"])
+                    result = migrate_document(
+                        table,
+                        document,
+                        type_aliases=type_aliases,
+                        lcia_review_map=lcia_review_map,
+                        unresolved_lifecycle_version=args.unresolved_lifecycle_version,
+                        current_version=row["version"],
+                        row_id=row["id"],
+                        version_index=version_index,
+                    )
+                    yield table, row, result
+                if args.progress_every_pages and pages % args.progress_every_pages == 0:
+                    print(
+                        json.dumps(
+                            {
+                                "phase": phase,
+                                "table": table,
+                                "event": "progress",
+                                "pages": pages,
+                                "rows": rows_seen,
+                            },
+                            sort_keys=True,
+                        ),
+                        file=sys.stderr,
+                        flush=True,
+                    )
+            print(
+                json.dumps(
+                    {
+                        "phase": phase,
+                        "table": table,
+                        "event": "table_done",
+                        "pages": pages,
+                        "rows": rows_seen,
+                    },
+                    sort_keys=True,
+                ),
+                file=sys.stderr,
+                flush=True,
+            )
+
+
+def cmd_scan(args) -> int:
+    # scan intentionally uses the same planner but does not write.
+    return cmd_plan(args, phase="scan")
+
+
+def cmd_plan(args, phase: str = "plan") -> int:
+    handle, should_close = open_output(args.out)
+    try:
+        counts: dict[str, int] = {}
+        for table, row, result in iter_plan_results(args, phase):
+            counts[result.status] = counts.get(result.status, 0) + 1
+            if result.status != "clean" or args.emit_clean:
+                event = build_row_event(
+                    run_id=args.run_id,
+                    phase=phase,
+                    table=table,
+                    row=row,
+                    result=result,
+                    include_hashes=args.event_hashes,
+                    compact=args.compact_events,
+                )
+                write_event(handle, event)
+        print(json.dumps({"phase": phase, "counts": counts}, sort_keys=True), file=sys.stderr)
+    finally:
+        if should_close:
+            handle.close()
+    return 0
+
+
+def _chunks(items: list[Any], size: int) -> Iterable[list[Any]]:
+    for index in range(0, len(items), size):
+        yield items[index : index + size]
+
+
+def cmd_apply(args) -> int:
+    db_url = resolve_db_url(args.environment, args.database_url)
+    type_aliases = load_type_aliases(args.type_map)
+    lcia_review_map = load_lcia_review_map(args.lcia_review_map)
+    handle, should_close = open_output(args.out)
+    counts: dict[str, int] = {}
+    try:
+        with connect(db_url) as conn:
+            conn.autocommit = False
+            with conn.cursor() as cur:
+                cur.execute("set statement_timeout = '5min'")
+            for table in parse_tables(args.tables):
+                pages = 0
+                rows_seen = 0
+                print(
+                    json.dumps(
+                        {
+                            "phase": "apply",
+                            "dryRun": args.dry_run,
+                            "table": table,
+                            "event": "table_start",
+                        },
+                        sort_keys=True,
+                    ),
+                    file=sys.stderr,
+                    flush=True,
+                )
+                for page in iter_rows(conn, table, page_size=args.page_size, all_rows=args.all_rows):
+                    pages += 1
+                    rows_seen += len(page)
+                    version_index = fetch_version_index(
+                        conn,
+                        collect_version_lookup_ids(
+                            table=table,
+                            rows=page,
+                            type_aliases=_merged_type_aliases(type_aliases),
+                        ),
+                    )
+                    planned: list[tuple[dict[str, Any], MigrationResult]] = []
+                    for row in page:
+                        result = migrate_document(
+                            table,
+                            copy.deepcopy(row["json"]),
+                            type_aliases=type_aliases,
+                            lcia_review_map=lcia_review_map,
+                            unresolved_lifecycle_version=args.unresolved_lifecycle_version,
+                            current_version=row["version"],
+                            row_id=row["id"],
+                            version_index=version_index,
+                        )
+                        if result.status not in ("planned", "delete_planned"):
+                            counts[result.status] = counts.get(result.status, 0) + 1
+                            if result.status != "clean" or args.emit_clean:
+                                event = build_row_event(
+                                    run_id=args.run_id,
+                                    phase="apply",
+                                    table=table,
+                                    row=row,
+                                    result=result,
+                                    include_hashes=args.event_hashes,
+                                    compact=args.compact_events,
+                                )
+                                write_event(handle, event)
+                            continue
+                        planned.append((row, result))
+
+                    for batch in _chunks(planned, args.batch_size):
+                        try:
+                            with conn.transaction():
+                                with conn.cursor() as cur:
+                                    cur.execute("set local statement_timeout = '30s'")
+                                    cur.execute("set local lock_timeout = '3s'")
+                                    if args.suppress_user_triggers:
+                                        cur.execute("set local session_replication_role = replica")
+                                    for row, result in batch:
+                                        event = build_row_event(
+                                            run_id=args.run_id,
+                                            phase="apply",
+                                            table=table,
+                                            row=row,
+                                            result=result,
+                                            include_hashes=args.event_hashes,
+                                            compact=args.compact_events,
+                                        )
+                                        if result.status == "delete_planned":
+                                            cur.execute(
+                                                f"""
+                                                delete from public.{table}
+                                                where id = %s::uuid
+                                                  and version = %s::character(9)
+                                                  and xmin = %s::xid
+                                                returning id::text as deleted_id
+                                                """,
+                                                (row["id"], row["version"], row["row_xmin"]),
+                                            )
+                                            updated = cur.fetchall()
+                                            if len(updated) != 1:
+                                                raise RuntimeError(
+                                                    f"expected one row delete for {table} {row['id']} {row['version']}, got {len(updated)}"
+                                                )
+                                            event["newVersion"] = None
+                                            event["status"] = "rolled_back" if args.dry_run else "deleted"
+                                            counts[event["status"]] = counts.get(event["status"], 0) + 1
+                                            write_event(handle, event)
+                                            continue
+
+                                        payload = json.dumps(result.document, ensure_ascii=False, separators=(",", ":"))
+                                        if args.suppress_user_triggers:
+                                            new_row_version = _dataset_version(table, result.document) or row["version"]
+                                            cur.execute(
+                                                f"""
+                                                update public.{table}
+                                                set json_ordered = %s::json,
+                                                    json = %s::jsonb,
+                                                    version = %s::character(9),
+                                                    modified_at = now()
+                                                where id = %s::uuid
+                                                  and version = %s::character(9)
+                                                  and xmin = %s::xid
+                                                returning trim(version::text) as new_version
+                                                """,
+                                                (
+                                                    payload,
+                                                    payload,
+                                                    new_row_version,
+                                                    row["id"],
+                                                    row["version"],
+                                                    row["row_xmin"],
+                                                ),
+                                            )
+                                        else:
+                                            cur.execute(
+                                                f"""
+                                                update public.{table}
+                                                set json_ordered = %s::json
+                                                where id = %s::uuid
+                                                  and version = %s::character(9)
+                                                  and xmin = %s::xid
+                                                returning trim(version::text) as new_version
+                                                """,
+                                                (payload, row["id"], row["version"], row["row_xmin"]),
+                                            )
+                                        updated = cur.fetchall()
+                                        if len(updated) != 1:
+                                            raise RuntimeError(
+                                                f"expected one row update for {table} {row['id']} {row['version']}, got {len(updated)}"
+                                            )
+                                        event["newVersion"] = updated[0]["new_version"]
+                                        event["status"] = "rolled_back" if args.dry_run else "written"
+                                        counts[event["status"]] = counts.get(event["status"], 0) + 1
+                                        write_event(handle, event)
+                                if args.dry_run:
+                                    raise _DryRunRollback()
+                        except _DryRunRollback:
+                            conn.rollback()
+                        except Exception as exc:
+                            conn.rollback()
+                            for row, result in batch:
+                                event = build_row_event(
+                                    run_id=args.run_id,
+                                    phase="apply",
+                                    table=table,
+                                    row=row,
+                                    result=result,
+                                    include_hashes=args.event_hashes,
+                                    compact=args.compact_events,
+                                )
+                                event["status"] = "write_conflict"
+                                event["error"] = str(exc)
+                                counts["write_conflict"] = counts.get("write_conflict", 0) + 1
+                                write_event(handle, event)
+                            if not args.continue_on_error:
+                                print(json.dumps({"phase": "apply", "counts": counts}, sort_keys=True), file=sys.stderr)
+                                return 1
+                    if args.progress_every_pages and pages % args.progress_every_pages == 0:
+                        print(
+                            json.dumps(
+                                {
+                                    "phase": "apply",
+                                    "dryRun": args.dry_run,
+                                    "table": table,
+                                    "event": "progress",
+                                    "pages": pages,
+                                    "rows": rows_seen,
+                                    "counts": counts,
+                                },
+                                sort_keys=True,
+                            ),
+                            file=sys.stderr,
+                            flush=True,
+                        )
+                print(
+                    json.dumps(
+                        {
+                            "phase": "apply",
+                            "dryRun": args.dry_run,
+                            "table": table,
+                            "event": "table_done",
+                            "pages": pages,
+                            "rows": rows_seen,
+                            "counts": counts,
+                        },
+                        sort_keys=True,
+                    ),
+                    file=sys.stderr,
+                    flush=True,
+                )
+        print(json.dumps({"phase": "apply", "dryRun": args.dry_run, "counts": counts}, sort_keys=True), file=sys.stderr)
+        return 0
+    finally:
+        if should_close:
+            handle.close()
+
+
+class _DryRunRollback(Exception):
+    pass
+
+
+def cmd_validate(args) -> int:
+    db_url = resolve_db_url(args.environment, args.database_url)
+    handle, should_close = open_output(args.out)
+    counts: dict[str, int] = {}
+    try:
+        with connect(db_url) as conn:
+            for table in parse_tables(args.tables):
+                for page in iter_rows(conn, table, page_size=args.page_size, all_rows=args.all_rows):
+                    for row in page:
+                        issues = validate_required_rules(table, row["json"])
+                        status = "validation_failed" if issues else "clean"
+                        counts[status] = counts.get(status, 0) + 1
+                        if issues or args.emit_clean:
+                            write_event(
+                                handle,
+                                {
+                                    "runId": args.run_id,
+                                    "phase": "validate",
+                                    "table": table,
+                                    "id": row["id"],
+                                    "version": row["version"],
+                                    "status": status,
+                                    "issues": issues,
+                                },
+                            )
+        print(json.dumps({"phase": "validate", "counts": counts}, sort_keys=True), file=sys.stderr)
+        return 1 if counts.get("validation_failed") else 0
+    finally:
+        if should_close:
+            handle.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="TIDAS schema 2026-06 database data migration runner")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument("--database-url")
+        subparser.add_argument("--environment", default="dev", choices=("dev", "main", "local"))
+        subparser.add_argument("--run-id", required=True)
+        subparser.add_argument("--tables")
+        subparser.add_argument("--type-map")
+        subparser.add_argument("--lcia-review-map")
+        subparser.add_argument("--unresolved-lifecycle-version", default="00.00.001")
+        subparser.add_argument("--out")
+        subparser.add_argument("--emit-clean", action="store_true")
+        subparser.add_argument("--page-size", type=int, default=1000)
+        subparser.add_argument("--progress-every-pages", type=int, default=50)
+        subparser.add_argument("--all-rows", action="store_true")
+        subparser.add_argument("--event-hashes", action="store_true")
+        subparser.add_argument("--compact-events", action="store_true")
+
+    scan = subparsers.add_parser("scan")
+    add_common(scan)
+    scan.set_defaults(func=cmd_scan)
+
+    plan = subparsers.add_parser("plan")
+    add_common(plan)
+    plan.add_argument("--dry-run", action="store_true")
+    plan.set_defaults(func=cmd_plan)
+
+    apply = subparsers.add_parser("apply")
+    add_common(apply)
+    apply.add_argument("--batch-size", type=int, default=50)
+    apply.add_argument("--dry-run", action="store_true")
+    apply.add_argument("--continue-on-error", action="store_true")
+    apply.add_argument("--suppress-user-triggers", action="store_true")
+    apply.set_defaults(func=cmd_apply)
+
+    validate = subparsers.add_parser("validate")
+    add_common(validate)
+    validate.set_defaults(func=cmd_validate)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: b6c351231116fd0890d2e2d8186f6ec2e455fea0
+lastReviewedAt: 2026-06-26
+lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: b6c351231116fd0890d2e2d8186f6ec2e455fea0
+lastReviewedAt: 2026-06-26
+lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/tests/data_migrations/__init__.py
+++ b/tests/data_migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for dated data migration runners."""

--- a/tests/data_migrations/test_tidas_schema_202606.py
+++ b/tests/data_migrations/test_tidas_schema_202606.py
@@ -1,0 +1,639 @@
+import copy
+import unittest
+
+from scripts.data_migrations.tidas_schema_202606 import runner as migrate
+
+
+class TidasSchema202606MigrationTests(unittest.TestCase):
+    def test_normalize_version_common_shapes(self):
+        self.assertEqual(migrate.normalize_version("1"), "01.00.000")
+        self.assertEqual(migrate.normalize_version("1.0"), "01.00.000")
+        self.assertEqual(migrate.normalize_version("01.02"), "01.02")
+        self.assertEqual(migrate.normalize_version("01.02.003"), "01.02.003")
+        self.assertEqual(migrate.normalize_version("v3"), "03.00.000")
+        self.assertIsNone(migrate.normalize_version("2025-06"))
+
+    def test_migrates_global_reference_types_and_versions(self):
+        doc = {
+            "flowDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {"common:dataSetVersion": "1.0"}
+                },
+                "flowProperties": {
+                    "flowProperty": {
+                        "referenceToFlowPropertyDataSet": {
+                            "@type": "flowproperties data set",
+                            "@refObjectId": "00000000-0000-0000-0000-000000000001",
+                            "@version": "1",
+                        }
+                    }
+                },
+            }
+        }
+
+        result = migrate.migrate_document(
+            "flows",
+            copy.deepcopy(doc),
+            type_aliases={"flowproperties data set": "flow property data set"},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version="00.00.001",
+        )
+
+        ref = result.document["flowDataSet"]["flowProperties"]["flowProperty"][
+            "referenceToFlowPropertyDataSet"
+        ]
+        self.assertEqual(ref["@type"], "flow property data set")
+        self.assertEqual(ref["@version"], "01.00.000")
+        self.assertEqual(
+            result.document["flowDataSet"]["administrativeInformation"][
+                "publicationAndOwnership"
+            ]["common:dataSetVersion"],
+            "01.00.000",
+        )
+        self.assertEqual(result.status, "planned")
+        self.assertGreaterEqual(len(result.changes), 3)
+
+    def test_ambiguous_reference_type_requires_manual_review(self):
+        doc = {
+            "unitGroupDataSet": {
+                "reference": {
+                    "@type": "2322333333333333",
+                    "@refObjectId": "00000000-0000-0000-0000-000000000001",
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "unitgroups",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+        )
+
+        self.assertEqual(result.status, "manual_required")
+        self.assertEqual(
+            result.document["unitGroupDataSet"]["reference"]["@type"],
+            "2322333333333333",
+        )
+        self.assertTrue(any(issue["rule"] == "A1_reference_type" for issue in result.issues))
+
+    def test_missing_dataset_version_uses_approved_initial_version_when_no_collision(self):
+        doc = {
+            "flowDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {}
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "flows",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            current_version="",
+            version_index={
+                "flows": {
+                    "00000000-0000-0000-0000-000000000010": {""}
+                }
+            },
+            row_id="00000000-0000-0000-0000-000000000010",
+        )
+
+        publication = result.document["flowDataSet"]["administrativeInformation"][
+            "publicationAndOwnership"
+        ]
+        self.assertEqual(publication["common:dataSetVersion"], "01.00.000")
+        self.assertEqual(result.status, "planned")
+        self.assertFalse(any(issue["rule"] == "A2_dataset_version" for issue in result.issues))
+
+    def test_missing_dataset_version_creates_missing_publication_container(self):
+        doc = {"flowPropertyDataSet": {}}
+
+        result = migrate.migrate_document(
+            "flowproperties",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            current_version="",
+            version_index={
+                "flowproperties": {
+                    "00000000-0000-0000-0000-000000000013": {""}
+                }
+            },
+            row_id="00000000-0000-0000-0000-000000000013",
+        )
+
+        publication = result.document["flowPropertyDataSet"]["administrativeInformation"][
+            "publicationAndOwnership"
+        ]
+        self.assertEqual(publication["common:dataSetVersion"], "01.00.000")
+        self.assertEqual(result.status, "planned")
+
+    def test_dataset_version_parent_container_type_mismatch_stays_manual(self):
+        doc = {"flowPropertyDataSet": {"administrativeInformation": "bad"}}
+
+        result = migrate.migrate_document(
+            "flowproperties",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            current_version="",
+            version_index={
+                "flowproperties": {
+                    "00000000-0000-0000-0000-000000000014": {""}
+                }
+            },
+            row_id="00000000-0000-0000-0000-000000000014",
+        )
+
+        self.assertEqual(result.status, "manual_required")
+        self.assertTrue(any(issue["rule"] == "A2_dataset_version" for issue in result.issues))
+
+    def test_prefixed_root_key_is_normalized_before_dataset_version_backfill(self):
+        doc = {"f:flowDataSet": {}}
+
+        result = migrate.migrate_document(
+            "flows",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            current_version="",
+            version_index={"flows": {"00000000-0000-0000-0000-000000000015": {""}}},
+            row_id="00000000-0000-0000-0000-000000000015",
+        )
+
+        self.assertNotIn("f:flowDataSet", result.document)
+        self.assertIn("flowDataSet", result.document)
+        self.assertEqual(
+            result.document["flowDataSet"]["administrativeInformation"][
+                "publicationAndOwnership"
+            ]["common:dataSetVersion"],
+            "01.00.000",
+        )
+        self.assertEqual(result.status, "planned")
+        self.assertTrue(any(change["rule"] == "A9_dataset_root_key" for change in result.changes))
+
+    def test_empty_json_dataset_is_marked_for_delete(self):
+        result = migrate.migrate_document(
+            "sources",
+            {},
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            current_version="",
+            version_index={"sources": {"00000000-0000-0000-0000-000000000016": {""}}},
+            row_id="00000000-0000-0000-0000-000000000016",
+        )
+
+        self.assertEqual(result.status, "delete_planned")
+        self.assertTrue(any(change["rule"] == "D1_empty_json_delete" for change in result.changes))
+
+    def test_missing_dataset_version_remains_manual_when_default_version_collides(self):
+        doc = {
+            "flowDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {}
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "flows",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            current_version="",
+            version_index={
+                "flows": {
+                    "00000000-0000-0000-0000-000000000010": {"", "01.00.000"}
+                }
+            },
+            row_id="00000000-0000-0000-0000-000000000010",
+        )
+
+        self.assertEqual(result.status, "manual_required")
+        self.assertTrue(any(issue["rule"] == "A2_dataset_version" for issue in result.issues))
+
+    def test_empty_dataset_version_uses_approved_initial_version_when_no_collision(self):
+        doc = {
+            "processDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {"common:dataSetVersion": ""}
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "processes",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            current_version="",
+            version_index={
+                "processes": {
+                    "00000000-0000-0000-0000-000000000011": {""}
+                }
+            },
+            row_id="00000000-0000-0000-0000-000000000011",
+        )
+
+        self.assertEqual(
+            result.document["processDataSet"]["administrativeInformation"][
+                "publicationAndOwnership"
+            ]["common:dataSetVersion"],
+            "01.00.000",
+        )
+        self.assertEqual(result.status, "planned")
+
+    def test_comma_dataset_version_is_normalized_when_no_collision(self):
+        doc = {
+            "processDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {"common:dataSetVersion": "01,01.000"}
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "processes",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            current_version="01,01.000",
+            version_index={
+                "processes": {
+                    "00000000-0000-0000-0000-000000000012": {"01,01.000"}
+                }
+            },
+            row_id="00000000-0000-0000-0000-000000000012",
+        )
+
+        self.assertEqual(
+            result.document["processDataSet"]["administrativeInformation"][
+                "publicationAndOwnership"
+            ]["common:dataSetVersion"],
+            "01.01.000",
+        )
+        self.assertEqual(result.status, "planned")
+
+    def test_reference_type_is_repaired_from_approved_path_mapping_not_value_alias(self):
+        doc = {
+            "processDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {"common:dataSetVersion": "01.00.000"}
+                },
+                "modellingAndValidation": {
+                    "complianceDeclarations": {
+                        "compliance": {
+                            "common:referenceToComplianceSystem": {
+                                "@type": "Compliance system",
+                                "@refObjectId": "00000000-0000-0000-0000-000000000020",
+                                "@version": "01.00.000",
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "processes",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+        )
+
+        ref = result.document["processDataSet"]["modellingAndValidation"][
+            "complianceDeclarations"
+        ]["compliance"]["common:referenceToComplianceSystem"]
+        self.assertEqual(ref["@type"], "source data set")
+        self.assertEqual(result.status, "planned")
+        self.assertFalse(any(issue["rule"] == "A1_reference_type" for issue in result.issues))
+
+    def test_untrusted_reference_type_value_stays_manual_on_unknown_path(self):
+        doc = {
+            "processDataSet": {
+                "someUnknownReference": {
+                    "@type": "Compliance system",
+                    "@refObjectId": "00000000-0000-0000-0000-000000000020",
+                    "@version": "01.00.000",
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "processes",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+        )
+
+        self.assertEqual(result.status, "manual_required")
+        self.assertEqual(
+            result.document["processDataSet"]["someUnknownReference"]["@type"],
+            "Compliance system",
+        )
+        self.assertTrue(any(issue["rule"] == "A1_reference_type" for issue in result.issues))
+
+    def test_invalid_reference_version_is_filled_from_unique_target_dataset_version(self):
+        doc = {
+            "lifeCycleModelDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {"common:dataSetVersion": "01.00.000"}
+                },
+                "lifeCycleModelInformation": {
+                    "technology": {
+                        "processes": {
+                            "processInstance": {
+                                "referenceToProcess": {
+                                    "@type": "process data set",
+                                    "@refObjectId": "00000000-0000-0000-0000-000000000030",
+                                    "@version": "         ",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "lifecyclemodels",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            version_index={
+                "processes": {
+                    "00000000-0000-0000-0000-000000000030": {"01.02.003"}
+                }
+            },
+        )
+
+        ref = result.document["lifeCycleModelDataSet"]["lifeCycleModelInformation"][
+            "technology"
+        ]["processes"]["processInstance"]["referenceToProcess"]
+        self.assertEqual(ref["@version"], "01.02.003")
+        self.assertEqual(result.status, "planned")
+        self.assertFalse(any(issue["rule"] == "A2_reference_version" for issue in result.issues))
+
+    def test_invalid_reference_version_stays_manual_when_target_has_multiple_versions(self):
+        doc = {
+            "lifeCycleModelDataSet": {
+                "administrativeInformation": {
+                    "publicationAndOwnership": {"common:dataSetVersion": "01.00.000"}
+                },
+                "lifeCycleModelInformation": {
+                    "technology": {
+                        "processes": {
+                            "processInstance": {
+                                "referenceToProcess": {
+                                    "@type": "process data set",
+                                    "@refObjectId": "00000000-0000-0000-0000-000000000030",
+                                    "@version": "",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "lifecyclemodels",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+            version_index={
+                "processes": {
+                    "00000000-0000-0000-0000-000000000030": {"01.00.000", "01.02.003"}
+                }
+            },
+        )
+
+        ref = result.document["lifeCycleModelDataSet"]["lifeCycleModelInformation"][
+            "technology"
+        ]["processes"]["processInstance"]["referenceToProcess"]
+        self.assertEqual(ref["@version"], "01.02.003")
+        self.assertEqual(result.status, "planned")
+        self.assertFalse(any(issue["rule"] == "A2_reference_version" for issue in result.issues))
+
+    def test_reference_type_is_repaired_from_dataset_reference_field_name(self):
+        doc = {
+            "flowDataSet": {
+                "flowProperties": {
+                    "flowProperty": {
+                        "referenceToFlowPropertyDataSet": {
+                            "@type": "asdaaaaaaaaaaaaaaa",
+                            "@refObjectId": "00000000-0000-0000-0000-000000000050",
+                            "@version": "01.00.000",
+                        }
+                    }
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "flows",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+        )
+
+        ref = result.document["flowDataSet"]["flowProperties"]["flowProperty"][
+            "referenceToFlowPropertyDataSet"
+        ]
+        self.assertEqual(ref["@type"], "flow property data set")
+        self.assertFalse(any(issue["rule"] == "A1_reference_type" for issue in result.issues))
+
+    def test_version_lookup_collection_ignores_invalid_reference_uuid(self):
+        rows = [
+            {
+                "id": "00000000-0000-0000-0000-000000000040",
+                "json": {
+                    "flowDataSet": {
+                        "administrativeInformation": {
+                            "dataEntryBy": {
+                                "common:referenceToDataSetFormat": {
+                                    "@type": "source data set",
+                                    "@refObjectId": "",
+                                    "@version": "",
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        ]
+
+        lookup_ids = migrate.collect_version_lookup_ids(
+            table="flows",
+            rows=rows,
+            type_aliases={},
+        )
+
+        self.assertEqual(
+            lookup_ids,
+            {"flows": {"00000000-0000-0000-0000-000000000040"}},
+        )
+
+    def test_lcia_boolean_and_uncertainty_key_migration(self):
+        doc = {
+            "LCIAMethodDataSet": {
+                "modellingAndValidation": {
+                    "LCIAMethod": {
+                        "normalisationAndWeighting": {
+                            "normalisation": "true",
+                            "weighting": "false",
+                        },
+                        "characterisationFactors": {
+                            "factor": [
+                                {"uncertaintyType": "normal"},
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "lciamethods",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+        )
+
+        naw = result.document["LCIAMethodDataSet"]["modellingAndValidation"][
+            "LCIAMethod"
+        ]["normalisationAndWeighting"]
+        factor = result.document["LCIAMethodDataSet"]["modellingAndValidation"][
+            "LCIAMethod"
+        ]["characterisationFactors"]["factor"][0]
+        self.assertIs(naw["normalisation"], True)
+        self.assertIs(naw["weighting"], False)
+        self.assertNotIn("uncertaintyType", factor)
+        self.assertEqual(factor["uncertaintyDistributionType"], "normal")
+
+    def test_process_location_codes_are_rewritten_on_location_fields_only(self):
+        doc = {
+            "processDataSet": {
+                "processInformation": {
+                    "geography": {
+                        "locationOfOperationSupplyOrProduction": {
+                            "@location": "CN-HK",
+                            "#text": "CN-HK should remain in prose",
+                        },
+                        "subLocationOfOperationSupplyOrProduction": {
+                            "@location": "CN-TW"
+                        },
+                    }
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "processes",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+        )
+
+        geography = result.document["processDataSet"]["processInformation"]["geography"]
+        self.assertEqual(
+            geography["locationOfOperationSupplyOrProduction"]["@location"], "HK"
+        )
+        self.assertEqual(
+            geography["subLocationOfOperationSupplyOrProduction"]["@location"], "TW"
+        )
+        self.assertEqual(
+            geography["locationOfOperationSupplyOrProduction"]["#text"],
+            "CN-HK should remain in prose",
+        )
+
+    def test_lifecycle_model_integer_and_missing_versions(self):
+        doc = {
+            "lifeCycleModelDataSet": {
+                "lifeCycleModelInformation": {
+                    "quantitativeReference": {
+                        "referenceToReferenceProcess": "12"
+                    },
+                    "technology": {
+                        "processes": {
+                            "processInstance": {
+                                "connections": {
+                                    "outputExchange": {
+                                        "@flowUUID": "00000000-0000-0000-0000-000000000001",
+                                        "downstreamProcess": {
+                                            "@id": "1",
+                                            "@flowUUID": "00000000-0000-0000-0000-000000000002",
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "lifecyclemodels",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version="00.00.001",
+        )
+
+        root = result.document["lifeCycleModelDataSet"]["lifeCycleModelInformation"]
+        self.assertEqual(root["quantitativeReference"]["referenceToReferenceProcess"], 12)
+        output = root["technology"]["processes"]["processInstance"]["connections"][
+            "outputExchange"
+        ]
+        self.assertEqual(output["@version"], "00.00.001")
+        self.assertEqual(output["downstreamProcess"]["@version"], "00.00.001")
+
+    def test_lifecycle_model_leading_zero_reference_process_is_manual(self):
+        doc = {
+            "lifeCycleModelDataSet": {
+                "lifeCycleModelInformation": {
+                    "quantitativeReference": {
+                        "referenceToReferenceProcess": "007"
+                    }
+                }
+            }
+        }
+
+        result = migrate.migrate_document(
+            "lifecyclemodels",
+            copy.deepcopy(doc),
+            type_aliases={},
+            lcia_review_map=migrate.LciaReviewMap(scope={}, method={}),
+            unresolved_lifecycle_version=None,
+        )
+
+        self.assertEqual(result.status, "manual_required")
+        self.assertEqual(
+            result.document["lifeCycleModelDataSet"]["lifeCycleModelInformation"][
+                "quantitativeReference"
+            ]["referenceToReferenceProcess"],
+            "007",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes tiangong-lca/database-engine#226

## Summary

- Promote `database-engine` `dev` to `main` after PR #225 landed in `dev`.
- Carry the TIDAS schema 2026-06 data migration runner, tests, README updates, and local artifact ignore rules onto the production/release line.

## Key Decisions

- This promote does not include any new `supabase/migrations/**`, `supabase/config.toml`, seed, or GitHub workflow changes.
- Production Supabase GitHub integration may still observe the `main` branch advance, but there are no checked-in pending schema migrations in this promote diff.
- Root workspace integration remains separate and should happen only after this promote exists on `database-engine/main`.

## Validation

- `git fetch origin dev main`
- `git log --oneline --decorate origin/main..origin/dev`
- `git diff --name-status origin/main..origin/dev`
- `git merge-tree origin/main origin/dev`
- PR #225 checks passed before this promote: `Gitleaks Security Scan`, `Supabase Preview`.

## Risks / Rollback

Low schema risk: the promote only moves repository tooling/docs/tests for the migration runner to `main`; it does not add a database migration file.

Rollback, if needed, should be a normal revert PR on `main`, followed by back-merge alignment according to the database-engine M2 branch policy.

## Follow-ups

- Confirm `main` advances after merge.
- Perform root workspace submodule integration separately after `database-engine/main` contains the promoted commit.

## Workspace Integration

Pending after this PR merges.
