### PR TITLE
[Release] Promote json_ordered derivative rebuilding

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-13"
-lastReviewedCommit: "22efdb533b3ea3f30c0746852ebdccbd49a8ddd5"
+lastReviewedCommit: "9ca0e371642e43596a970bebbb8313481ecdcd9e"
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-13
-lastReviewedCommit: 22efdb533b3ea3f30c0746852ebdccbd49a8ddd5
+lastReviewedCommit: 9ca0e371642e43596a970bebbb8313481ecdcd9e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-13
-lastReviewedCommit: 22efdb533b3ea3f30c0746852ebdccbd49a8ddd5
+lastReviewedCommit: 9ca0e371642e43596a970bebbb8313481ecdcd9e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-13
-lastReviewedCommit: 22efdb533b3ea3f30c0746852ebdccbd49a8ddd5
+lastReviewedCommit: 9ca0e371642e43596a970bebbb8313481ecdcd9e
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260713150223_json_ordered_derivative_webhooks.sql
+++ b/supabase/migrations/20260713150223_json_ordered_derivative_webhooks.sql
@@ -1,0 +1,25 @@
+-- Dataset commands treat json_ordered as the writable source document and
+-- synchronize json in a BEFORE trigger. PostgreSQL column-specific UPDATE
+-- triggers only consider columns named by the original UPDATE statement, so
+-- the markdown webhook must explicitly cover both writable representations.
+
+drop trigger if exists flow_extract_md_trigger_update on public.flows;
+create trigger flow_extract_md_trigger_update
+after update of json, json_ordered on public.flows
+for each row
+when (new.json is distinct from old.json)
+execute function util.invoke_edge_webhook('webhook_flow_embedding_ft', '1000');
+
+drop trigger if exists lifecyclemodel_extract_md_trigger_update on public.lifecyclemodels;
+create trigger lifecyclemodel_extract_md_trigger_update
+after update of json, json_ordered on public.lifecyclemodels
+for each row
+when (new.json is distinct from old.json)
+execute function util.invoke_edge_webhook('webhook_model_embedding_ft', '1000');
+
+drop trigger if exists process_extract_md_trigger_update on public.processes;
+create trigger process_extract_md_trigger_update
+after update of json, json_ordered on public.processes
+for each row
+when (new.json is distinct from old.json)
+execute function util.invoke_edge_webhook('webhook_process_embedding_ft', '1000');

--- a/supabase/tests/20260404_dataset_command_rpcs.sql
+++ b/supabase/tests/20260404_dataset_command_rpcs.sql
@@ -20,7 +20,34 @@ begin
 end;
 $$;
 
-select plan(13);
+create temporary table command_derivative_webhook_calls (
+  edge_function text not null,
+  body jsonb not null,
+  timeout_milliseconds integer not null
+) on commit drop;
+
+grant select on pg_temp.command_derivative_webhook_calls to authenticated;
+
+create or replace function util.invoke_edge_function(
+  name text,
+  body jsonb,
+  timeout_milliseconds integer default ((5 * 60) * 1000)
+) returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into pg_temp.command_derivative_webhook_calls (
+    edge_function,
+    body,
+    timeout_milliseconds
+  )
+  values (name, body, timeout_milliseconds);
+end;
+$$;
+
+select plan(15);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -143,9 +170,7 @@ values (
   true
 );
 
-alter table public.processes disable trigger "processes_json_sync_trigger";
 alter table public.processes disable trigger "process_extract_md_trigger_insert";
-alter table public.processes disable trigger "process_extract_md_trigger_update";
 select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
 select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_update');
 
@@ -296,6 +321,49 @@ select is(
 );
 
 select is(
+  (
+    select count(*)::text
+    from pg_temp.command_derivative_webhook_calls
+    where edge_function = 'webhook_process_embedding_ft'
+      and body->>'table' = 'processes'
+      and body->>'type' = 'UPDATE'
+      and timeout_milliseconds = 1000
+  ),
+  '1',
+  'changed process draft save invokes markdown extraction exactly once'
+);
+
+with replay as materialized (
+  select public.cmd_dataset_save_draft(
+    p_table => 'processes',
+    p_id => '31000000-0000-0000-0000-000000000003',
+    p_version => '01.00.000',
+    p_json_ordered => '{
+      "processDataSet": {
+        "administrativeInformation": {
+          "publicationAndOwnership": {
+            "common:dataSetVersion": "01.00.000"
+          }
+        }
+      }
+    }'::jsonb,
+    p_audit => '{}'::jsonb
+  ) as result
+)
+select ok(
+  (select result->>'ok' = 'true' from replay)
+  and (
+    select count(*) = 1
+    from pg_temp.command_derivative_webhook_calls
+    where edge_function = 'webhook_process_embedding_ft'
+      and body->>'table' = 'processes'
+      and body->>'type' = 'UPDATE'
+      and timeout_milliseconds = 1000
+  ),
+  'same-payload draft save succeeds without duplicating markdown extraction'
+);
+
+select is(
   public.cmd_dataset_save_draft(
     'sources',
     '31000000-0000-0000-0000-000000000002',
@@ -370,7 +438,7 @@ select is(
      'cmd_dataset_assign_team',
      'cmd_dataset_publish'
    )),
-  '4',
+  '5',
   'successful dataset commands write command_audit_log entries'
 );
 

