### PR TITLE
fix: preserve nested nulls in worker job payloads

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-12"
-lastReviewedCommit: "ceee1433d9cef649865a191e9bc2afed25452d4f"
+lastReviewedAt: "2026-07-13"
+lastReviewedCommit: "22efdb533b3ea3f30c0746852ebdccbd49a8ddd5"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-12
-lastReviewedCommit: ce99778b79134aaa7d4318be054ddc1bd98ea6ac
+lastReviewedAt: 2026-07-13
+lastReviewedCommit: 22efdb533b3ea3f30c0746852ebdccbd49a8ddd5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-12
-lastReviewedCommit: ce99778b79134aaa7d4318be054ddc1bd98ea6ac
+lastReviewedAt: 2026-07-13
+lastReviewedCommit: 22efdb533b3ea3f30c0746852ebdccbd49a8ddd5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-12
-lastReviewedCommit: ce99778b79134aaa7d4318be054ddc1bd98ea6ac
+lastReviewedAt: 2026-07-13
+lastReviewedCommit: 22efdb533b3ea3f30c0746852ebdccbd49a8ddd5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260713080636_preserve_worker_job_nested_nulls.sql
+++ b/supabase/migrations/20260713080636_preserve_worker_job_nested_nulls.sql
@@ -1,0 +1,78 @@
+-- Preserve semantic null values inside worker payloads and result documents.
+--
+-- jsonb_strip_nulls() is recursive. Applying it to the complete worker-job
+-- envelope changed nested business JSON such as {"is": null} into {}, which
+-- invalidated integrity-bound payloads after they were claimed. Filter only
+-- top-level JSON nulls so optional envelope fields remain omitted without
+-- rewriting any nested document.
+
+create or replace function public.worker_job_payload(
+  p_job public.worker_jobs,
+  p_include_internal boolean default false
+) returns jsonb
+language sql
+stable
+set search_path = public, pg_temp
+as $$
+  select coalesce(
+    jsonb_object_agg(entry.key, entry.value)
+      filter (where entry.value <> 'null'::jsonb),
+    '{}'::jsonb
+  )
+  from jsonb_each(
+    jsonb_build_object(
+      'id', (p_job).id,
+      'jobKind', (p_job).job_kind,
+      'workerRuntime', (p_job).worker_runtime,
+      'workerQueue', (p_job).worker_queue,
+      'priority', (p_job).priority,
+      'queueKey', (p_job).queue_key,
+      'rootJobId', (p_job).root_job_id,
+      'parentJobId', (p_job).parent_job_id,
+      'subjectType', (p_job).subject_type,
+      'subjectId', (p_job).subject_id,
+      'subjectVersion', (p_job).subject_version,
+      'requesterType', (p_job).requester_type,
+      'requestedBy', (p_job).requested_by,
+      'teamId', (p_job).team_id,
+      'idempotencyKey', (p_job).idempotency_key,
+      'requestHash', (p_job).request_hash,
+      'concurrencyKey', (p_job).concurrency_key,
+      'status', (p_job).status,
+      'phase', (p_job).phase,
+      'progress', (p_job).progress,
+      'visibility', (p_job).visibility,
+      'runAfter', to_jsonb((p_job).run_after),
+      'attemptCount', (p_job).attempt_count,
+      'maxAttempts', (p_job).max_attempts,
+      'leasedBy', case when p_include_internal then (p_job).leased_by else null end,
+      'leaseToken', case when p_include_internal then (p_job).lease_token else null end,
+      'leaseExpiresAt', case when p_include_internal then to_jsonb((p_job).lease_expires_at) else null end,
+      'heartbeatAt', to_jsonb((p_job).heartbeat_at),
+      'timeoutAt', to_jsonb((p_job).timeout_at),
+      'payloadSchemaVersion', (p_job).payload_schema_version,
+      'payload', case when p_include_internal then (p_job).payload_json else null end,
+      'payloadRef', case when p_include_internal then (p_job).payload_ref else null end,
+      'resultSchemaVersion', (p_job).result_schema_version,
+      'result', (p_job).result_json,
+      'resultRef', case when p_include_internal then (p_job).result_ref else null end,
+      'diagnostics', case when p_include_internal then (p_job).diagnostics else null end,
+      'errorCode', (p_job).error_code,
+      'errorMessage', (p_job).error_message,
+      'errorDetails', case when p_include_internal then (p_job).error_details else null end,
+      'blockerCodes', to_jsonb((p_job).blocker_codes),
+      'resolutionScope', (p_job).resolution_scope,
+      'retryable', (p_job).retryable,
+      'createdAt', to_jsonb((p_job).created_at),
+      'updatedAt', to_jsonb((p_job).updated_at),
+      'startedAt', to_jsonb((p_job).started_at),
+      'finishedAt', to_jsonb((p_job).finished_at),
+      'expiresAt', to_jsonb((p_job).expires_at),
+      'cancelledAt', to_jsonb((p_job).cancelled_at),
+      'cancelledBy', (p_job).cancelled_by
+    )
+  ) as entry(key, value)
+$$;
+
+revoke all on function public.worker_job_payload(public.worker_jobs, boolean)
+  from public, anon, authenticated;

--- a/supabase/tests/20260531_worker_jobs_foundation.sql
+++ b/supabase/tests/20260531_worker_jobs_foundation.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(42);
+select plan(46);
 
 select ok(to_regclass('public.worker_job_kinds') is not null, 'worker job kind registry exists');
 select ok(to_regclass('public.worker_jobs') is not null, 'worker_jobs table exists');
@@ -219,6 +219,102 @@ from (
     p_concurrency_key => 'snapshot-gc:test:dry-run'
   ) as result
 ) as enqueue;
