### PR TITLE
fix: normalize in-progress closure summary projection

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-07-24"
-lastReviewedCommit: "d748dbb2e43763e5ca217c61ea4cb136977ef0bc"
-lastReviewedNote: "Reviewed issue #287 after the production-scale candidate hash backfill exceeded the Supabase statement timeout; ownership and routing remain accurate, and the required bounded migration proof is documented."
+lastReviewedCommit: "8281967cf9031229789ace9df6cbcfe33f13622c"
+lastReviewedNote: "Reviewed the owner-scoped closure-check V1 read projection for queued and running checks; ownership, routing, and proof requirements remain accurate."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-24
-lastReviewedCommit: d748dbb2e43763e5ca217c61ea4cb136977ef0bc
-lastReviewedNote: "Reviewed issue #287 after the production candidate hash backfill exceeded the platform statement timeout; repo ownership, main hotfix path, and workspace integration rules remain unchanged."
+lastReviewedCommit: 8281967cf9031229789ace9df6cbcfe33f13622c
+lastReviewedNote: "Reviewed the nonterminal closure-check V1 read projection hotfix; repo ownership, main hotfix path, and workspace integration rules remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,8 +28,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-24
-lastReviewedCommit: d748dbb2e43763e5ca217c61ea4cb136977ef0bc
-lastReviewedNote: "Reviewed issue #287 after the production candidate hash backfill exceeded the platform statement timeout; documented the bounded administrative timeout contract."
+lastReviewedCommit: 8281967cf9031229789ace9df6cbcfe33f13622c
+lastReviewedNote: "Reviewed the owner-scoped closure-check V1 read projection for nonterminal checks; the current architecture and cross-repo boundaries remain accurate."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-07-24
-lastReviewedCommit: d748dbb2e43763e5ca217c61ea4cb136977ef0bc
-lastReviewedNote: "Reviewed issue #287 after the production candidate hash backfill exceeded the platform statement timeout; first-release scope-closure changes also require bounded production-volume migration proof."
+lastReviewedCommit: 8281967cf9031229789ace9df6cbcfe33f13622c
+lastReviewedNote: "Reviewed the queued/running closure-check V1 projection regression; the existing scope-closure proof matrix already requires the correct local and production evidence."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260724062800_normalize_scope_closure_in_progress_projection.sql
+++ b/supabase/migrations/20260724062800_normalize_scope_closure_in_progress_projection.sql
@@ -1,0 +1,88 @@
+-- Keep the owner-scoped closure-check read DTO valid while a check is still
+-- queued or running. The persisted "pending" certificate state and NULL scan
+-- completeness are internal lifecycle values; the public V1 projection uses
+-- "unavailable" and "unknown" until terminal evidence exists.
+
+create or replace function public.get_lcia_scope_closure_check(
+  p_closure_check_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_check public.lcia_scope_closure_checks%rowtype;
+  v_job public.worker_jobs%rowtype;
+begin
+  if v_actor is null then
+    return public.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not public.lcia_scope_closure_is_manager() then
+    return public.lcia_scope_closure_error(
+      'closure_check_not_found', 404, 'Closure check not found'
+    );
+  end if;
+
+  select *
+    into v_check
+  from public.lcia_scope_closure_checks
+  where id = p_closure_check_id
+    and requested_by = v_actor;
+
+  if v_check.id is null then
+    return public.lcia_scope_closure_error(
+      'closure_check_not_found', 404, 'Closure check not found'
+    );
+  end if;
+
+  select *
+    into v_job
+  from public.worker_jobs
+  where id = v_check.worker_job_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_strip_nulls(jsonb_build_object(
+      'schemaVersion', 'lcia.scope-closure-check.v1',
+      'closureCheckId', v_check.id,
+      'runStatus', v_check.status,
+      'scanCompleteness', coalesce(v_check.scan_completeness, 'unknown'),
+      'certificateValidity', case
+        when v_check.certificate_status = 'pending' then 'unavailable'
+        else v_check.certificate_status
+      end,
+      'requestedScopeHash', v_check.requested_scope_hash,
+      'effectiveScopeHash', v_check.effective_scope_hash,
+      'policyFingerprint', v_check.policy_fingerprint,
+      'dataSnapshotToken', v_check.data_snapshot_token,
+      'blockerCodes', to_jsonb(v_check.blocker_codes),
+      'summary', v_check.result_summary,
+      'scanExecutionId', v_check.scan_execution_id,
+      'reusedFromCheckId', v_check.reused_from_check_id,
+      'createdAt', v_check.created_at,
+      'updatedAt', v_check.updated_at,
+      'finishedAt', v_check.finished_at,
+      'workerJob', case
+        when v_job.id is null then null
+        else jsonb_strip_nulls(jsonb_build_object(
+          'jobId', v_job.id,
+          'status', v_job.status,
+          'phase', v_job.phase,
+          'progressFraction', v_job.progress,
+          'errorCode', v_job.error_code,
+          'blockerCodes', to_jsonb(v_job.blocker_codes),
+          'createdAt', v_job.created_at,
+          'updatedAt', v_job.updated_at,
+          'finishedAt', v_job.finished_at
+        ))
+      end
+    ))
+  );
+end;
+$$;
+
+comment on function public.get_lcia_scope_closure_check(uuid) is
+  'Returns the owner-scoped V1 closure-check DTO; internal pending/null lifecycle values project as unavailable/unknown while execution is nonterminal.';

