### PR TITLE
feat(identity-center): identity_center SSO 集成表(additive + 休眠)

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-26"
-lastReviewedCommit: "8fff106adf1e559b5fd4df6ad8ac578e8c8e57de"
+lastReviewedAt: "2026-07-04"
+lastReviewedCommit: "a8aef0bc7bb89333a30d22da10d7269107d38f44"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-26
-lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
+lastReviewedAt: 2026-07-04
+lastReviewedCommit: a8aef0bc7bb89333a30d22da10d7269107d38f44
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-26
-lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
+lastReviewedAt: 2026-07-04
+lastReviewedCommit: a8aef0bc7bb89333a30d22da10d7269107d38f44
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-26
-lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
+lastReviewedAt: 2026-07-04
+lastReviewedCommit: a8aef0bc7bb89333a30d22da10d7269107d38f44
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: b6c351231116fd0890d2e2d8186f6ec2e455fea0
+lastReviewedAt: 2026-07-04
+lastReviewedCommit: a8aef0bc7bb89333a30d22da10d7269107d38f44
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: b6c351231116fd0890d2e2d8186f6ec2e455fea0
+lastReviewedAt: 2026-07-04
+lastReviewedCommit: a8aef0bc7bb89333a30d22da10d7269107d38f44
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/supabase/migrations/20260704120000_identity_center_sso_tables.sql
+++ b/supabase/migrations/20260704120000_identity_center_sso_tables.sql
@@ -1,0 +1,39 @@
+-- Identity Center (IC) SSO integration: local user mapping + webhook idempotency tables.
+--
+-- Additive and dormant. These two tables are created on every deployment but are only
+-- read/written by the identity_center edge functions (identity_login_sync /
+-- identity_center_webhook) when IC authentication is enabled. Deployments that do not use
+-- IC auth simply carry two empty, unused tables; no existing object is modified.
+--
+-- Access model: RLS is enabled with NO policies, and table access is granted only to
+-- service_role (used by the edge functions, which additionally bypass RLS). anon and
+-- authenticated get no grants — the cross-system identity mapping is service-side only.
+-- keycloak_sub (the Keycloak `sub`) is the cross-system identity key; email is never used.
+
+create table if not exists public.identity_center_users (
+    keycloak_sub text not null,
+    user_id uuid,
+    status character varying(32) default 'active'::character varying not null,
+    desired_role character varying(64),
+    metadata jsonb default '{}'::jsonb,
+    created_at timestamp with time zone default now(),
+    modified_at timestamp with time zone,
+    constraint identity_center_users_pkey primary key (keycloak_sub),
+    constraint identity_center_users_user_id_key unique (user_id),
+    constraint identity_center_users_user_id_fkey foreign key (user_id) references auth.users (id)
+);
+
+alter table public.identity_center_users owner to postgres;
+alter table public.identity_center_users enable row level security;
+grant all on table public.identity_center_users to service_role;
+
+create table if not exists public.identity_center_processed_events (
+    event_id text not null,
+    event_type text not null,
+    processed_at timestamp with time zone default now(),
+    constraint identity_center_processed_events_pkey primary key (event_id)
+);
+
+alter table public.identity_center_processed_events owner to postgres;
+alter table public.identity_center_processed_events enable row level security;
+grant all on table public.identity_center_processed_events to service_role;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-26
-lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
+lastReviewedAt: 2026-07-04
+lastReviewedCommit: a8aef0bc7bb89333a30d22da10d7269107d38f44
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-26
-lastReviewedCommit: 8fff106adf1e559b5fd4df6ad8ac578e8c8e57de
+lastReviewedAt: 2026-07-04
+lastReviewedCommit: a8aef0bc7bb89333a30d22da10d7269107d38f44
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/schemas/public/tables/identity_center_processed_events/table.sql
+++ b/supabase/workspace/schemas/public/tables/identity_center_processed_events/table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "public"."identity_center_processed_events" (
+    "event_id" "text" NOT NULL,
+    "event_type" "text" NOT NULL,
+    "processed_at" timestamp with time zone DEFAULT "now"()
+);
+
+ALTER TABLE "public"."identity_center_processed_events" OWNER TO "postgres";
+
+COMMENT ON TABLE "public"."identity_center_processed_events" IS 'Identity Center webhook idempotency ledger (dedupe by platform event id). Service-role only: RLS enabled with no policies.';
+
+ALTER TABLE ONLY "public"."identity_center_processed_events"
+    ADD CONSTRAINT "identity_center_processed_events_pkey" PRIMARY KEY ("event_id");
+
+ALTER TABLE "public"."identity_center_processed_events" ENABLE ROW LEVEL SECURITY;
+
+GRANT ALL ON TABLE "public"."identity_center_processed_events" TO "service_role";

