### PR TITLE
promote: admin rejection shared-reference fix to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-21"
-lastReviewedCommit: "c86556d46a311c3f3f7c2723f5093eb46ecda2d9"
-lastReviewedNote: "Reviewed issue #277 production migration-history recovery routing, ownership, and required proof; existing governance remains accurate."
+lastReviewedAt: "2026-07-22"
+lastReviewedCommit: "08e8dd1dc08aa7757154074154f116817ba9742f"
+lastReviewedNote: "Reviewed issue #281 administrator-rejection shared-reference routing, ownership, and required proof; existing governance remains accurate."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-21
-lastReviewedCommit: c86556d46a311c3f3f7c2723f5093eb46ecda2d9
-lastReviewedNote: "Reviewed issue #277 production migration-history recovery; source-of-truth ownership, main hotfix, dev back-merge, and workspace integration rules remain unchanged."
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 08e8dd1dc08aa7757154074154f116817ba9742f
+lastReviewedNote: "Reviewed issue #281 administrator-rejection migration delivery; source-of-truth ownership, dev-based routine delivery, and workspace integration rules remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-21
-lastReviewedCommit: c86556d46a311c3f3f7c2723f5093eb46ecda2d9
-lastReviewedNote: "Reviewed issue #277 production-only migration recovery through the authoritative migration path and main hotfix flow; the path map remains accurate."
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 08e8dd1dc08aa7757154074154f116817ba9742f
+lastReviewedNote: "Reviewed issue #281 administrator-rejection migration and SQL-test ownership; the stable/generated path map remains accurate."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-21
-lastReviewedCommit: c86556d46a311c3f3f7c2723f5093eb46ecda2d9
-lastReviewedNote: "Reviewed issue #277 migration-history recovery proof; exact SQL fingerprinting, db reset, and migration-list verification remain sufficient."
+lastReviewedAt: 2026-07-22
+lastReviewedCommit: 08e8dd1dc08aa7757154074154f116817ba9742f
+lastReviewedNote: "Reviewed issue #281 administrator-rejection proof; db reset, migration-list verification, and targeted review workflow SQL assertions remain sufficient."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260722000000_admin_reject_preserve_shared_review_references.sql
+++ b/supabase/migrations/20260722000000_admin_reject_preserve_shared_review_references.sql
@@ -1,0 +1,385 @@
+create or replace function public.cmd_review_reject(
+  p_table text,
+  p_review_id uuid,
+  p_reason text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_actor uuid := auth.uid();
+  v_review public.reviews%rowtype;
+  v_root_table text;
+  v_root_targets jsonb;
+  v_comment_ref_roots jsonb := '[]'::jsonb;
+  v_target record;
+  v_comment_ref record;
+  v_review_json jsonb;
+  v_affected_datasets jsonb := '[]'::jsonb;
+  v_retained_datasets jsonb := '[]'::jsonb;
+  v_unverifiable_datasets jsonb := '[]'::jsonb;
+  v_other_active_review_ids jsonb := '[]'::jsonb;
+  v_unverifiable_review_refs jsonb := '[]'::jsonb;
+  v_has_current_review_ref boolean := false;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if not public.cmd_review_is_review_admin(v_actor) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_ADMIN_REQUIRED',
+      'status', 403,
+      'message', 'Only review admins can reject reviews'
+    );
+  end if;
+
+  v_root_table := lower(coalesce(p_table, ''));
+  if v_root_table not in ('processes', 'lifecyclemodels') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_TABLE',
+      'status', 400,
+      'message', 'table must be processes or lifecyclemodels'
+    );
+  end if;
+
+  select *
+    into v_review
+  from public.reviews
+  where id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code not in (-1, 0, 1) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_REVIEW_STATE',
+      'status', 409,
+      'message', 'Only pending, assigned, or rejected reviews can be rejected',
+      'details', jsonb_build_object(
+        'state_code', v_review.state_code
+      )
+    );
+  end if;
+
+  v_root_targets := jsonb_build_array(
+    jsonb_build_object(
+      'table', v_root_table,
+      'id', v_review.data_id,
+      'version', v_review.data_version,
+      'is_root', true
+    )
+  );
+
+  create temporary table if not exists cmd_review_reject_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    dataset_row jsonb not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+
+  truncate table cmd_review_reject_targets;
+
+  insert into cmd_review_reject_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_root_targets, true);
+
+  for v_comment_ref in
+    select distinct
+      ref.ref_type,
+      ref.ref_object_id,
+      ref.ref_version
+    from public.comments as c
+    cross join lateral public.cmd_review_extract_refs(coalesce(to_jsonb(c.json), '{}'::jsonb)) as ref
+    where c.review_id = p_review_id
+      and c.state_code <> -2
+  loop
+    v_comment_ref_roots := v_comment_ref_roots || jsonb_build_array(
+      jsonb_build_object(
+        'table', public.cmd_review_ref_type_to_table(v_comment_ref.ref_type),
+        'id', v_comment_ref.ref_object_id,
+        'version', v_comment_ref.ref_version,
+        'is_root', false
+      )
+    );
+  end loop;
+
+  insert into cmd_review_reject_targets (
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  )
+  select
+    table_name,
+    dataset_id,
+    dataset_version,
+    state_code,
+    reviews,
+    dataset_row,
+    is_root
+  from public.cmd_review_collect_dataset_targets(v_comment_ref_roots, true)
+  on conflict (table_name, dataset_id, dataset_version) do nothing;
+
+  for v_target in
+    select *
+    from cmd_review_reject_targets
+    where state_code >= 20
+      and state_code < 100
+    order by table_name, dataset_id, dataset_version
+  loop
+    if not v_target.is_root then
+      v_other_active_review_ids := '[]'::jsonb;
+      v_unverifiable_review_refs := '[]'::jsonb;
+      v_has_current_review_ref := false;
+
+      if jsonb_typeof(v_target.reviews) is distinct from 'array' then
+        v_unverifiable_review_refs := jsonb_build_array(
+          jsonb_build_object(
+            'reason', 'REVIEWS_NOT_ARRAY',
+            'reviews', coalesce(v_target.reviews, 'null'::jsonb)
+          )
+        );
+      elsif jsonb_array_length(v_target.reviews) = 0 then
+        v_unverifiable_review_refs := jsonb_build_array(
+          jsonb_build_object(
+            'reason', 'REVIEWS_EMPTY'
+          )
+        );
+      else
+        with review_refs as (
+          select
+            entry.value as review_ref,
+            entry.ordinality,
+            case
+              when jsonb_typeof(entry.value) = 'object'
+                and jsonb_typeof(entry.value->'id') = 'string'
+                and (entry.value->>'id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+              then (entry.value->>'id')::uuid
+              else null
+            end as review_id
+          from jsonb_array_elements(v_target.reviews)
+            with ordinality as entry(value, ordinality)
+        ),
+        resolved_review_refs as (
+          select
+            review_refs.review_ref,
+            review_refs.ordinality,
+            review_refs.review_id,
+            linked_review.id is not null as is_resolved
+          from review_refs
+          left join public.reviews as linked_review
+            on linked_review.id = review_refs.review_id
+        )
+        select
+          coalesce(
+            jsonb_agg(
+              jsonb_build_object(
+                'ordinal', ordinality,
+                'review_ref', review_ref,
+                'reason', case
+                  when review_id is null then 'INVALID_REVIEW_REF'
+                  else 'REVIEW_NOT_FOUND'
+                end
+              )
+              order by ordinality
+            ) filter (where review_id is null or not is_resolved),
+            '[]'::jsonb
+          ),
+          coalesce(bool_or(review_id = p_review_id), false)
+        into
+          v_unverifiable_review_refs,
+          v_has_current_review_ref
+        from resolved_review_refs;
+
+        if not v_has_current_review_ref then
+          v_unverifiable_review_refs := v_unverifiable_review_refs || jsonb_build_array(
+            jsonb_build_object(
+              'reason', 'CURRENT_REVIEW_REF_MISSING',
+              'review_id', p_review_id
+            )
+          );
+        end if;
+      end if;
+
+      if jsonb_array_length(v_unverifiable_review_refs) > 0 then
+        v_retained_datasets := v_retained_datasets || jsonb_build_array(
+          jsonb_build_object(
+            'table', v_target.table_name,
+            'id', v_target.dataset_id,
+            'version', v_target.dataset_version,
+            'state_code', v_target.state_code,
+            'reason', 'UNVERIFIABLE_REVIEW_LINKS',
+            'unverifiable_review_refs', v_unverifiable_review_refs
+          )
+        );
+        v_unverifiable_datasets := v_unverifiable_datasets || jsonb_build_array(
+          jsonb_build_object(
+            'table', v_target.table_name,
+            'id', v_target.dataset_id,
+            'version', v_target.dataset_version,
+            'state_code', v_target.state_code,
+            'unverifiable_review_refs', v_unverifiable_review_refs
+          )
+        );
+        continue;
+      end if;
+
+      select coalesce(
+        jsonb_agg(to_jsonb(active_review.review_id) order by active_review.review_id),
+        '[]'::jsonb
+      )
+        into v_other_active_review_ids
+      from (
+        select distinct linked_review.id::text as review_id
+        from jsonb_array_elements(v_target.reviews) as review_ref(value)
+        join public.reviews as linked_review
+          on linked_review.id = (review_ref.value->>'id')::uuid
+        where linked_review.id <> p_review_id
+          and linked_review.state_code in (0, 1)
+      ) as active_review;
+
+      if jsonb_array_length(v_other_active_review_ids) > 0 then
+        v_retained_datasets := v_retained_datasets || jsonb_build_array(
+          jsonb_build_object(
+            'table', v_target.table_name,
+            'id', v_target.dataset_id,
+            'version', v_target.dataset_version,
+            'state_code', v_target.state_code,
+            'reason', 'OTHER_ACTIVE_REVIEWS',
+            'active_review_ids', v_other_active_review_ids
+          )
+        );
+        continue;
+      end if;
+    end if;
+
+    execute format(
+      'update public.%I
+          set state_code = 0,
+              modified_at = now()
+        where id = $1
+          and version = $2',
+      v_target.table_name
+    )
+      using v_target.dataset_id, v_target.dataset_version;
+
+    v_affected_datasets := v_affected_datasets || jsonb_build_array(
+      jsonb_build_object(
+        'table', v_target.table_name,
+        'id', v_target.dataset_id,
+        'version', v_target.dataset_version,
+        'previous_state_code', v_target.state_code,
+        'state_code', 0
+      )
+    );
+  end loop;
+
+  update public.comments
+    set state_code = -1,
+        modified_at = now()
+  where review_id = p_review_id
+    and state_code <> -2;
+
+  v_review_json := coalesce(v_review.json, '{}'::jsonb);
+  v_review_json := jsonb_set(
+    v_review_json,
+    '{comment}',
+    coalesce(v_review_json->'comment', '{}'::jsonb) || jsonb_build_object(
+      'message', coalesce(p_reason, '')
+    ),
+    true
+  );
+  v_review_json := public.cmd_review_append_log(
+    v_review_json,
+    'rejected',
+    v_actor,
+    jsonb_build_object(
+      'reason', coalesce(p_reason, '')
+    )
+  );
+
+  update public.reviews
+    set state_code = -1,
+        json = v_review_json,
+        modified_at = now()
+  where id = p_review_id
+  returning *
+    into v_review;
+
+  insert into public.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_reject',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'root_table', v_root_table,
+      'reason', coalesce(p_reason, ''),
+      'active_review_state_codes', jsonb_build_array(0, 1),
+      'affected_datasets', v_affected_datasets,
+      'retained_datasets', v_retained_datasets,
+      'unverifiable_datasets', v_unverifiable_datasets
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'affected_datasets', v_affected_datasets,
+      'retained_datasets', v_retained_datasets,
+      'unverifiable_datasets', v_unverifiable_datasets
+    )
+  );
+end;
+$function$;
+
+comment on function public.cmd_review_reject(text, uuid, text, jsonb) is
+  'Rejects an admin-managed review while retaining non-root under-review datasets still occupied by another active review; unverifiable review links fail closed and are audited.';

