### PR TITLE
fix: harden Performance Advisor index governance

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-22"
-lastReviewedCommit: "0c0abfb73a85d0322177b1236200f564b5a023c8"
-lastReviewedNote: "Reviewed issues #281 and #283 for administrator-rejection shared references and numerical snapshot certificates; existing ownership, routing, and validation governance remains accurate."
+lastReviewedAt: "2026-07-27"
+lastReviewedCommit: "97f7a95ecf91ffb12f25f39f978a5074e33240d7"
+lastReviewedNote: "Reviewed Issue #291 routing: index-health migrations and SQL assertions remain database-owned, while hooks physical compaction stays an explicit operator proof step."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 2d991a7
-lastReviewedNote: "Reviewed issues #281 and #283 for administrator-rejection migration delivery and numerical snapshot certificate coverage; repo ownership, dev-based delivery, and workspace integration rules remain unchanged."
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: 97f7a95ecf91ffb12f25f39f978a5074e33240d7
+lastReviewedNote: "Reviewed for Issue #291 Performance Advisor governance; schema ownership, dev-based delivery, automatic migration boundaries, and later workspace integration remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0c0abfb73a85d0322177b1236200f564b5a023c8
-lastReviewedNote: "Reviewed issues #281 and #283 for administrator-rejection and numerical snapshot certificate changes through authoritative migration and SQL-test paths; the stable/generated path map remains accurate."
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: 97f7a95ecf91ffb12f25f39f978a5074e33240d7
+lastReviewedNote: "Reviewed for Issue #291: schema truth includes usable FK-support prefixes and exact duplicate removal; physical hooks compaction remains an operator action rather than a migration."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -88,6 +88,7 @@ The current migration and test history clusters around these themes:
 7. review-submit gate persistence, `worker_jobs` queue state, final submit-review assertions, and retired legacy job-table archives
 8. worker-produced domain artifact/state contracts for retained `lca_package_*`, LCA result/cache/projection, and review-submit report/coordinator tables
 9. canonical LCI/LCIA release runs, exact dataset-version indexes, immutable four-package artifact refs, durable approval, publication, and readback
+10. Performance Advisor evidence, usable foreign-key support indexes, exact duplicate removal, and lock-aware managed-schema bloat maintenance
 
 If the task touches one of those areas, expect both schema truth and regression assertions to matter.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-22
-lastReviewedCommit: 0c0abfb73a85d0322177b1236200f564b5a023c8
-lastReviewedNote: "Reviewed issues #281 and #283 for administrator-rejection and numerical snapshot certificate proof; db reset, migration-list verification, focused pgTAP/E2E, and advisor checks remain the required validation."
+lastReviewedAt: 2026-07-27
+lastReviewedCommit: 97f7a95ecf91ffb12f25f39f978a5074e33240d7
+lastReviewedNote: "Reviewed for Issue #291: index-health assertions now require usable key prefixes, while hooks heap compaction remains a measured maintenance-window operation outside automatic migrations."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -61,6 +61,7 @@ supabase migration list
 | Change type | Minimum local proof | Stronger proof when risk is higher | Notes |
 | --- | --- | --- | --- |
 | `supabase/migrations/**` | `supabase db reset` succeeds | run the relevant SQL assertions under `supabase/tests/**`; inspect affected workspace objects if the migration was authored from workspace files | Record which migration and which SQL test files were exercised. |
