### PR TITLE
Allow review submit with shared under-review references

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-18"
-lastReviewedCommit: "04b85de6311260d92237c2472eb5cee57cc30baa"
-lastReviewedNote: "Reviewed PR269 outer-owned private temp, fsync-before-ACK recovery checkpoints, logout-before-delete retention, and 39-surface residue contracts; exact-head Hosted execution remains deferred."
+lastReviewedAt: "2026-07-21"
+lastReviewedCommit: "7215b23a56118f203f8826839227af2d6a849ef1"
+lastReviewedNote: "Reviewed issue #274 review-submit migration routing, ownership, and required proof; existing governance remains accurate."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-18
-lastReviewedCommit: 04b85de6311260d92237c2472eb5cee57cc30baa
-lastReviewedNote: "Reviewed PR269 outer-owned private temp, fsync-before-ACK recovery checkpoints, logout-before-delete retention, and 39-surface residue closure; exact-head Hosted execution remains deferred."
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: 7215b23a56118f203f8826839227af2d6a849ef1
+lastReviewedNote: "Reviewed issue #274 final review-submit boundary; root duplicate protection, comment-submit protection, and repo ownership remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-18
-lastReviewedCommit: 04b85de6311260d92237c2472eb5cee57cc30baa
-lastReviewedNote: "Reviewed PR269 outer-owned private temp, fsync-before-ACK recovery checkpoints, logout-before-delete Auth retention, and transaction-external 39-surface closure; exact-head Hosted execution remains deferred."
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: 7215b23a56118f203f8826839227af2d6a849ef1
+lastReviewedNote: "Reviewed issue #274 migration authoring through the stable workspace overlay and review-submit final assertion boundary; the path map remains accurate."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-18
-lastReviewedCommit: 04b85de6311260d92237c2472eb5cee57cc30baa
-lastReviewedNote: "Reviewed PR269 outer-owned private temp, durable recovery checkpoint/ACK, logout-before-delete retention, and 39-surface residue contracts; exact-head Hosted execution remains deferred."
+lastReviewedAt: 2026-07-21
+lastReviewedCommit: 7215b23a56118f203f8826839227af2d6a849ef1
+lastReviewedNote: "Reviewed issue #274 review-submit proof; the existing db reset plus RPC, job coordinator, and gate suites remain sufficient."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260721111242_allow_review_submit_referenced_data_under_review.sql
+++ b/supabase/migrations/20260721111242_allow_review_submit_referenced_data_under_review.sql
@@ -1,0 +1,557 @@
+CREATE OR REPLACE FUNCTION "public"."cmd_review_submit_without_gate"("p_table" "text", "p_id" "uuid", "p_version" "text", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'pg_temp'
+    AS $_$
+declare
+  v_actor uuid := auth.uid();
+  v_current record;
+  v_current_row jsonb;
+  v_current_state_code integer;
+  v_conflicting_version text;
+  v_conflicting_state integer;
+  v_root_row jsonb;
+  v_root_owner_id uuid;
+  v_review_id uuid := gen_random_uuid();
+  v_review_record public.reviews%rowtype;
+  v_review_json jsonb;
+  v_review_row jsonb;
+  v_team_name jsonb;
+  v_user_meta jsonb;
+  v_ref record;
+  v_ref_table text;
+  v_submodel jsonb;
+  v_paired_process_exists boolean;
+  v_paired_model_exists boolean;
+  v_affected_datasets jsonb := '[]'::jsonb;
+  v_updated_reviews jsonb;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table not in (
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table for review submission'
+    );
+  end if;
+
+  create temporary table if not exists cmd_review_submit_queue (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  create temporary table if not exists cmd_review_submit_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  truncate table cmd_review_submit_queue;
+  truncate table cmd_review_submit_targets;
+
+  insert into cmd_review_submit_queue (
+    table_name,
+    dataset_id,
+    dataset_version,
+    is_root
+  )
+  values (
+    p_table,
+    p_id,
+    p_version,
+    true
+  )
+  on conflict do nothing;
+
+  while exists (select 1 from cmd_review_submit_queue) loop
+    select
+      table_name,
+      dataset_id,
+      dataset_version,
+      is_root
+    into v_current
+    from cmd_review_submit_queue
+    order by is_root desc, table_name, dataset_id, dataset_version
+    limit 1;
+
+    delete from cmd_review_submit_queue
+    where table_name = v_current.table_name
+      and dataset_id = v_current.dataset_id
+      and dataset_version = v_current.dataset_version;
+
+    if exists (
+      select 1
+      from cmd_review_submit_targets
+      where table_name = v_current.table_name
+        and dataset_id = v_current.dataset_id
+        and dataset_version = v_current.dataset_version
+    ) then
+      continue;
+    end if;
+
+    v_current_row := public.cmd_review_get_dataset_row(
+      v_current.table_name,
+      v_current.dataset_id,
+      v_current.dataset_version,
+      true
+    );
+
+    if v_current_row is null then
+      if v_current.is_root then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'DATASET_NOT_FOUND',
+          'status', 404,
+          'message', 'Dataset not found'
+        );
+      end if;
+
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'REFERENCED_DATASET_NOT_FOUND',
+        'status', 409,
+        'message', 'Referenced dataset not found',
+        'details', jsonb_build_object(
+          'table', v_current.table_name,
+          'id', v_current.dataset_id,
+          'version', v_current.dataset_version
+        )
+      );
+    end if;
+
+    v_current_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+    if v_current.is_root then
+      v_root_row := v_current_row;
+      v_root_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+
+      if v_root_owner_id is distinct from v_actor then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'DATASET_OWNER_REQUIRED',
+          'status', 403,
+          'message', 'Only the dataset owner can submit review'
+        );
+      end if;
+
+      if v_current_state_code >= 100 then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'DATA_ALREADY_PUBLISHED',
+          'status', 403,
+          'message', 'Published data cannot be submitted for review',
+          'details', jsonb_build_object(
+            'state_code', v_current_state_code
+          )
+        );
+      end if;
+
+      if v_current_state_code >= 20 then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'DATA_UNDER_REVIEW',
+          'status', 403,
+          'message', 'Data is already under review',
+          'details', jsonb_build_object(
+            'state_code', 20,
+            'review_state_code', v_current_state_code
+          )
+        );
+      end if;
+    else
+      if v_current_state_code >= 100 then
+        if v_current.table_name = 'processes' then
+          v_paired_model_exists := public.cmd_review_get_dataset_row(
+            'lifecyclemodels',
+            v_current.dataset_id,
+            v_current.dataset_version,
+            false
+          ) is not null;
+
+          if v_paired_model_exists then
+            insert into cmd_review_submit_queue (
+              table_name,
+              dataset_id,
+              dataset_version,
+              is_root
+            )
+            values (
+              'lifecyclemodels',
+              v_current.dataset_id,
+              v_current.dataset_version,
+              false
+            )
+            on conflict do nothing;
+          end if;
+        end if;
+
+        continue;
+      end if;
+    end if;
+
+    execute format(
+      'select version, state_code
+         from public.%I
+        where id = $1
+          and version <> $2
+          and state_code >= 20
+          and state_code < 100
+        order by version desc
+        limit 1',
+      v_current.table_name
+    )
+      into v_conflicting_version, v_conflicting_state
+      using v_current.dataset_id, v_current.dataset_version;
+
+    if v_conflicting_version is not null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', case
+          when v_current.is_root then 'DATASET_VERSION_UNDER_REVIEW'
+          else 'REFERENCED_VERSION_UNDER_REVIEW'
+        end,
+        'status', case
+          when v_current.is_root then 403
+          else 409
+        end,
+        'message', case
+          when v_current.is_root then 'Another version of this dataset is already under review'
+          else 'Another version of a referenced dataset is already under review'
+        end,
+        'details', jsonb_build_object(
+          'table', v_current.table_name,
+          'id', v_current.dataset_id,
+          'version', v_current.dataset_version,
+          'under_review_version', v_conflicting_version,
+          'state_code', 20,
+          'review_state_code', v_conflicting_state
+        )
+      );
+    end if;
+
+    execute format(
+      'select version
+         from public.%I
+        where id = $1
+          and version > $2
+          and state_code = 100
+        order by version desc
+        limit 1',
+      v_current.table_name
+    )
+      into v_conflicting_version
+      using v_current.dataset_id, v_current.dataset_version;
+
+    if v_conflicting_version is not null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', case
+          when v_current.is_root then 'DATASET_VERSION_ALREADY_PUBLISHED'
+          else 'REFERENCED_VERSION_ALREADY_PUBLISHED'
+        end,
+        'status', case
+          when v_current.is_root then 403
+          else 409
+        end,
+        'message', case
+          when v_current.is_root then 'A newer published version of this dataset already exists'
+          else 'A newer published version of a referenced dataset already exists'
+        end,
+        'details', jsonb_build_object(
+          'table', v_current.table_name,
+          'id', v_current.dataset_id,
+          'version', v_current.dataset_version,
+          'published_version', v_conflicting_version,
+          'state_code', 100
+        )
+      );
+    end if;
+
+    insert into cmd_review_submit_targets (
+      table_name,
+      dataset_id,
+      dataset_version,
+      state_code,
+      reviews
+    )
+    values (
+      v_current.table_name,
+      v_current.dataset_id,
+      v_current.dataset_version,
+      v_current_state_code,
+      v_current_row->'reviews'
+    )
+    on conflict do nothing;
+
+    for v_ref in (
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json_ordered', '{}'::jsonb))
+      union
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json', '{}'::jsonb))
+      union
+      select *
+      from public.cmd_review_extract_refs(coalesce(v_current_row->'json_tg', '{}'::jsonb))
+    ) loop
+      v_ref_table := public.cmd_review_ref_type_to_table(v_ref.ref_type);
+
+      if v_ref_table is null then
+        continue;
+      end if;
+
+      if v_ref_table = v_current.table_name
+        and v_ref.ref_object_id = v_current.dataset_id
+        and v_ref.ref_version = v_current.dataset_version then
+        continue;
+      end if;
+
+      insert into cmd_review_submit_queue (
+        table_name,
+        dataset_id,
+        dataset_version,
+        is_root
+      )
+      values (
+        v_ref_table,
+        v_ref.ref_object_id,
+        v_ref.ref_version,
+        false
+      )
+      on conflict do nothing;
+    end loop;
+
+    if v_current.table_name = 'processes' and not v_current.is_root then
+      v_paired_model_exists := public.cmd_review_get_dataset_row(
+        'lifecyclemodels',
+        v_current.dataset_id,
+        v_current.dataset_version,
+        false
+      ) is not null;
+
+      if v_paired_model_exists then
+        insert into cmd_review_submit_queue (
+          table_name,
+          dataset_id,
+          dataset_version,
+          is_root
+        )
+        values (
+          'lifecyclemodels',
+          v_current.dataset_id,
+          v_current.dataset_version,
+          false
+        )
+        on conflict do nothing;
+      end if;
+    end if;
+
+    if v_current.table_name = 'lifecyclemodels' then
+      if v_current.is_root then
+        v_paired_process_exists := public.cmd_review_get_dataset_row(
+          'processes',
+          v_current.dataset_id,
+          v_current.dataset_version,
+          false
+        ) is not null;
+
+        if v_paired_process_exists then
+          insert into cmd_review_submit_queue (
+            table_name,
+            dataset_id,
+            dataset_version,
+            is_root
+          )
+          values (
+            'processes',
+            v_current.dataset_id,
+            v_current.dataset_version,
+            false
+          )
+          on conflict do nothing;
+        end if;
+      end if;
+
+      for v_submodel in
+        select value
+        from jsonb_array_elements(coalesce(v_current_row->'json_tg'->'submodels', '[]'::jsonb))
+      loop
+        if coalesce(v_submodel->>'type', '') <> 'secondary' then
+          continue;
+        end if;
+
+        if not ((v_submodel->>'id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') then
+          continue;
+        end if;
+
+        insert into cmd_review_submit_queue (
+          table_name,
+          dataset_id,
+          dataset_version,
+          is_root
+        )
+        values (
+          'processes',
+          (v_submodel->>'id')::uuid,
+          coalesce(nullif(v_submodel->>'version', ''), v_current.dataset_version),
+          false
+        )
+        on conflict do nothing;
+      end loop;
+    end if;
+  end loop;
+
+  select coalesce(t.json->'title', t.json->'name')
+    into v_team_name
+  from public.teams as t
+  where t.id = nullif(v_root_row->>'team_id', '')::uuid;
+
+  select u.raw_user_meta_data
+    into v_user_meta
+  from public.users as u
+  where u.id = v_actor;
+
+  v_review_json := jsonb_build_object(
+    'data', jsonb_build_object(
+      'id', p_id,
+      'version', p_version,
+      'name', public.cmd_review_get_dataset_name(p_table, v_root_row)
+    ),
+    'team', jsonb_build_object(
+      'id', nullif(v_root_row->>'team_id', ''),
+      'name', v_team_name
+    ),
+    'user', jsonb_build_object(
+      'id', v_actor,
+      'name', coalesce(nullif(v_user_meta->>'display_name', ''), nullif(v_user_meta->>'email', '')),
+      'email', nullif(v_user_meta->>'email', '')
+    ),
+    'comment', jsonb_build_object(
+      'message', ''
+    ),
+    'logs', jsonb_build_array(
+      jsonb_build_object(
+        'action', 'submit_review',
+        'time', to_jsonb(now()),
+        'user', jsonb_build_object(
+          'id', v_actor,
+          'display_name', coalesce(nullif(v_user_meta->>'display_name', ''), nullif(v_user_meta->>'email', ''))
+        )
+      )
+    )
+  );
+
+  insert into public.reviews (
+    id,
+    data_id,
+    data_version,
+    state_code,
+    reviewer_id,
+    json
+  )
+  values (
+    v_review_id,
+    p_id,
+    p_version,
+    0,
+    '[]'::jsonb,
+    v_review_json
+  )
+  returning *
+    into v_review_record;
+
+  for v_current in
+    select
+      table_name,
+      dataset_id,
+      dataset_version,
+      state_code,
+      reviews
+    from cmd_review_submit_targets
+    order by table_name, dataset_id, dataset_version
+  loop
+    v_updated_reviews := public.cmd_review_append_review_ref(v_current.reviews, v_review_id);
+
+    execute format(
+      'update public.%I
+          set state_code = $1,
+              reviews = $2
+        where id = $3
+          and version = $4',
+      v_current.table_name
+    )
+      using
+        greatest(v_current.state_code, 20),
+        v_updated_reviews,
+        v_current.dataset_id,
+        v_current.dataset_version;
+  end loop;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'table', table_name,
+        'id', dataset_id,
+        'version', dataset_version,
+        'state_code', greatest(state_code, 20)
+      )
+      order by table_name, dataset_id, dataset_version
+    ),
+    '[]'::jsonb
+  )
+    into v_affected_datasets
+  from cmd_review_submit_targets;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_review_submit',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'review_id', v_review_id,
+      'affected_datasets', v_affected_datasets
+    )
+  );
+
+  v_review_row := to_jsonb(v_review_record);
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', v_review_row,
+      'affected_datasets', v_affected_datasets
+    )
+  );
+end;
+$_$;
+
+ALTER FUNCTION "public"."cmd_review_submit_without_gate"("p_table" "text", "p_id" "uuid", "p_version" "text", "p_audit" "jsonb") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "public"."cmd_review_submit_without_gate"("p_table" "text", "p_id" "uuid", "p_version" "text", "p_audit" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "public"."cmd_review_submit_without_gate"("p_table" "text", "p_id" "uuid", "p_version" "text", "p_audit" "jsonb") TO "anon";

--- a/supabase/tests/20260404_review_submit_rpc.sql
+++ b/supabase/tests/20260404_review_submit_rpc.sql
@@ -20,7 +20,7 @@ begin
 end;
 $$;
 
-select plan(14);
+select plan(15);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -804,7 +804,7 @@ values (
         "dataSetInformation": {
           "name": {
             "baseName": [
-              { "@xml:lang": "en", "#text": "Blocked Process" }
+              { "@xml:lang": "en", "#text": "Shared Reference Process" }
             ]
           }
         }
@@ -828,7 +828,7 @@ values (
         "dataSetInformation": {
           "name": {
             "baseName": [
-              { "@xml:lang": "en", "#text": "Blocked Process" }
+              { "@xml:lang": "en", "#text": "Shared Reference Process" }
             ]
           }
         }
@@ -858,7 +858,7 @@ select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000001
 
 insert into review_submit_gate_ids (label, gate_run_id)
 select
-  'blocked_process',
+  'shared_reference_process',
   (
     public.cmd_dataset_review_submit_gate(
       p_table => 'processes',
@@ -875,9 +875,9 @@ reset role;
 set local role service_role;
 
 select public.cmd_dataset_review_submit_gate_record_result(
-  p_gate_run_id => (select gate_run_id from review_submit_gate_ids where label = 'blocked_process'),
+  p_gate_run_id => (select gate_run_id from review_submit_gate_ids where label = 'shared_reference_process'),
   p_status => 'passed',
-  p_calculator_report => '{"reportId":"blocked-process-gate-test","generatedAt":"2026-05-25T00:00:00Z"}'::jsonb,
+  p_calculator_report => '{"reportId":"shared-reference-process-gate-test","generatedAt":"2026-05-25T00:00:00Z"}'::jsonb,
   p_audit => '{"command":"dataset_review_submit_gate_record_result"}'::jsonb
 );
 
@@ -892,13 +892,13 @@ select is(
     p_id => '32000000-0000-0000-0000-000000000022',
     p_version => '01.00.000',
     p_audit => '{}'::jsonb,
-    p_review_submit_gate_run_id => (select gate_run_id from review_submit_gate_ids where label = 'blocked_process'),
+    p_review_submit_gate_run_id => (select gate_run_id from review_submit_gate_ids where label = 'shared_reference_process'),
     p_review_submit_revision_checksum => repeat('b', 64),
     p_review_submit_policy_profile => 'review_submit_fast.v1',
     p_review_submit_report_schema_version => 'review_submit_gate_report.v1'
-  )->>'code',
-  'REFERENCED_DATA_UNDER_REVIEW',
-  'review submission is blocked when a referenced dataset is already under review'
+  )->>'ok',
+  'true',
+  'review submission succeeds when a referenced dataset is already under review'
 );
 
 select is(
@@ -906,8 +906,17 @@ select is(
    from public.reviews
    where data_id = '32000000-0000-0000-0000-000000000022'
      and data_version = '01.00.000'),
-  '0',
-  'blocked review submission does not create a review row'
+  '1',
+  'review submission with an under-review reference creates one review row'
+);
+
+select is(
+  (select state_code::text
+   from public.flows
+   where id = '32000000-0000-0000-0000-000000000021'
+     and version = '01.00.000'),
+  '20',
+  'review submission preserves the referenced dataset under-review state'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes #274

## Summary
- Remove the final non-root REFERENCED_DATA_UNDER_REVIEW rejection from cmd_review_submit_without_gate.
- Preserve an existing referenced review state while continuing to promote draft targets to state 20.
- Replace the blocking regression with successful submission, review creation, and reference-state preservation assertions.

## Key Decisions
- Keep root DATA_UNDER_REVIEW duplicate-submit protection unchanged.
- Keep cmd_review_submit_comment referenced-data protection unchanged.

## Validation
- supabase db reset
- supabase migration list --local (20260721111242 recorded locally and in the database)
- 20260404_review_submit_rpc.sql: 15/15 passed
- 20260529_review_submit_jobs.sql: 21/21 passed
- 20260525_review_submit_gate_runs.sql: 20/20 passed
- Docpact strict pre-push validation and lint passed

## Risks / Rollback
- Rollback by deploying a follow-up function definition that restores the non-root active-review rejection.

## Follow-ups
- Refresh generated workspace inspection output from persistent dev after deployment.

## Workspace Integration
- After dev-to-main promotion, lca-workspace must deliberately bump the database-engine submodule pointer.