--- a/supabase/tests/20260722_admin_review_reject_shared_references.sql
+++ b/supabase/tests/20260722_admin_review_reject_shared_references.sql
@@ -1,0 +1,409 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+create or replace function pg_temp.disable_trigger_if_exists(p_table regclass, p_trigger name)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute format('alter table %s disable trigger %I', p_table, p_trigger);
+  end if;
+end;
+$$;
+
+select plan(26);
+
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'processes_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_md_trigger_update');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'process_extract_text_trigger_update');
+select pg_temp.disable_trigger_if_exists('public.processes'::regclass, 'zz_processes_extracted_text_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flows_json_sync_trigger');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_md_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_md_trigger_update');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_text_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_extract_text_trigger_update');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'flow_dataset_extraction_trigger_insert');
+select pg_temp.disable_trigger_if_exists('public.flows'::regclass, 'zz_flows_extracted_text_sync_trigger');
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  '28100000-0000-0000-0000-000000000001',
+  'authenticated',
+  'authenticated',
+  'issue-281-review-admin@example.com',
+  'test-password-hash',
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"sub":"28100000-0000-0000-0000-000000000001","email":"issue-281-review-admin@example.com","display_name":"Issue 281 Review Admin"}'::jsonb,
+  now(),
+  now(),
+  false,
+  false
+);
+
+insert into public.users (id, raw_user_meta_data)
+values (
+  '28100000-0000-0000-0000-000000000001',
+  '{"email":"issue-281-review-admin@example.com","display_name":"Issue 281 Review Admin"}'::jsonb
+);
+
+insert into public.roles (user_id, team_id, role)
+values (
+  '28100000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000000',
+  'review-admin'
+);
+
+insert into public.flows (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  rule_verification,
+  reviews
+)
+values
+  (
+    '28120000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"flowDataSet":{"name":"pending shared reference"}}'::jsonb,
+    '{"flowDataSet":{"name":"pending shared reference"}}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000001"},{"key":1,"id":"28130000-0000-0000-0000-000000000002"}]'::jsonb
+  ),
+  (
+    '28120000-0000-0000-0000-000000000002',
+    '01.00.000',
+    '{"flowDataSet":{"name":"assigned shared reference"}}'::jsonb,
+    '{"flowDataSet":{"name":"assigned shared reference"}}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000001"},{"key":1,"id":"28130000-0000-0000-0000-000000000003"}]'::jsonb
+  ),
+  (
+    '28120000-0000-0000-0000-000000000003',
+    '01.00.000',
+    '{"flowDataSet":{"name":"completed history reference"}}'::jsonb,
+    '{"flowDataSet":{"name":"completed history reference"}}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000001"},{"key":1,"id":"28130000-0000-0000-0000-000000000005"}]'::jsonb
+  ),
+  (
+    '28120000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"flowDataSet":{"name":"malformed review reference"}}'::jsonb,
+    '{"flowDataSet":{"name":"malformed review reference"}}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000004"},{"key":1,"id":"not-a-uuid"}]'::jsonb
+  ),
+  (
+    '28120000-0000-0000-0000-000000000005',
+    '01.00.000',
+    '{"flowDataSet":{"name":"missing review reference"}}'::jsonb,
+    '{"flowDataSet":{"name":"missing review reference"}}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000004"},{"key":1,"id":"28130000-0000-0000-0000-000000000099"}]'::jsonb
+  );
+
+insert into public.processes (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  model_id,
+  rule_verification,
+  reviews
+)
+values
+  (
+    '28110000-0000-0000-0000-000000000001',
+    '01.00.000',
+    '{"references":[{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000001","@version":"01.00.000"},{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000002","@version":"01.00.000"},{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000003","@version":"01.00.000"}]}'::jsonb,
+    '{"references":[{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000001","@version":"01.00.000"},{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000002","@version":"01.00.000"},{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000003","@version":"01.00.000"}]}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    '28140000-0000-0000-0000-000000000001',
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000001"}]'::jsonb
+  ),
+  (
+    '28110000-0000-0000-0000-000000000002',
+    '01.00.000',
+    '{"references":[{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000001","@version":"01.00.000"}]}'::jsonb,
+    '{"references":[{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000001","@version":"01.00.000"}]}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    '28140000-0000-0000-0000-000000000002',
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000002"}]'::jsonb
+  ),
+  (
+    '28110000-0000-0000-0000-000000000003',
+    '01.00.000',
+    '{"references":[{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000002","@version":"01.00.000"}]}'::jsonb,
+    '{"references":[{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000002","@version":"01.00.000"}]}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    '28140000-0000-0000-0000-000000000003',
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000003"}]'::jsonb
+  ),
+  (
+    '28110000-0000-0000-0000-000000000004',
+    '01.00.000',
+    '{"references":[{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000004","@version":"01.00.000"},{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000005","@version":"01.00.000"}]}'::jsonb,
+    '{"references":[{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000004","@version":"01.00.000"},{"@type":"flow data set","@refObjectId":"28120000-0000-0000-0000-000000000005","@version":"01.00.000"}]}'::json,
+    '28100000-0000-0000-0000-000000000001',
+    20,
+    '28140000-0000-0000-0000-000000000004',
+    true,
+    '[{"key":0,"id":"28130000-0000-0000-0000-000000000004"}]'::jsonb
+  );
+
+insert into public.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json
+)
+values
+  (
+    '28130000-0000-0000-0000-000000000001',
+    '28110000-0000-0000-0000-000000000001',
+    '01.00.000',
+    1,
+    '[]'::jsonb,
+    '{"comment":{"message":""},"logs":[]}'::jsonb
+  ),
+  (
+    '28130000-0000-0000-0000-000000000002',
+    '28110000-0000-0000-0000-000000000002',
+    '01.00.000',
+    0,
+    '[]'::jsonb,
+    '{"comment":{"message":""},"logs":[]}'::jsonb
+  ),
+  (
+    '28130000-0000-0000-0000-000000000003',
+    '28110000-0000-0000-0000-000000000003',
+    '01.00.000',
+    1,
+    '[]'::jsonb,
+    '{"comment":{"message":""},"logs":[]}'::jsonb
+  ),
+  (
+    '28130000-0000-0000-0000-000000000004',
+    '28110000-0000-0000-0000-000000000004',
+    '01.00.000',
+    1,
+    '[]'::jsonb,
+    '{"comment":{"message":""},"logs":[]}'::jsonb
+  ),
+  (
+    '28130000-0000-0000-0000-000000000005',
+    '28110000-0000-0000-0000-000000000001',
+    '01.00.000',
+    2,
+    '[]'::jsonb,
+    '{"comment":{"message":""},"logs":[]}'::jsonb
+  );
+
+create temporary table reject_results (
+  review_id uuid primary key,
+  result jsonb not null
+) on commit drop;
+
+grant select, insert on reject_results to authenticated;
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', '28100000-0000-0000-0000-000000000001', true);
+
+set local role authenticated;
+insert into reject_results (review_id, result)
+values (
+  '28130000-0000-0000-0000-000000000001',
+  public.cmd_review_reject(
+    'processes',
+    '28130000-0000-0000-0000-000000000001',
+    'reject first shared review',
+    '{"issue":281,"scenario":"shared-first"}'::jsonb
+  )
+);
+reset role;
+
+select is((select result->>'ok' from reject_results where review_id = '28130000-0000-0000-0000-000000000001'), 'true', 'first shared review rejection succeeds');
+select is((select state_code from public.processes where id = '28110000-0000-0000-0000-000000000001' and version = '01.00.000'), 0, 'the rejected review root always returns to draft');
+select is((select state_code from public.flows where id = '28120000-0000-0000-0000-000000000001' and version = '01.00.000'), 20, 'a non-root reference stays under review while another pending review is active');
+select is((select state_code from public.flows where id = '28120000-0000-0000-0000-000000000002' and version = '01.00.000'), 20, 'a non-root reference stays under review while another assigned review is active');
+select is((select state_code from public.flows where id = '28120000-0000-0000-0000-000000000003' and version = '01.00.000'), 0, 'a completed historical review does not keep a non-root reference under review');
+select is((select state_code from public.reviews where id = '28130000-0000-0000-0000-000000000001'), -1, 'the rejected review row is marked rejected');
+
+select ok(
+  (select result->'data'->'retained_datasets' from reject_results where review_id = '28130000-0000-0000-0000-000000000001') @>
+    '[{"table":"flows","id":"28120000-0000-0000-0000-000000000001","reason":"OTHER_ACTIVE_REVIEWS","active_review_ids":["28130000-0000-0000-0000-000000000002"]}]'::jsonb,
+  'the response identifies the pending review that retains the shared reference'
+);
+
+select ok(
+  (select result->'data'->'retained_datasets' from reject_results where review_id = '28130000-0000-0000-0000-000000000001') @>
+    '[{"table":"flows","id":"28120000-0000-0000-0000-000000000002","reason":"OTHER_ACTIVE_REVIEWS","active_review_ids":["28130000-0000-0000-0000-000000000003"]}]'::jsonb,
+  'the response identifies the assigned review that retains the shared reference'
+);
+
+select ok(
+  (select result->'data'->'affected_datasets' from reject_results where review_id = '28130000-0000-0000-0000-000000000001') @>
+    '[{"table":"flows","id":"28120000-0000-0000-0000-000000000003","state_code":0}]'::jsonb,
+  'the response reports references actually restored to draft separately'
+);
+
+set local role authenticated;
+insert into reject_results (review_id, result)
+values (
+  '28130000-0000-0000-0000-000000000002',
+  public.cmd_review_reject(
+    'processes',
+    '28130000-0000-0000-0000-000000000002',
+    'reject last pending occupant',
+    '{"issue":281,"scenario":"shared-last-pending"}'::jsonb
+  )
+);
+reset role;
+
+select is((select result->>'ok' from reject_results where review_id = '28130000-0000-0000-0000-000000000002'), 'true', 'rejecting the last pending occupant succeeds');
+select is((select state_code from public.processes where id = '28110000-0000-0000-0000-000000000002' and version = '01.00.000'), 0, 'the pending occupant root returns to draft');
+select is((select state_code from public.flows where id = '28120000-0000-0000-0000-000000000001' and version = '01.00.000'), 0, 'the shared reference returns to draft after its final active review is rejected');
+
+set local role authenticated;
+insert into reject_results (review_id, result)
+values (
+  '28130000-0000-0000-0000-000000000003',
+  public.cmd_review_reject(
+    'processes',
+    '28130000-0000-0000-0000-000000000003',
+    'reject last assigned occupant',
+    '{"issue":281,"scenario":"shared-last-assigned"}'::jsonb
+  )
+);
+reset role;
+
+select is((select result->>'ok' from reject_results where review_id = '28130000-0000-0000-0000-000000000003'), 'true', 'rejecting the last assigned occupant succeeds');
+select is((select state_code from public.processes where id = '28110000-0000-0000-0000-000000000003' and version = '01.00.000'), 0, 'the assigned occupant root returns to draft');
+select is((select state_code from public.flows where id = '28120000-0000-0000-0000-000000000002' and version = '01.00.000'), 0, 'the assigned shared reference returns to draft after its final active review is rejected');
+
+select is(
+  (select reviews::text from public.flows where id = '28120000-0000-0000-0000-000000000001' and version = '01.00.000'),
+  '[{"id": "28130000-0000-0000-0000-000000000001", "key": 0}, {"id": "28130000-0000-0000-0000-000000000002", "key": 1}]',
+  'sequential rejections preserve the pending shared reference review history'
+);
+
+select is(
+  (select reviews::text from public.flows where id = '28120000-0000-0000-0000-000000000002' and version = '01.00.000'),
+  '[{"id": "28130000-0000-0000-0000-000000000001", "key": 0}, {"id": "28130000-0000-0000-0000-000000000003", "key": 1}]',
+  'sequential rejections preserve the assigned shared reference review history'
+);
+
+set local role authenticated;
+insert into reject_results (review_id, result)
+values (
+  '28130000-0000-0000-0000-000000000004',
+  public.cmd_review_reject(
+    'processes',
+    '28130000-0000-0000-0000-000000000004',
+    'reject review with unverifiable references',
+    '{"issue":281,"scenario":"fail-closed"}'::jsonb
+  )
+);
+reset role;
+
+select is((select result->>'ok' from reject_results where review_id = '28130000-0000-0000-0000-000000000004'), 'true', 'review rejection succeeds when non-root review links are unverifiable');
+select is((select state_code from public.processes where id = '28110000-0000-0000-0000-000000000004' and version = '01.00.000'), 0, 'the root still returns to draft when referenced review links are unverifiable');
+select is((select state_code from public.flows where id = '28120000-0000-0000-0000-000000000004' and version = '01.00.000'), 20, 'a malformed review link fails closed and retains the non-root state');
+select is((select state_code from public.flows where id = '28120000-0000-0000-0000-000000000005' and version = '01.00.000'), 20, 'a missing linked review fails closed and retains the non-root state');
+
+select is(
+  (select jsonb_array_length(result->'data'->'unverifiable_datasets') from reject_results where review_id = '28130000-0000-0000-0000-000000000004'),
+  2,
+  'the response lists every unverifiable non-root dataset'
+);
+
+select ok(
+  (select result->'data'->'retained_datasets' from reject_results where review_id = '28130000-0000-0000-0000-000000000004') @>
+    '[{"id":"28120000-0000-0000-0000-000000000004","reason":"UNVERIFIABLE_REVIEW_LINKS","unverifiable_review_refs":[{"reason":"INVALID_REVIEW_REF"}]}]'::jsonb,
+  'the response distinguishes a malformed review reference'
+);
+
+select ok(
+  (select result->'data'->'retained_datasets' from reject_results where review_id = '28130000-0000-0000-0000-000000000004') @>
+    '[{"id":"28120000-0000-0000-0000-000000000005","reason":"UNVERIFIABLE_REVIEW_LINKS","unverifiable_review_refs":[{"reason":"REVIEW_NOT_FOUND"}]}]'::jsonb,
+  'the response distinguishes a missing linked review'
+);
+
+select is(
+  (
+    select jsonb_array_length(payload->'unverifiable_datasets')
+    from public.command_audit_log
+    where command = 'cmd_review_reject'
+      and target_id = '28130000-0000-0000-0000-000000000004'
+    order by created_at desc
+    limit 1
+  ),
+  2,
+  'the command audit records every fail-closed dataset'
+);
+
+select is(
+  (
+    select payload->'active_review_state_codes'
+    from public.command_audit_log
+    where command = 'cmd_review_reject'
+      and target_id = '28130000-0000-0000-0000-000000000004'
+    order by created_at desc
+    limit 1
+  )::text,
+  '[0, 1]',
+  'the command audit records the exact active review state definition'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes #281

## Summary
- Promote the current database-engine dev line at 97f7a9597b0b4487fc7f3ffaa2bbaa012c25a975 to production main through the governed M2 promotion path.
- The file delta is the administrator-rejection shared-reference fix delivered by PR #282: non-root references remain under review while another pending or assigned review still occupies them, and unverifiable review links fail closed with structured audit evidence.

## Key Decisions
- Promote the complete current dev line instead of cherry-picking migration commits.
- Keep production migration execution owned by the Supabase GitHub integration bound to main; no manual production db push is part of this PR.

## Validation
- PR #282: supabase db reset passed and migration 20260722000000 was registered.
- PR #282: 20260722_admin_review_reject_shared_references.sql passed 26/26, 20260405_review_workflow_rpcs.sql passed 44/44, and 20260404_review_submit_rpc.sql passed 15/15.
- PR #282 Supabase Preview and Gitleaks checks passed.
- Persistent dev deployment run 29981231898 succeeded for exact head 97f7a9597b0b4487fc7f3ffaa2bbaa012c25a975.
- git diff --check origin/main...origin/dev passed, and a three-way merge-tree check reported no conflicts.

## Risks / Rollback
- Merging advances the production schema through the Supabase GitHub integration. Verify production migration history and the administrator-rejection RPC immediately after merge.
- Rollback is forward-fix oriented; do not rewrite committed migration history.

## Follow-ups
- Confirm the production Supabase integration applies 20260722000000_admin_reject_preserve_shared_review_references.sql successfully.

## Workspace Integration
- After production verification, update the lca-workspace database-engine submodule pointer to the exact promoted main merge SHA.