--- a/supabase/tests/20260711_guarded_dataset_alias_batch.sql
+++ b/supabase/tests/20260711_guarded_dataset_alias_batch.sql
@@ -574,7 +574,32 @@ as $$
   select public.cmd_dataset_alias_batch_guarded(p_batch);
 $$;
 
-select plan(78);
+create temporary table alias_derivative_webhook_calls (
+  edge_function text not null,
+  body jsonb not null,
+  timeout_milliseconds integer not null
+) on commit drop;
+
+create or replace function util.invoke_edge_function(
+  name text,
+  body jsonb,
+  timeout_milliseconds integer default ((5 * 60) * 1000)
+) returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into pg_temp.alias_derivative_webhook_calls (
+    edge_function,
+    body,
+    timeout_milliseconds
+  )
+  values (name, body, timeout_milliseconds);
+end;
+$$;
+
+select plan(81);
 
 alter table public.flowproperties
   disable trigger zz_flowproperties_extracted_text_sync_trigger;
@@ -589,8 +614,6 @@ alter table public.flows
 alter table public.flows
   disable trigger flow_embedding_ft_on_extract_md_update;
 alter table public.flows
-  disable trigger flow_extract_md_trigger_update;
-alter table public.flows
   disable trigger zz_flows_extracted_text_sync_trigger;
 alter table public.flows
   disable trigger flows_set_modified_at_trigger;
@@ -598,8 +621,6 @@ alter table public.processes
   disable trigger process_embedding_ft_on_extract_md_update;
 alter table public.processes
   disable trigger process_extract_md_trigger_insert;
-alter table public.processes
-  disable trigger process_extract_md_trigger_update;
 alter table public.processes
   disable trigger zz_processes_extracted_text_sync_trigger;
 alter table public.processes
@@ -1966,6 +1987,8 @@ set user_id = 'c1000000-0000-0000-0000-000000000001'
 where id = pg_temp.alias_entity_id('time', 'flow', 1)
   and version = '01.00.000';
 