+| Performance Advisor index or table-bloat governance | `supabase db reset`; run `supabase/tests/20260608_missing_fk_support_indexes.sql` and any affected domain regression | run `supabase db lint --level warning`; compare the relevant Performance Advisor notices on Preview and persistent `dev`; for physical compaction, follow the hooks maintenance-window procedure below | An unused-index notice alone is not permission to drop HNSW, GIN, PGroonga, FK-supporting, or other workload-sensitive indexes. `VACUUM FULL` is never part of the automatic migration path. |
 | guarded atomic owner-draft FP/UG alias primitive | `supabase db reset`; run `supabase/tests/20260711_guarded_dataset_alias_batch.sql` and the legacy `supabase/tests/20260404_dataset_command_rpcs.sql` | prove both the replay-capable whole-plan function and per-dimension executor have no API grants; exercise them only through postgres-owned test wrappers; retain the exact `dataset-alias-plan.v1` envelope, ordered time plus length-time batches, 25-row/20-exchange and 27-row/39-exchange scopes, public/foreign rejection, exact factors, live closure, hashes, and all-or-nothing audit proof | This is an internal mutation primitive after protected cutover. It never publishes or changes `state_code`; direct authenticated and service-role execution remains revoked. |
 | protected one-shot owner-draft FP/UG execution | `supabase db reset`; run `supabase/tests/20260715_protected_dataset_alias_execution.sql`, `supabase/tests/20260711_guarded_dataset_alias_batch.sql`, both derivative rebuild suites, and the rollback-only statement-timeout fault assertion under `supabase/tests/preview/**` | on the exact hosted Preview ref, run `node supabase/tests/preview/protected_alias_rest_e2e.mjs --expected-preview-ref <ref>` and prove real authenticated success, atomic business rollback, concurrent duplicate admission, lost response, HTTP timeout, status-only recovery, exact 52 rows/59 exchanges/55 audits plus 23-flow + 27-process child admission, 309 unrelated-exchange preservation, and zero actor-scoped fixture residue; also retain the exact authenticated preflight/gate/admit/read ACLs and service-only executor, trusted server context, canonical plan/freeze/approval binding, immutable live-gate hashes, 180-second window, owner/state fences, zero legacy RPC grants, six unchanged support snapshots, and all-terminal causal aggregate proof | Hosted fixtures must hard-fail outside the exact disposable Preview, use separate Auth actors/UUID namespaces, emit redacted evidence, and clean up only their own rows, ledgers, queue items, failures, audits, and users. If a disposable Preview lacks `project_url` and `project_secret_key`, the fixture may create only two exact scenario-scoped Vault values after ref/URL binding, must refuse every pre-existing same-name value, and must delete them by exact name, description, and decrypted value; cleanup failure revokes but retains the actor identity for recovery. Pure BAFU owner-draft data may use the released tool directly on production only after a fresh production freeze and exact human approval; Preview/Dev validate shared capability and never replay BAFU data. No retry, approval reuse, publication, `state_code` change, raw SQL fallback, broad queue cleanup, or client-supplied desired PostgreSQL hash is allowed. |
 | guarded owner-draft flow/process derivative rebuild | `supabase db reset`; run `supabase/tests/20260714_guarded_dataset_derivative_rebuild.sql` and `supabase/tests/20260715_guarded_dataset_derivative_rebuild_batch.sql` plus nearby webhook, embedding queue, and dataset-command regressions | retain the single-process v1 ACL/envelope/error contract; prove flow/process snapshot, fence, staging, quarantine, dispatch, proposal, commit, and terminal parity; prove the internal admission/read helpers have empty search paths and no anon/authenticated/service-role grants; reject 0, 51, duplicate, foreign, public, non-draft, incomplete, or desired-hash-drift targets before any child/audit/quarantine effect; atomically bind 1..50 children to supplied frozen baselines and actual post-write primary snapshots; and require exact 50/50, 23-flow + 27-process live primary, committed proposal, fresh vector, terminal audit, queue/failure drain, and completed-snapshot proof before aggregate completion | The compatible public v1 admission remains one process. Protected alias execution alone may invoke the private batch primitive in its mutation transaction. The primitive has a five-second lock wait, takes stable table/id/version row locks rather than a broad table write lock, validates every target before effects, never reports replay, and never retries. Nonterminal drain/failure phases retain each target fence. `completed`, `stale`, or `failed` may release it only after request-specific work and pre-existing worker windows are drained. |
@@ -97,6 +98,67 @@ If you add or change SQL assertions:
 3. record the exact invocation in the PR
 
 If you add or change an offline Node contract, run its exact file with `node --test` and record that command separately from any deferred Hosted proof.
