### PR TITLE
fix: restore production dataset withdrawal migration

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-21"
-lastReviewedCommit: "7215b23a56118f203f8826839227af2d6a849ef1"
-lastReviewedNote: "Reviewed issue #274 review-submit migration routing, ownership, and required proof; existing governance remains accurate."
+lastReviewedCommit: "c86556d46a311c3f3f7c2723f5093eb46ecda2d9"
+lastReviewedNote: "Reviewed issue #277 production migration-history recovery routing, ownership, and required proof; existing governance remains accurate."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 7215b23a56118f203f8826839227af2d6a849ef1
-lastReviewedNote: "Reviewed issue #274 final review-submit boundary; root duplicate protection, comment-submit protection, and repo ownership remain unchanged."
+lastReviewedCommit: c86556d46a311c3f3f7c2723f5093eb46ecda2d9
+lastReviewedNote: "Reviewed issue #277 production migration-history recovery; source-of-truth ownership, main hotfix, dev back-merge, and workspace integration rules remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,8 +28,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 7215b23a56118f203f8826839227af2d6a849ef1
-lastReviewedNote: "Reviewed issue #274 migration authoring through the stable workspace overlay and review-submit final assertion boundary; the path map remains accurate."
+lastReviewedCommit: c86556d46a311c3f3f7c2723f5093eb46ecda2d9
+lastReviewedNote: "Reviewed issue #277 production-only migration recovery through the authoritative migration path and main hotfix flow; the path map remains accurate."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-21
-lastReviewedCommit: 7215b23a56118f203f8826839227af2d6a849ef1
-lastReviewedNote: "Reviewed issue #274 review-submit proof; the existing db reset plus RPC, job coordinator, and gate suites remain sufficient."
+lastReviewedCommit: c86556d46a311c3f3f7c2723f5093eb46ecda2d9
+lastReviewedNote: "Reviewed issue #277 migration-history recovery proof; exact SQL fingerprinting, db reset, and migration-list verification remain sufficient."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260719110000_add_dataset_withdraw_command.sql
+++ b/supabase/migrations/20260719110000_add_dataset_withdraw_command.sql
@@ -1,0 +1,157 @@
+create or replace function public.cmd_dataset_withdraw(
+  p_table text,
+  p_id uuid,
+  p_version text,
+  p_reason text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_current_row jsonb;
+  v_owner_id uuid;
+  v_state_code integer;
+  v_updated_row jsonb;
+  v_reason text := btrim(coalesce(p_reason, ''));
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if p_table not in ('sources', 'flows', 'processes') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Only sources, flows, and processes can be withdrawn'
+    );
+  end if;
+
+  if v_reason = '' or length(v_reason) > 4000 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_WITHDRAW_REASON',
+      'status', 400,
+      'message', 'A non-empty withdrawal reason of at most 4000 characters is required'
+    );
+  end if;
+
+  if jsonb_typeof(coalesce(p_audit, '{}'::jsonb)) <> 'object' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_AUDIT_PAYLOAD',
+      'status', 400,
+      'message', 'Audit payload must be a JSON object'
+    );
+  end if;
+
+  execute format(
+    'select to_jsonb(t)
+       from public.%I as t
+      where t.id = $1
+        and t.version = $2
+      for update of t',
+    p_table
+  )
+    into v_current_row
+    using p_id, p_version;
+
+  if v_current_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  v_owner_id := nullif(v_current_row->>'user_id', '')::uuid;
+  v_state_code := coalesce((v_current_row->>'state_code')::integer, 0);
+
+  if v_owner_id is distinct from v_actor then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_OWNER_REQUIRED',
+      'status', 403,
+      'message', 'Only the dataset owner can withdraw this dataset'
+    );
+  end if;
+
+  if v_state_code = 0 then
+    return jsonb_build_object(
+      'ok', true,
+      'changed', false,
+      'code', 'DATASET_ALREADY_DRAFT',
+      'data', v_current_row
+    );
+  end if;
+
+  if v_state_code < 100 or v_state_code >= 200 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_WITHDRAW_REQUIRES_PUBLISHED_STATE',
+      'status', 403,
+      'message', 'Only public datasets in state 100 through 199 can be withdrawn',
+      'details', jsonb_build_object(
+        'state_code', v_state_code
+      )
+    );
+  end if;
+
+  execute format(
+    'update public.%I as t
+        set state_code = 0,
+            rule_verification = false,
+            modified_at = now()
+      where t.id = $1
+        and t.version = $2
+    returning to_jsonb(t)',
+    p_table
+  )
+    into v_updated_row
+    using p_id, p_version;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_dataset_withdraw',
+    v_actor,
+    p_table,
+    p_id,
+    p_version,
+    coalesce(p_audit, '{}'::jsonb)
+      || jsonb_build_object(
+        'reason', v_reason,
+        'from_state_code', v_state_code,
+        'to_state_code', 0
+      )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'changed', true,
+    'data', v_updated_row
+  );
+end;
+$$;
+comment on function public.cmd_dataset_withdraw(text, uuid, text, text, jsonb)
+  is 'Owner-authenticated, audited withdrawal of public source, flow, or process datasets to draft state without changing dataset JSON.';
+revoke all on function public.cmd_dataset_withdraw(text, uuid, text, text, jsonb) from public;
+revoke all on function public.cmd_dataset_withdraw(text, uuid, text, text, jsonb) from anon;
+grant execute on function public.cmd_dataset_withdraw(text, uuid, text, text, jsonb) to authenticated;
+grant execute on function public.cmd_dataset_withdraw(text, uuid, text, text, jsonb) to service_role;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#277

## Summary
- Restore remote-only production migration 20260719110000_add_dataset_withdraw_command to the checked-in migration history.
- Unblock the production Supabase integration so pending main migration 20260721111242 can be applied automatically.

## Key Decisions
- Use the exact 4,132-byte SQL payload recovered read-only from the production migration record; the local file SHA-256 is fbcac25f2abab8297c6203b463a1c3b5df4375b0ad6412a3d3f3aba6fc92dad5.
- Do not use supabase migration repair because the production function and migration are already applied.
- Follow the database-engine hotfix path from main, then back-merge main into dev after production proof.

## Validation
- Supabase CLI 2.106.0: supabase db reset (pass; applied both 20260719110000 and 20260721111242).
- supabase migration list --local (pass; both target versions aligned).
- Read-only local SQL verification: migration rows present, cmd_dataset_withdraw is SECURITY DEFINER with search_path=public,pg_temp, and REFERENCED_DATA_UNDER_REVIEW is absent from cmd_review_submit_without_gate.
- scripts/docpact validate-config --root . --strict (pass).
- scripts/docpact lint --root . --files supabase/migrations/20260719110000_add_dataset_withdraw_command.sql,.docpact/config.yaml,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,AGENTS.md --mode enforce (pass).
- supabase db lint --level warning reports existing baseline findings only; none reference cmd_dataset_withdraw.

## Risks / Rollback
- Low schema risk because production already contains this exact migration; the integration should mark it satisfied and apply later pending migrations.
- Rollback is to revert the Git hotfix only before merge; do not remove the production function or rewrite production migration metadata.

## Follow-ups
- After merge, verify the production Supabase integration records 20260721111242, then back-merge main into dev and verify the persistent dev workflow.

## Workspace Integration
- Workspace Integration remains pending until production proof succeeds and lca-workspace points to the eligible database-engine/main commit.