+truncate pg_temp.alias_derivative_webhook_calls;
+
 set local role authenticated;
 select set_config(
   'request.jwt.claim.sub',
@@ -1994,6 +2017,12 @@ from (
 ) as failed;
 
 reset role;
+
+select is(
+  (select count(*)::integer from pg_temp.alias_derivative_webhook_calls),
+  0,
+  'forced second-dimension failure rolls back every queued derivative webhook'
+);
 
 select is(
   (
@@ -2119,6 +2148,19 @@ reset role;
 select is(
   (
     select count(*)::text
+      || ':' || count(*) filter (where body->>'table' = 'flows')::text
+      || ':' || count(*) filter (where body->>'table' = 'processes')::text
+    from pg_temp.alias_derivative_webhook_calls
+    where body->>'type' = 'UPDATE'
+      and timeout_milliseconds = 1000
+  ),
+  '50:23:27',
+  'full-plan success queues exactly 23 flow and 27 process derivative webhooks'
+);
+
+select is(
+  (
+    select count(*)::text
     from public.flowproperties
     where id = pg_temp.alias_entity_id('time', 'source_flowproperty')
       and json_ordered::jsonb = pg_temp.alias_flow_after_payload('time')
@@ -2237,6 +2279,12 @@ from (
 ) as replay;
 
 reset role;
+
+select is(
+  (select count(*)::integer from pg_temp.alias_derivative_webhook_calls),
+  50,
+  'full-plan replay queues no duplicate derivative webhooks'
+);
 
 select is(
   (

--- a/supabase/tests/20260713_json_ordered_derivative_webhooks.sql
+++ b/supabase/tests/20260713_json_ordered_derivative_webhooks.sql
@@ -1,0 +1,426 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create temporary table derivative_webhook_calls (
+  edge_function text not null,
+  body jsonb not null,
+  timeout_milliseconds integer not null
+) on commit drop;
+
+-- Keep the real trigger function and payload construction in the test path,
+-- but replace the final pg_net boundary transactionally with a deterministic
+-- call ledger. ROLLBACK restores the production implementation.
+create or replace function util.invoke_edge_function(
+  name text,
+  body jsonb,
+  timeout_milliseconds integer default ((5 * 60) * 1000)
+) returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  insert into pg_temp.derivative_webhook_calls (
+    edge_function,
+    body,
+    timeout_milliseconds
+  )
+  values (name, body, timeout_milliseconds);
+end;
+$$;
+
+create or replace function pg_temp.trigger_update_columns(
+  p_table regclass,
+  p_trigger_name text
+) returns text
+language sql
+stable
+as $$
+  select string_agg(att.attname, ', ' order by att.attnum)
+  from pg_trigger trg
+  cross join lateral unnest(trg.tgattr::smallint[]) a(attnum)
+  join pg_attribute att
+    on att.attrelid = trg.tgrelid
+   and att.attnum = a.attnum
+  where trg.tgrelid = p_table
+    and trg.tgname = p_trigger_name
+    and not trg.tgisinternal
+  group by trg.oid;
+$$;
+
+select plan(18);
+
+select is(
+  pg_temp.trigger_update_columns(
+    'public.flows'::regclass,
+    'flow_extract_md_trigger_update'
+  ),
+  'json, json_ordered',
+  'flow markdown extraction covers direct and ordered JSON updates'
+);
+
+select is(
+  pg_temp.trigger_update_columns(
+    'public.processes'::regclass,
+    'process_extract_md_trigger_update'
+  ),
+  'json, json_ordered',
+  'process markdown extraction covers direct and ordered JSON updates'
+);
+
+select is(
+  pg_temp.trigger_update_columns(
+    'public.lifecyclemodels'::regclass,
+    'lifecyclemodel_extract_md_trigger_update'
+  ),
+  'json, json_ordered',
+  'lifecycle model markdown extraction covers direct and ordered JSON updates'
+);
+
+select is(
+  (
+    with expected(table_name, trigger_name, edge_function_name) as (
+      values
+        ('flows', 'flow_extract_md_trigger_update', 'webhook_flow_embedding_ft'),
+        ('processes', 'process_extract_md_trigger_update', 'webhook_process_embedding_ft'),
+        ('lifecyclemodels', 'lifecyclemodel_extract_md_trigger_update', 'webhook_model_embedding_ft')
+    )
+    select count(*)::integer
+    from expected e
+    join pg_class c on c.relname = e.table_name
+    join pg_namespace cn on cn.oid = c.relnamespace and cn.nspname = 'public'
+    join pg_trigger t on t.tgrelid = c.oid and t.tgname = e.trigger_name
+    join pg_proc p on p.oid = t.tgfoid
+    join pg_namespace pn on pn.oid = p.pronamespace
+    where not t.tgisinternal
+      and pn.nspname = 'util'
+      and p.proname = 'invoke_edge_webhook'
+      and lower(replace(pg_get_triggerdef(t.oid, true), '"', ''))
+        like '%after update of json, json_ordered%'
+      and lower(replace(pg_get_triggerdef(t.oid, true), '"', ''))
+        like '%new.json is distinct from old.json%'
+      and pg_get_triggerdef(t.oid, true) like '%' || e.edge_function_name || '%'
+      and pg_get_triggerdef(t.oid, true) like '%''1000''%'
+  ),
+  3,
+  'all three update hooks preserve timing, no-op guard, function, target, and timeout'
+);
+
+alter table public.flows disable trigger flow_dataset_extraction_trigger_insert;
+alter table public.processes disable trigger process_extract_md_trigger_insert;
+alter table public.lifecyclemodels disable trigger lifecyclemodel_extract_md_trigger_insert;
+
+insert into public.flows (id, version, json_ordered)
+values (
+  'e7100000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{
+    "flowDataSet": {
+      "flowInformation": {
+        "dataSetInformation": {
+          "common:UUID": "e7100000-0000-0000-0000-000000000001"
+        }
+      },
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json
+);
+
+insert into public.processes (id, version, json_ordered)
+values (
+  'e7200000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{
+    "processDataSet": {
+      "processInformation": {
+        "dataSetInformation": {
+          "common:UUID": "e7200000-0000-0000-0000-000000000001"
+        }
+      },
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json
+);
+
+insert into public.lifecyclemodels (id, version, json_ordered)
+values (
+  'e7300000-0000-0000-0000-000000000001',
+  '01.00.000',
+  '{
+    "lifeCycleModelDataSet": {
+      "lifeCycleModelInformation": {
+        "dataSetInformation": {
+          "common:UUID": "e7300000-0000-0000-0000-000000000001"
+        }
+      },
+      "administrativeInformation": {
+        "publicationAndOwnership": {
+          "common:dataSetVersion": "01.00.000"
+        }
+      }
+    }
+  }'::json
+);
+
+alter table public.flows enable trigger flow_dataset_extraction_trigger_insert;
+alter table public.processes enable trigger process_extract_md_trigger_insert;
+alter table public.lifecyclemodels enable trigger lifecyclemodel_extract_md_trigger_insert;
+
+truncate pg_temp.derivative_webhook_calls;
+
+update public.flows
+set json = jsonb_set(json, '{derivativeProbe}', '"direct-json"')
+where id = 'e7100000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.processes
+set json = jsonb_set(json, '{derivativeProbe}', '"direct-json"')
+where id = 'e7200000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.lifecyclemodels
+set json = jsonb_set(json, '{derivativeProbe}', '"direct-json"')
+where id = 'e7300000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+select is(
+  (select count(*)::integer from pg_temp.derivative_webhook_calls),
+  3,
+  'direct json changes invoke one webhook per dataset table'
+);
+
+select is(
+  (
+    select count(distinct body->>'table')::integer
+    from pg_temp.derivative_webhook_calls
+    where body->>'type' = 'UPDATE'
+  ),
+  3,
+  'direct json webhook payloads identify all three updated tables'
+);
+
+select is(
+  (
+    select count(distinct edge_function)::integer
+    from pg_temp.derivative_webhook_calls
+    where timeout_milliseconds = 1000
+  ),
+  3,
+  'direct json webhook calls retain the three exact Edge targets and timeout'
+);
+
+truncate pg_temp.derivative_webhook_calls;
+
+update public.flows
+set json_ordered = jsonb_set(json_ordered::jsonb, '{derivativeProbe}', '"ordered-json"')::json
+where id = 'e7100000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.processes
+set json_ordered = jsonb_set(json_ordered::jsonb, '{derivativeProbe}', '"ordered-json"')::json
+where id = 'e7200000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.lifecyclemodels
+set json_ordered = jsonb_set(json_ordered::jsonb, '{derivativeProbe}', '"ordered-json"')::json
+where id = 'e7300000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+select is(
+  (select count(*)::integer from pg_temp.derivative_webhook_calls),
+  3,
+  'json_ordered changes invoke one webhook per dataset table'
+);
+
+select is(
+  (
+    select count(distinct body->>'table')::integer
+    from pg_temp.derivative_webhook_calls
+    where body->>'type' = 'UPDATE'
+  ),
+  3,
+  'json_ordered webhook payloads identify all three updated tables'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from public.flows
+    where id = 'e7100000-0000-0000-0000-000000000001'
+      and json = json_ordered::jsonb
+      and extracted_text is not distinct from
+        util.dataset_json_search_text('flows', json)
+  ),
+  1,
+  'flow ordered JSON keeps json and extracted_text synchronized'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from public.processes
+    where id = 'e7200000-0000-0000-0000-000000000001'
+      and json = json_ordered::jsonb
+      and extracted_text is not distinct from
+        util.dataset_json_search_text('processes', json)
+  ),
+  1,
+  'process ordered JSON keeps json and extracted_text synchronized'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from public.lifecyclemodels
+    where id = 'e7300000-0000-0000-0000-000000000001'
+      and json = json_ordered::jsonb
+      and extracted_text is not distinct from
+        util.dataset_json_search_text('lifecyclemodels', json)
+  ),
+  1,
+  'lifecycle model ordered JSON keeps json and extracted_text synchronized'
+);
+
+truncate pg_temp.derivative_webhook_calls;
+
+update public.flows
+set json = jsonb_set(json, '{derivativeProbe}', '"both-columns"'),
+    json_ordered = jsonb_set(json_ordered::jsonb, '{derivativeProbe}', '"both-columns"')::json
+where id = 'e7100000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.processes
+set json = jsonb_set(json, '{derivativeProbe}', '"both-columns"'),
+    json_ordered = jsonb_set(json_ordered::jsonb, '{derivativeProbe}', '"both-columns"')::json
+where id = 'e7200000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.lifecyclemodels
+set json = jsonb_set(json, '{derivativeProbe}', '"both-columns"'),
+    json_ordered = jsonb_set(json_ordered::jsonb, '{derivativeProbe}', '"both-columns"')::json
+where id = 'e7300000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+select is(
+  (select count(*)::integer from pg_temp.derivative_webhook_calls),
+  3,
+  'one UPDATE naming both JSON columns invokes only once per row'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from (
+      select body->>'table'
+      from pg_temp.derivative_webhook_calls
+      group by body->>'table'
+      having count(*) = 1
+    ) exactly_once
+  ),
+  3,
+  'both-column updates produce one call for each dataset table'
+);
+
+truncate pg_temp.derivative_webhook_calls;
+
+update public.flows
+set json_ordered = json_ordered
+where id = 'e7100000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.processes
+set json_ordered = json_ordered
+where id = 'e7200000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.lifecyclemodels
+set json_ordered = json_ordered
+where id = 'e7300000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+select is(
+  (select count(*)::integer from pg_temp.derivative_webhook_calls),
+  0,
+  'same-value ordered JSON updates do not invoke markdown extraction'
+);
+
+update public.flows
+set rule_verification = true
+where id = 'e7100000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.processes
+set rule_verification = true
+where id = 'e7200000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+update public.lifecyclemodels
+set rule_verification = true
+where id = 'e7300000-0000-0000-0000-000000000001'
+  and version = '01.00.000';
+
+select is(
+  (select count(*)::integer from pg_temp.derivative_webhook_calls),
+  0,
+  'unrelated changed columns do not invoke markdown extraction'
+);
+
+select is(
+  (
+    with expected(table_name, trigger_name, input_function) as (
+      values
+        ('flows', 'flow_embedding_ft_on_extract_md_update', 'flows_embedding_ft_input'),
+        ('processes', 'process_embedding_ft_on_extract_md_update', 'processes_embedding_ft_input'),
+        ('lifecyclemodels', 'lifecyclemodel_embedding_ft_on_extract_md_update', 'lifecyclemodels_embedding_ft_input')
+    )
+    select count(*)::integer
+    from expected e
+    join pg_class c on c.relname = e.table_name
+    join pg_namespace cn on cn.oid = c.relnamespace and cn.nspname = 'public'
+    join pg_trigger t on t.tgrelid = c.oid and t.tgname = e.trigger_name
+    join pg_proc p on p.oid = t.tgfoid
+    join pg_namespace pn on pn.oid = p.pronamespace
+    where not t.tgisinternal
+      and pn.nspname = 'util'
+      and p.proname = 'queue_embeddings'
+      and lower(replace(pg_get_triggerdef(t.oid, true), '"', ''))
+        like '%after update of extracted_md%'
+      and lower(replace(pg_get_triggerdef(t.oid, true), '"', ''))
+        like '%old.extracted_md is distinct from new.extracted_md%'
+      and pg_get_triggerdef(t.oid, true) like '%' || e.input_function || '%'
+  ),
+  3,
+  'downstream extracted_md-to-embedding triggers remain unchanged'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_trigger t
+    join pg_proc p on p.oid = t.tgfoid
+    join pg_namespace pn on pn.oid = p.pronamespace
+    where t.tgname in (
+      'flow_extract_md_trigger_update',
+      'process_extract_md_trigger_update',
+      'lifecyclemodel_extract_md_trigger_update'
+    )
+      and not t.tgisinternal
+      and pn.nspname = 'util'
+      and p.proname = 'invoke_edge_webhook'
+  ),
+  3,
+  'all update triggers remain attached to the governed webhook function'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Promote the database-engine dev release containing the minimal derivative-trigger correction from PR #247.

The release makes the flow, process, and lifecycle-model markdown hooks listen to both json and json_ordered while retaining the effective-payload change guard. It contains no BAFU data mutation.

## Persistent dev evidence

- Supabase Dev deployment run 29263085463 passed and applied migration 20260713150223.
- Direct readback from the persistent dev database confirms the migration row exists.
- Direct catalog readback confirms all three update triggers are AFTER UPDATE OF json, json_ordered.
- All three retain WHEN new.json IS DISTINCT FROM old.json and their existing Edge targets/timeouts.
- The schema-only dev branch contains zero rows for the BAFU owner across flows, processes, flowproperties, unitgroups, sources, and contacts.

## Validation inherited from PR #247

- Supabase Preview and Gitleaks passed.
- Local reset and 7 targeted pgTAP files / 184 tests passed.
- Direct new/command/alias suites passed 18/18, 15/15, and 81/81.
- Full local suite passed 52/53 files; the sole baseline ACL expectation is tracked separately in #230.
- DB lint, migration alignment, Docpact, diff checks, and independent review passed.

## Production gate

After merge, wait for production migration deployment, then perform a read-only production catalog and BAFU/audit fingerprint check. Only after that evidence may P0-A be re-frozen and a new exact approval artifact issued.

Closes #246