+
+insert into worker_job_test_ids (label, job_id)
+select
+  'nested_null_payload',
+  (result->'data'->>'id')::uuid
+from (
+  select public.worker_enqueue_job(
+    p_job_kind => 'lca.build_snapshot',
+    p_payload_json => '{
+      "scope_manifest": {
+        "schema_version": "lca.data_scope.manifest.v1",
+        "scope": "public_plus_owner_draft",
+        "actor": {
+          "kind": "authenticated_user",
+          "user_id": "96000000-0000-4000-8000-000000000001"
+        },
+        "owner_draft_collaboration_guards": {
+          "processes": {
+            "team_id": {"is": null},
+            "review_id": {"is": null}
+          },
+          "flows": {
+            "team_id": {"is": null},
+            "review_id": {"is": null}
+          }
+        }
+      }
+    }'::jsonb,
+    p_payload_schema_version => 'lca.build_snapshot.request.v2',
+    p_requested_by => '96000000-0000-4000-8000-000000000001',
+    p_visibility => 'operator',
+    p_idempotency_key => 'worker-job:nested-null-payload'
+  ) as result
+) as enqueue;
+
+update public.worker_jobs
+set payload_ref = '{"nested":{"is":null}}'::jsonb,
+    result_json = '{"nested":{"is":null}}'::jsonb,
+    result_ref = '{"nested":{"is":null}}'::jsonb,
+    diagnostics = '{"nested":{"is":null}}'::jsonb,
+    error_details = '{"nested":{"is":null}}'::jsonb
+where id = (select job_id from worker_job_test_ids where label = 'nested_null_payload');
+
+select is(
+  (
+    select public.worker_job_payload(j, true)->'payload'
+    from public.worker_jobs as j
+    where id = (select job_id from worker_job_test_ids where label = 'nested_null_payload')
+  ),
+  (
+    select payload_json
+    from public.worker_jobs
+    where id = (select job_id from worker_job_test_ids where label = 'nested_null_payload')
+  ),
+  'internal projection preserves the exact payload including frozen nested null guards'
+);
+
+select is(
+  (
+    select
+      public.worker_job_payload(j, true) #> '{payloadRef,nested,is}' = 'null'::jsonb
+      and public.worker_job_payload(j, true) #> '{result,nested,is}' = 'null'::jsonb
+      and public.worker_job_payload(j, true) #> '{resultRef,nested,is}' = 'null'::jsonb
+      and public.worker_job_payload(j, true) #> '{diagnostics,nested,is}' = 'null'::jsonb
+      and public.worker_job_payload(j, true) #> '{errorDetails,nested,is}' = 'null'::jsonb
+    from public.worker_jobs as j
+    where id = (select job_id from worker_job_test_ids where label = 'nested_null_payload')
+  ),
+  true,
+  'internal projection preserves nested nulls in other internal JSON documents'
+);
+
+select is(
+  (
+    select public.worker_job_payload(j, true) ? 'teamId'
+    from public.worker_jobs as j
+    where id = (select job_id from worker_job_test_ids where label = 'nested_null_payload')
+  ),
+  false,
+  'internal projection still omits optional top-level null fields'
+);
+
+select is(
+  public.worker_claim_jobs(
+    p_worker_queue => 'solver',
+    p_worker_id => 'worker-null-preservation',
+    p_limit => 1,
+    p_lease_seconds => 300
+  )->'data'->0->'payload',
+  (
+    select payload_json
+    from public.worker_jobs
+    where id = (select job_id from worker_job_test_ids where label = 'nested_null_payload')
+  ),
+  'claim preserves the exact payload including frozen nested null guards'
+);
 
 select is(
   jsonb_array_length(


### PR DESCRIPTION
## Summary

- replace recursive envelope-wide `jsonb_strip_nulls` in `worker_job_payload` with top-level-only JSON-null filtering
- preserve integrity-bound nested JSON in payload, payload refs, results, diagnostics, and error details
- add a production-shaped frozen-scope regression fixture through both direct projection and `worker_claim_jobs`
- keep optional top-level null fields omitted and keep Worker fail-closed validation unchanged

Closes #242

## Key decision

The database claim projection is the mutation point. The stored job payload is correct; recursive null stripping changes each frozen `{"is": null}` guard to `{}` before the Worker receives it. The fix therefore belongs in database-engine. It does not relax the Worker manifest comparison or trust a hash without structural validation.

## Validation

- `npx --yes supabase@latest --version` → `2.109.1`
- `npx --yes supabase@latest start` → local stack healthy/already running
- `npx --yes supabase@latest db reset` → all migrations through `20260713080636` applied successfully
- `npx --yes supabase@latest test db supabase/tests/20260531_worker_jobs_foundation.sql` → 46/46 passing
- `npx --yes supabase@latest migration list --local` → local history aligned through `20260713080636`
- `scripts/docpact-gate.sh --base origin/dev` → strict config and enforced lint pass
- `npx --yes supabase@latest db lint --local --schema public --level error --fail-on error` → reports the existing unrelated baseline of 9 legacy-function errors; no issue references `worker_job_payload` or this migration

## Deferred environment proof

- PR preview branch migration/checks
- persistent Supabase `dev` migration after merge into Git `dev`
- production migration after governed `dev -> main` promotion
- fresh isolated private-LCIA smoke and root workspace pointer integration

## Risk and rollback

The migration replaces one stable projection function without changing tables, rows, grants, RLS, claim ordering, or authorization. If rollback is required, ship a follow-up migration restoring the prior projection function; do not edit migration history or production rows manually.