+
+## Supabase Functions Hooks Compaction
+
+`util.purge_supabase_functions_hooks` enforces logical retention, but ordinary
+deletes and autovacuum do not return the table files to the operating system.
+Treat physical compaction as an explicit production maintenance action.
+
+Before the maintenance window:
+
+1. confirm a current backup or point-in-time recovery window
+2. run the retention preview and bounded purge until `eligible_rows` is zero
+3. capture row count and heap, index, and total bytes with the query below
+4. confirm no long-running session or queued lock is using the hooks relation
+5. stop if the application cannot tolerate an `ACCESS EXCLUSIVE` lock
+
+```sql
+select *
+from util.preview_supabase_functions_hooks_retention(
+  interval '14 days',
+  pg_catalog.now()
+);
+
+select
+  count(*) as row_count,
+  pg_catalog.pg_relation_size('supabase_functions.hooks') as heap_bytes,
+  pg_catalog.pg_indexes_size('supabase_functions.hooks') as index_bytes,
+  pg_catalog.pg_total_relation_size('supabase_functions.hooks') as total_bytes
+from supabase_functions.hooks;
+
+select
+  activity.pid,
+  activity.usename,
+  activity.state,
+  activity.wait_event_type,
+  activity.wait_event,
+  lock.mode,
+  lock.granted,
+  activity.query_start
+from pg_catalog.pg_locks as lock
+join pg_catalog.pg_stat_activity as activity
+  on activity.pid = lock.pid
+where lock.relation = 'supabase_functions.hooks'::regclass
+order by lock.granted, activity.query_start;
+```
+
+Run compaction from a direct database session during the approved window. The
+timeouts make lock contention fail closed instead of queueing indefinitely:
+
+```sql
+set lock_timeout = '5s';
+set statement_timeout = '15min';
+vacuum (full, analyze) supabase_functions.hooks;
+reset statement_timeout;
+reset lock_timeout;
+```
+
+If the lock timeout fires, reschedule; do not increase it while traffic is
+active. After success, rerun the storage query and the retention SQL test,
+record before/after bytes in the delivery Issue, and verify webhook execution.
+`VACUUM FULL` cannot be rolled back, so do not repeat it merely because the
+remaining live rows still require disk space.
 
 ## Schema Workspace Tooling Checks
 

--- a/supabase/migrations/20260727081314_repair_invalid_fk_support_index.sql
+++ b/supabase/migrations/20260727081314_repair_invalid_fk_support_index.sql
@@ -1,0 +1,4 @@
+-- A failed concurrent build can leave the relation present but unusable.
+-- REINDEX CONCURRENTLY repairs both that production state and an already-valid
+-- preview/local index without blocking ordinary reads and writes for the build.
+reindex index concurrently public.dataset_review_submit_gate_runs_supersedes_idx;

--- a/supabase/migrations/20260727081316_performance_advisor_index_governance.sql
+++ b/supabase/migrations/20260727081316_performance_advisor_index_governance.sql
@@ -1,0 +1,54 @@
+-- Nullable foreign-key columns use partial indexes because null rows never
+-- participate in referential checks. Non-nullable keys use full indexes.
+create index if not exists lcia_document_validation_evidence_source_worker_job_idx
+  on public.lcia_document_validation_evidence (source_worker_job_id)
+  where source_worker_job_id is not null;
+
+create index if not exists lcia_result_packages_latest_all_unit_result_idx
+  on public.lcia_result_packages (latest_all_unit_result_id)
+  where latest_all_unit_result_id is not null;
+
+create index if not exists lcia_result_packages_result_idx
+  on public.lcia_result_packages (result_id);
+
+create index if not exists lcia_result_packages_snapshot_idx
+  on public.lcia_result_packages (snapshot_id);
+
+create index if not exists lcia_scope_closure_checks_report_artifact_idx
+  on public.lcia_scope_closure_checks (report_artifact_id)
+  where report_artifact_id is not null;
+
+create index if not exists lcia_scope_closure_checks_reused_from_check_idx
+  on public.lcia_scope_closure_checks (reused_from_check_id)
+  where reused_from_check_id is not null;
+
+create index if not exists lcia_scope_closure_scan_executions_completed_check_idx
+  on public.lcia_scope_closure_scan_executions (completed_check_id)
+  where completed_check_id is not null;
+
+create index if not exists lcia_scope_closure_scan_executions_data_snapshot_token_idx
+  on public.lcia_scope_closure_scan_executions (data_snapshot_token);
+
+create index if not exists lcia_scope_closure_scan_executions_leased_by_job_idx
+  on public.lcia_scope_closure_scan_executions (leased_by_job_id)
+  where leased_by_job_id is not null;
+
+create index if not exists dataset_derivative_rebuild_permits_proposal_idx
+  on util.dataset_derivative_rebuild_permits (proposal_id);
+
+create index if not exists dataset_flow_identity_mutation_permits_scope_ordinal_idx
+  on util.dataset_flow_identity_mutation_permits (scope_id, ordinal);
+
+create index if not exists dataset_flow_identity_process_ledger_audit_idx
+  on util.dataset_flow_identity_process_ledger (audit_id)
+  where audit_id is not null;
+
+create index if not exists dataset_flow_identity_scopes_final_invocation_idx
+  on util.dataset_flow_identity_scopes (final_wrapper_invocation_id)
+  where final_wrapper_invocation_id is not null;
+
+create index if not exists dataset_flow_identity_scopes_receipt_idx
+  on util.dataset_flow_identity_scopes (receipt_id);
+
+-- The unique constraint already provides the same ordered key prefix.
+drop index if exists public.lca_release_artifacts_run_idx;