--- a/supabase/workspace/schemas/public/tables/identity_center_users/table.sql
+++ b/supabase/workspace/schemas/public/tables/identity_center_users/table.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS "public"."identity_center_users" (
+    "keycloak_sub" "text" NOT NULL,
+    "user_id" "uuid",
+    "status" character varying(32) DEFAULT 'active'::character varying NOT NULL,
+    "desired_role" character varying(64),
+    "metadata" "jsonb" DEFAULT '{}'::"jsonb",
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "modified_at" timestamp with time zone
+);
+
+ALTER TABLE "public"."identity_center_users" OWNER TO "postgres";
+
+COMMENT ON TABLE "public"."identity_center_users" IS 'Identity Center SSO local user mapping (keycloak_sub is the cross-system key; email is never used). Service-role only: RLS enabled with no policies.';
+
+ALTER TABLE ONLY "public"."identity_center_users"
+    ADD CONSTRAINT "identity_center_users_pkey" PRIMARY KEY ("keycloak_sub");
+
+ALTER TABLE ONLY "public"."identity_center_users"
+    ADD CONSTRAINT "identity_center_users_user_id_key" UNIQUE ("user_id");
+
+ALTER TABLE ONLY "public"."identity_center_users"
+    ADD CONSTRAINT "identity_center_users_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id");
+
+ALTER TABLE "public"."identity_center_users" ENABLE ROW LEVEL SECURITY;
+
+GRANT ALL ON TABLE "public"."identity_center_users" TO "service_role";


### PR DESCRIPTION
## 目的

为统一身份平台(Identity Center)SSO 接入新增两张业务应用侧表,供 identity_center 边缘函数(`identity_login_sync` / `identity_center_webhook`,见 linancn/tiangong-lca-edge-functions PR)使用。首个消费方 TianGong LCA。

## 新增

- `supabase/migrations/20260704120000_identity_center_sso_tables.sql`(可部署迁移):
  - `public.identity_center_users` —— `keycloak_sub`(跨系统身份键,PK)↔ 本地 `user_id`(FK auth.users)映射 + `status` + `desired_role`;
  - `public.identity_center_processed_events` —— webhook 幂等去重(`event_id` PK)。
- `supabase/workspace/schemas/public/tables/…/table.sql` × 2 —— 声明式 schema truth(手写以匹配惯例;维护者可按仓库工具从远端刷新/重新生成校准)。

## 安全 / 兼容性(对不使用 IC 的部署)

- **additive、休眠、不修改任何现有对象**:`create table if not exists`;不动现有表/策略/函数。
- 访问模型:**RLS 启用、无策略**,仅 `grant … to service_role`(边缘函数用,且 service_role 绕过 RLS);**不授 anon/authenticated** —— 身份映射仅服务端可见。
- 未启用 IC 认证的部署仅多两张**空的、未使用的**表,行为不变。
- 跨系统身份键恒为 `keycloak_sub`,不用 email。

## 验证

- 迁移已在**隔离 scratch 库**(带最小 auth.users)真跑通:两表创建、PK/UNIQUE/FK 约束、RLS 启用、service_role grant 全部正确;单事务无错。
- docpact gate `lint: pass`。

## 说明

声明式 schema 文件为手写近似(正常由仓库工具从远端 DB 生成)。合并前维护者可用 database-engine 工具刷新 workspace 校准列序/grant 细节;可部署的**迁移**已独立验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)