--- a/supabase/tests/20260724_initial_candidate_scope_closure_e2e.sql
+++ b/supabase/tests/20260724_initial_candidate_scope_closure_e2e.sql
@@ -322,7 +322,9 @@ select set_config(
   true
 );
 
-select is(
+insert into candidate_closure_responses values
+(
+  'candidate-global',
   public.cmd_lcia_scope_closure_check_request_v2(
     '{
       "coverageMode":"global_eligible",
@@ -334,9 +336,38 @@ select is(
     }'::jsonb,
     'candidate-global',
     '{}'
-  )->>'ok',
+  )
+);
+select is(
+  (
+    select result->>'ok'
+    from candidate_closure_responses
+    where idempotency_token = 'candidate-global'
+  ),
   'true',
   'zero-release global eligible preflight is accepted'
+);
+select is(
+  public.get_lcia_scope_closure_check(
+    (
+      select (result->'data'->>'closureCheckId')::uuid
+      from candidate_closure_responses
+      where idempotency_token = 'candidate-global'
+    )
+  )->'data'->>'scanCompleteness',
+  'unknown',
+  'queued zero-release checks project unknown scan completeness'
+);
+select is(
+  public.get_lcia_scope_closure_check(
+    (
+      select (result->'data'->>'closureCheckId')::uuid
+      from candidate_closure_responses
+      where idempotency_token = 'candidate-global'
+    )
+  )->'data'->>'certificateValidity',
+  'unavailable',
+  'queued zero-release checks hide the internal pending certificate state'
 );
 
 reset role;


### PR DESCRIPTION
Closes #287

## Summary
- Project queued/running closure checks into the published V1 DTO instead of exposing internal pending/null lifecycle values.
- Add zero-release regression assertions for scanCompleteness=unknown and certificateValidity=unavailable.

## Key Decisions
- Keep persisted lifecycle states unchanged; normalize only the owner-scoped read projection so Worker, Edge, and Next contracts remain stable.

## Validation
- supabase db reset
- psql ... -f supabase/tests/20260724_initial_candidate_scope_closure_e2e.sql (20/20)
- psql ... -f supabase/tests/20260722_scope_closure_release_binding_e2e.sql (61/61)
- psql ... -f supabase/tests/20260722_data_product_scope_closure_and_task_feed.sql (100/100)
- supabase migration list --local includes 20260724062800
- docpact validate-config --strict and enforced lint pass

## Risks / Rollback
- Database lint still reports only pre-existing repository-wide findings; the new projection function adds no new finding.

## Follow-ups
- After merge, verify production migration, reload the production page, and repeat the real zero-release preflight.

## Workspace Integration
- Hotfix targets main; back-merge main to dev, then bump the database-engine submodule on lca-workspace main.