--- a/supabase/tests/20260608_missing_fk_support_indexes.sql
+++ b/supabase/tests/20260608_missing_fk_support_indexes.sql
@@ -3,41 +3,255 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(7);
+create or replace function pg_temp.has_usable_index_prefix(
+  p_schema text,
+  p_table text,
+  p_columns text[]
+) returns boolean
+language sql
+stable
+as $$
+  select exists (
+    select 1
+    from pg_catalog.pg_namespace as namespace
+    join pg_catalog.pg_class as relation
+      on relation.relnamespace = namespace.oid
+    join pg_catalog.pg_index as idx
+      on idx.indrelid = relation.oid
+    where namespace.nspname = p_schema
+      and relation.relname = p_table
+      and idx.indisvalid
+      and idx.indisready
+      and idx.indislive
+      and idx.indnkeyatts >= cardinality(p_columns)
+      and array(
+        select attribute.attname::text
+        from unnest(idx.indkey) with ordinality as key(attnum, ordinal)
+        join pg_catalog.pg_attribute as attribute
+          on attribute.attrelid = relation.oid
+         and attribute.attnum = key.attnum
+        where key.ordinal <= cardinality(p_columns)
+        order by key.ordinal
+      ) = p_columns
+  );
+$$;
+
+select plan(23);
 
 select ok(
-  to_regclass('public.dataset_review_submit_gate_runs_supersedes_idx') is not null,
-  'dataset_review_submit_gate_runs has a supersedes gate run support index'
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'dataset_review_submit_gate_runs',
+    array['supersedes_gate_run_id']
+  ),
+  'dataset_review_submit_gate_runs has a usable supersedes gate run support index'
 );
 
 select ok(
-  to_regclass('public.lca_network_snapshots_lcia_idx') is not null,
-  'lca_network_snapshots has an LCIA method support index'
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lca_network_snapshots',
+    array['lcia_method_id', 'lcia_method_version']
+  ),
+  'lca_network_snapshots has a usable LCIA method support index'
 );
 
 select ok(
-  to_regclass('public.lca_package_request_cache_export_artifact_idx') is not null,
-  'lca_package_request_cache has an export artifact support index'
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lca_package_request_cache',
+    array['export_artifact_id']
+  ),
+  'lca_package_request_cache has a usable export artifact support index'
 );
 
 select ok(
-  to_regclass('public.lca_package_request_cache_report_artifact_idx') is not null,
-  'lca_package_request_cache has a report artifact support index'
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lca_package_request_cache',
+    array['report_artifact_id']
+  ),
+  'lca_package_request_cache has a usable report artifact support index'
 );
 
 select ok(
-  to_regclass('public.lca_result_cache_snapshot_idx') is not null,
-  'lca_result_cache has a snapshot support index'
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lca_result_cache',
+    array['snapshot_id']
+  ),
+  'lca_result_cache has a usable snapshot support index'
 );
 
 select ok(
-  to_regclass('public.notifications_sender_user_id_idx') is not null,
-  'notifications has a sender user support index'
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'notifications',
+    array['sender_user_id']
+  ),
+  'notifications has a usable sender user support index'
 );
 
 select ok(
-  to_regclass('public.worker_jobs_job_kind_idx') is not null,
-  'worker_jobs has a job kind support index'
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'worker_jobs',
+    array['job_kind']
+  ),
+  'worker_jobs has a usable job kind support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_document_validation_evidence',
+    array['source_worker_job_id']
+  ),
+  'lcia_document_validation_evidence has a usable worker job support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_result_packages',
+    array['latest_all_unit_result_id']
+  ),
+  'lcia_result_packages has a usable latest all-unit result support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_result_packages',
+    array['result_id']
+  ),
+  'lcia_result_packages has a usable result support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_result_packages',
+    array['snapshot_id']
+  ),
+  'lcia_result_packages has a usable snapshot support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_scope_closure_checks',
+    array['report_artifact_id']
+  ),
+  'lcia_scope_closure_checks has a usable report artifact support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_scope_closure_checks',
+    array['reused_from_check_id']
+  ),
+  'lcia_scope_closure_checks has a usable reuse support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_scope_closure_scan_executions',
+    array['completed_check_id']
+  ),
+  'lcia_scope_closure_scan_executions has a usable completed-check support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_scope_closure_scan_executions',
+    array['data_snapshot_token']
+  ),
+  'lcia_scope_closure_scan_executions has a usable snapshot-token support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lcia_scope_closure_scan_executions',
+    array['leased_by_job_id']
+  ),
+  'lcia_scope_closure_scan_executions has a usable lease-job support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'util',
+    'dataset_derivative_rebuild_permits',
+    array['proposal_id']
+  ),
+  'dataset_derivative_rebuild_permits has a usable proposal support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'util',
+    'dataset_flow_identity_mutation_permits',
+    array['scope_id', 'ordinal']
+  ),
+  'dataset_flow_identity_mutation_permits has a usable scope and ordinal support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'util',
+    'dataset_flow_identity_process_ledger',
+    array['audit_id']
+  ),
+  'dataset_flow_identity_process_ledger has a usable audit support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'util',
+    'dataset_flow_identity_scopes',
+    array['final_wrapper_invocation_id']
+  ),
+  'dataset_flow_identity_scopes has a usable final invocation support index'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'util',
+    'dataset_flow_identity_scopes',
+    array['receipt_id']
+  ),
+  'dataset_flow_identity_scopes has a usable receipt support index'
+);
+
+select ok(
+  to_regclass('public.lca_release_artifacts_run_idx') is null,
+  'the redundant lca_release_artifacts run index is absent'
+);
+
+select ok(
+  pg_temp.has_usable_index_prefix(
+    'public',
+    'lca_release_artifacts',
+    array['release_run_id', 'profile_id', 'artifact_format']
+  )
+  and exists (
+    select 1
+    from pg_catalog.pg_class as index_relation
+    join pg_catalog.pg_index as idx
+      on idx.indexrelid = index_relation.oid
+    where index_relation.oid = to_regclass(
+      'public.lca_release_artifacts_profile_format_unique'
+    )
+      and idx.indisunique
+      and idx.indisvalid
+      and idx.indisready
+      and idx.indislive
+  ),
+  'the release artifact profile-format unique index remains usable and unique'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes #291

## Summary
- Repair the invalid dataset-review supersedes support index with REINDEX INDEX CONCURRENTLY.
- Add 14 evidence-backed foreign-key support indexes and remove the exact duplicate release-artifact index.
- Upgrade the SQL regression to verify valid, ready, live ordered key prefixes instead of object names.
- Add a lock-aware hooks compaction runbook while keeping VACUUM FULL outside automatic migrations.

## Key Decisions
- Use partial indexes only for nullable FK columns; null rows do not participate in referential checks.
- Retain all other unused-index notices until workload evidence supports an individual removal.
- Keep the non-transactional concurrent reindex isolated from the ordinary index-governance migration.

## Validation
- npx --yes supabase@2.109.1 start
- npx --yes supabase@2.109.1 db reset
- npx --yes supabase@2.109.1 migration list --local
- npx --yes supabase@2.109.1 test db --local supabase/tests/20260608_missing_fk_support_indexes.sql (23/23)
- Hooks retention, LCI/LCIA release, scope-closure, and guarded flow-identity pgTAP regressions passed; 343 assertions ran in the combined suite, followed by the corrected 23/23 index suite.
- npx --yes supabase@2.109.1 db lint --level warning completed; it reports existing function diagnostics and this PR adds no functions.
- docpact validate-config --root . --strict and enforced seven-path docpact lint passed; the pre-push gate repeated both successfully.

## Risks / Rollback
- REINDEX CONCURRENTLY and index creation consume temporary I/O and disk; target relations are currently small, and Preview proof should precede dev merge.
- VACUUM FULL is documented but deliberately not executed or deployed; production hooks compaction requires an approved backup-backed maintenance window.

## Follow-ups
- Verify the Performance Advisor delta on the PR Preview branch.
- After merge, verify persistent dev migration history and advisor output; the current persistent dev branch reports MIGRATIONS_FAILED and must be reconciled before relying on it for rollout proof.

## Workspace Integration
- After dev-to-main promotion, lca-workspace may integrate only the resulting database-engine main commit.