### PR TITLE
feat: add api boundary POC schema stage

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-07-31"
-lastReviewedCommit: "be5b5db38fd34649524c1b18b2e582ad84b4f6bc"
-lastReviewedNote: "Reviewed through Issues #323, #324, and #329: existing ownership, guarded-flow-identity routing, generated-workspace boundaries, and workspace-integration requirements remain correct; Root/Reference Review stays migration/test owned and provider qualification stays script/proof owned."
+lastReviewedAt: "2026-08-01"
+lastReviewedCommit: "cccdb4e90b65cc7b56dbae72946637cede599ba3"
+lastReviewedNote: "Reviewed for Issue #340 api/private boundary POC: config ownership and validation routes cover the staged api exposure contract while private/util/archive remain non-exposed."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: be5b5db38fd34649524c1b18b2e582ad84b4f6bc
-lastReviewedNote: "Reviewed through Issues #323, #324, and #329: database ownership, migration source-of-truth, dev-first delivery, and later workspace integration remain unchanged; the Flow fence stays narrow, Root/Reference Review stays migration/test owned, and isolated provider adapters add executable evidence only."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
+lastReviewedNote: "Reviewed for Issue #340 api/private boundary POC: api is created before its separately deployed exposure; private, util, and archive remain non-exposed, and database ownership, dev-first delivery, and workspace integration remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -110,6 +110,7 @@ Do not start from generated schema workspace files, long migration history, or G
 Keep these entry-level facts in `AGENTS.md`. Use `docs/agents/repo-validation.md` and the narrow source docs for the full details.
 
 - local baseline: `supabase start`, `supabase db reset`, `supabase migration list`
+- Data API exposure is explicit and staged: create and validate `api` before a later configuration deployment exposes `api`, `public`, and `graphql_public`; `private`, `util`, and `archive` must remain absent from both exposed schemas and `extra_search_path`
 - `supabase/seed.sql` must remain an executable SQL batch even when it seeds no rows; retain a data-neutral no-op rather than comments only
 - hosted mutation E2E assets under `supabase/tests/preview/**` must hard-bind the exact Preview project ref, use disposable actors and UUID namespaces, clean up only their own effects, and never become migrations, seeds, Dev data rehearsals, or production execution paths
 - disposable Hosted actors must use an outer-frozen request/namespace and deterministic role email, be registered before creation, carry exact fixture/request/namespace/role metadata, recover only one exact filtered metadata match, use global logout, and treat hard admin DELETE as incomplete until both GET-by-ID returns 404 and a fresh exact filtered census is empty; the outer wrapper must create the exact empty owner-only non-symlink private temp directory and durably fsync each secret-free inner recovery checkpoint before returning its exact IPC ACK, so an actor ID is durable before sign-in or fixture mutation; cleanup must hold the derivative coordinator lock and remain before external dispatch, any missing or ambiguous global logout must retain the actor and forbid hard DELETE, and temporary credential files must be proven removed independently by the inner and outer processes; offline lifecycle and 39-surface residue contracts prove the local control/readback shape without replacing the later exact-head Hosted run and independent Auth/SQL readback execution

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ It owns the checked-in database source of truth:
 - the GitHub Actions flow that pushes committed migrations to the persistent Supabase `dev` branch
 - the production Supabase GitHub integration contract that applies Git `main` migrations automatically
 
+The target Data API boundary is configuration-as-code: `api`, `public`, and `graphql_public` are exposed, while `private`, `util`, and `archive` remain non-exposed. New stable DTO/RPC contracts belong in `api`; internal runtime relations and routines belong in `private`. A new exposed schema must be deployed and validated before a later configuration deployment exposes it.
+
 It does **not** own:
 
 - frontend runtime env files such as `.env` or `.env.development`

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: be5b5db38fd34649524c1b18b2e582ad84b4f6bc
-lastReviewedNote: "Reviewed through Issues #323, #324, and #329: schema truth remains migration-owned; the narrowed Flow fence and Root/Reference Review workflow preserve ownership and generated-workspace boundaries, while isolated provider evidence stays script-owned."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
+lastReviewedNote: "Reviewed for Issue #340 api/private boundary POC: record the staged api DTO/RPC layer and non-exposed private runtime boundary without changing repo ownership or source-of-truth paths."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -59,6 +59,16 @@ This repo is organized around one checked-in Supabase project plus a generated s
 | `supabase/workspace/remote_schema.sql` | generated full raw dump from the remote database |
 | `supabase/workspace/global/**` | generated split-out global objects rebuilt on workspace refresh |
 | `supabase/workspace/schemas/**` | generated human-browsable split schema objects rebuilt on workspace refresh |
+
+## Schema Boundary Model
+
+- `public` retains the nine core entity tables and existing compatibility objects during Expand.
+- `api` is the explicit versioned PostgREST DTO/RPC layer. Views use `security_invoker`, routines have fixed search paths, and grants are per object. Its schema and objects are deployed before a later configuration change exposes it.
+- `private` owns internal runtime and control-plane objects and is never an exposed Data API schema.
+- `util` and `archive` retain operations/history responsibilities and are never exposed Data API schemas.
+- Realtime publishes explicitly selected physical tables; `api` views are not a Realtime source.
+
+Physical moves happen only after consumers use the `api` or `private` contract and the Contract gate proves zero compatibility callers. Expand views and wrappers must preserve one physical source of truth.
 
 ## Branch Model In Practice
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-07-31
-lastReviewedCommit: be5b5db38fd34649524c1b18b2e582ad84b4f6bc
-lastReviewedNote: "Reviewed through Issues #323, #324, and #329: retain Flow identity/rebuild and Root/Reference Review backup/cutover proofs; the existing #308/#316 scope-closure matrix remains authoritative and is executed by isolated owner adapters."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
+lastReviewedNote: "Reviewed for Issue #340 api/private boundary POC: add staged schema/config deployment plus SQL ACL/parity, local REST profile, and hosted exact-ref proof requirements."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -103,6 +103,7 @@ reported as those 19 files passing.
 | `supabase/tests/**` only | run the relevant SQL assertion files against a reset local DB | add a nearby migration or policy smoke check if the new assertions expose a gap | This repo stores PGTAP-style SQL assertions, not a single canonical runner wrapper. |
 | `supabase/seed.sql` or `supabase/seeds/dev.sql` | `supabase db reset` succeeds with expected seed behavior | rerun targeted SQL assertions that depend on the seeded rows; for shared-seed changes, confirm the hosted Preview seed stage completes | Keep shared seed and dev-only seed expectations separate. A shared seed with no data must still contain an executable no-op statement; a comments-only batch is not deployment-safe. |
 | `supabase/config.toml` | `supabase start` and `supabase db reset` still work locally | verify the changed branch-binding or auth assumption against `docs/agents/supabase-branching.md` | Config changes can affect preview, persistent dev, and local behavior together. |
+| Data API exposed-schema or `api` DTO/RPC boundary | deploy in two stages: first `supabase db reset` and `supabase/tests/20260801_api_private_boundary_poc.sql`; only after that exact migration is hosted, change exposed schemas and run `node --test supabase/tests/20260801_api_private_boundary_config_contract.mjs` plus the read-only `20260801_api_private_boundary_rest_contract.mjs` with local URL/keys | after the schema-only stage succeeds on persistent `dev`, deploy configuration separately; on that exact ref rerun the REST contract with `EXPECTED_PROJECT_REF` and prove `api` succeeds, `private`/`util`/`archive` return PGRST106, anonymous service RPC calls fail, authenticated write and service/direct-SQL paths succeed, and schema-cache reload plus generated types see the intended contract | Supabase applies `Configure` before `Migrate`; never expose a schema in the same deployment that first creates it. `api` views are `security_invoker`; every object has explicit grants; private schemas stay out of exposed schemas and `extra_search_path`; Realtime remains on explicitly published physical tables rather than API views. |
 | `.github/workflows/supabase-dev.yml` | inspect YAML changes and confirm referenced secrets and vars still exist in docs | verify the intended deploy path in a PR note because the real push occurs only on Git `dev`; for `main -> dev` reconciliation, prove an older-timestamped committed migration is installed with `--include-all` without reapplying recorded history | Local dry-run for GitHub-hosted execution is limited; document the expected remote proof. |
 | `scripts/**` | run the touched script with `--help` when possible, or execute the narrowest safe non-destructive path | if a script changes generated workspace behavior, refresh the workspace in a safe environment and inspect git diff | Avoid remote-destructive script runs unless the task explicitly requires them. |
 | `supabase/workspace/**` | prove whether the touched file is generated or stable | if stable manual overlay files changed, explain how they feed migration generation | Generated files alone are not sufficient evidence of a durable schema change. |

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,9 +20,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: 6577b7a48f90ae449cbdd2ef419d92d13c273a0c
-lastReviewedNote: "Reviewed Issue #308 rollout follow-up: the additive publication/GC migration reapplies final guards and RPCs so an existing Preview can advance even when earlier PR migrations were already recorded."
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
+lastReviewedNote: "Reviewed Issue #340 api/private boundary POC: document the required schema-first, configuration-second rollout for the api/public/graphql_public exposure contract."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -80,6 +80,8 @@ When review changes an already-applied PR migration, add a later migration that 
 - Keep `.github/workflows/supabase-dev.yml` as the only GitHub Actions flow in this repo that runs `supabase db push` for the persistent Supabase `dev` branch.
 - Do not add a checked-in GitHub Actions production deploy for Git `main`; the production project is migrated by the Supabase GitHub integration bound to this repository.
 - Do not author normal schema changes by editing the remote database first and reconstructing migrations later.
+- Keep Data API schemas configuration-as-code: the target is `api`, `public`, and `graphql_public`; never add `private`, `util`, or `archive` to exposed schemas or `extra_search_path`.
+- Supabase's GitHub deployment DAG applies `Configure` before `Migrate`. Therefore, first deploy and verify a new schema and its API objects with the existing exposure configuration; only a later commit/PR may expose that already-hosted schema. Never introduce a schema and expose it in the same deployment.
 
 ## Files to maintain
 

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -20,8 +20,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-05-18
-lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
+lastReviewedAt: 2026-08-01
+lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
+lastReviewedNote: "已针对 Issue #340 api/private 边界 POC 复核：记录 api/public/graphql_public 暴露合同必须先部署 schema、再单独部署配置。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -77,6 +78,8 @@ related:
 - 把 `.github/workflows/supabase-dev.yml` 作为本仓唯一会对持久化 Supabase `dev` 分支执行 `supabase db push` 的 GitHub Actions 流程。
 - 不要为 Git `main` 增加 checked-in 的 GitHub Actions 生产部署流程；生产项目由绑定到本仓的 Supabase GitHub integration 自动迁移。
 - 不要先手改远端数据库再回头补 migration。
+- Data API schema 必须配置即代码：目标只暴露 `api`、`public` 和 `graphql_public`；不得把 `private`、`util` 或 `archive` 加入 exposed schemas 或 `extra_search_path`。
+- Supabase GitHub 部署 DAG 会先执行 `Configure`，后执行 `Migrate`。因此必须先用现有暴露配置部署并验证新 schema 及其 API 对象，后续再通过单独的 commit/PR 暴露已存在的 schema；不得在同一次部署中首次创建并暴露 schema。
 
 ## 需要维护的文件
 

--- a/supabase/migrations/20260801023000_api_private_boundary_poc.sql
+++ b/supabase/migrations/20260801023000_api_private_boundary_poc.sql
@@ -1,0 +1,144 @@
+-- Representative api/private boundary contract for the full schema refactor.
+--
+-- This is an additive Expand migration. Physical tables remain in public while
+-- consumers move to explicit api DTO/RPC contracts and direct database workers
+-- use private schema-qualified relations. Contract-stage physical moves remain
+-- separately gated by exact consumer-zero and populated-upgrade evidence.
+
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '2min';
+
+create schema if not exists api;
+revoke all on schema api from public;
+grant usage on schema api to anon, authenticated, service_role;
+
+-- New API objects are closed by default. Every DTO/RPC below grants only the
+-- roles required by its contract.
+alter default privileges for role postgres in schema api
+  revoke all on tables from public, anon, authenticated, service_role;
+alter default privileges for role postgres in schema api
+  revoke all on sequences from public, anon, authenticated, service_role;
+alter default privileges for role postgres in schema api
+  revoke execute on functions from public, anon, authenticated, service_role;
+
+create or replace view api.processes_v1
+with (security_invoker = true)
+as
+select
+  id,
+  json,
+  created_at,
+  user_id,
+  state_code,
+  version,
+  modified_at,
+  team_id,
+  review_id,
+  rule_verification,
+  reviews,
+  model_id
+from public.processes;
+
+revoke all on api.processes_v1 from public, anon, authenticated, service_role;
+grant select on api.processes_v1 to anon, authenticated, service_role;
+
+comment on view api.processes_v1 is
+  'Versioned, security-invoker core Process read DTO. RLS remains owned by public.processes during Expand.';
+
+create or replace view api.review_comments_v1
+with (security_invoker = true)
+as
+select
+  review_id,
+  reviewer_id,
+  json,
+  created_at,
+  modified_at,
+  state_code
+from public.comments;
+
+revoke all on api.review_comments_v1 from public, anon, authenticated, service_role;
+grant select on api.review_comments_v1 to authenticated, service_role;
+
+comment on view api.review_comments_v1 is
+  'Versioned, security-invoker review comment DTO. The underlying public.comments RLS remains authoritative during Expand.';
+
+create or replace function api.cmd_review_save_comment_draft_v1(
+  p_review_id uuid,
+  p_json jsonb,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language sql
+security invoker
+set search_path = ''
+as $$
+  select public.cmd_review_save_comment_draft(p_review_id, p_json, p_audit)
+$$;
+
+alter function api.cmd_review_save_comment_draft_v1(uuid, jsonb, jsonb)
+  owner to postgres;
+revoke all on function api.cmd_review_save_comment_draft_v1(uuid, jsonb, jsonb)
+  from public, anon, authenticated, service_role;
+grant execute on function api.cmd_review_save_comment_draft_v1(uuid, jsonb, jsonb)
+  to authenticated, service_role;
+
+comment on function api.cmd_review_save_comment_draft_v1(uuid, jsonb, jsonb) is
+  'Authenticated versioned command adapter preserving the existing review draft result/error envelope during Expand.';
+
+create or replace function api.worker_list_jobs_by_concurrency_key_v1(
+  p_job_kind text,
+  p_concurrency_key text,
+  p_statuses text[],
+  p_limit integer default 20,
+  p_include_internal boolean default true
+) returns jsonb
+language sql
+security invoker
+set search_path = ''
+as $$
+  select public.worker_list_jobs_by_concurrency_key(
+    p_job_kind,
+    p_concurrency_key,
+    p_statuses,
+    p_limit,
+    p_include_internal
+  )
+$$;
+
+alter function api.worker_list_jobs_by_concurrency_key_v1(text, text, text[], integer, boolean)
+  owner to postgres;
+revoke all on function api.worker_list_jobs_by_concurrency_key_v1(text, text, text[], integer, boolean)
+  from public, anon, authenticated, service_role;
+grant execute on function api.worker_list_jobs_by_concurrency_key_v1(text, text, text[], integer, boolean)
+  to service_role;
+
+create or replace function api.worker_read_jobs_by_ids_v1(
+  p_job_ids uuid[],
+  p_include_internal boolean default false
+) returns jsonb
+language sql
+security invoker
+set search_path = ''
+as $$
+  select public.worker_read_jobs_by_ids(p_job_ids, p_include_internal)
+$$;
+
+alter function api.worker_read_jobs_by_ids_v1(uuid[], boolean)
+  owner to postgres;
+revoke all on function api.worker_read_jobs_by_ids_v1(uuid[], boolean)
+  from public, anon, authenticated, service_role;
+grant execute on function api.worker_read_jobs_by_ids_v1(uuid[], boolean)
+  to service_role;
+
+comment on function api.worker_list_jobs_by_concurrency_key_v1(text, text, text[], integer, boolean) is
+  'Service-only versioned Data API adapter over the private Worker control-plane Expand contract.';
+comment on function api.worker_read_jobs_by_ids_v1(uuid[], boolean) is
+  'Service-only versioned bounded batch-read adapter over the private Worker control-plane Expand contract.';
+
+-- Views are deliberately not added to supabase_realtime. Core public tables
+-- remain the Realtime publication boundary; api is a PostgREST DTO/RPC layer.
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/tests/20260801_api_private_boundary_poc.sql
+++ b/supabase/tests/20260801_api_private_boundary_poc.sql
@@ -1,0 +1,175 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select no_plan();
+
+select has_schema('api', 'api schema exists');
+select ok(has_schema_privilege('anon', 'api', 'USAGE'), 'anon can resolve explicitly granted api objects');
+select ok(has_schema_privilege('authenticated', 'api', 'USAGE'), 'authenticated can resolve api objects');
+select ok(has_schema_privilege('service_role', 'api', 'USAGE'), 'service role can resolve api objects');
+select ok(not has_schema_privilege('public', 'api', 'USAGE'), 'PUBLIC has no api schema usage');
+
+select has_view('api', 'processes_v1', 'versioned Process DTO exists');
+select has_view('api', 'review_comments_v1', 'versioned review comment DTO exists');
+select ok((
+  select coalesce(c.reloptions, '{}') @> array['security_invoker=true']
+  from pg_class c join pg_namespace n on n.oid = c.relnamespace
+  where n.nspname = 'api' and c.relname = 'processes_v1'
+), 'Process DTO is security_invoker');
+select ok((
+  select coalesce(c.reloptions, '{}') @> array['security_invoker=true']
+  from pg_class c join pg_namespace n on n.oid = c.relnamespace
+  where n.nspname = 'api' and c.relname = 'review_comments_v1'
+), 'review comment DTO is security_invoker');
+
+select ok(has_table_privilege('anon', 'api.processes_v1', 'SELECT'), 'anon may enter the Process DTO and remains constrained by base RLS');
+select ok(has_table_privilege('authenticated', 'api.processes_v1', 'SELECT'), 'authenticated may select the Process DTO');
+select ok(has_table_privilege('service_role', 'api.processes_v1', 'SELECT'), 'service role may select the Process DTO');
+select ok(not has_table_privilege('anon', 'api.review_comments_v1', 'SELECT'), 'anon cannot select review comments');
+select ok(has_table_privilege('authenticated', 'api.review_comments_v1', 'SELECT'), 'authenticated may select review comments through base RLS');
+
+select has_function('api', 'cmd_review_save_comment_draft_v1', array['uuid', 'jsonb', 'jsonb'], 'authenticated write adapter exists');
+select has_function('api', 'worker_list_jobs_by_concurrency_key_v1', array['text', 'text', 'text[]', 'integer', 'boolean'], 'service list adapter exists');
+select has_function('api', 'worker_read_jobs_by_ids_v1', array['uuid[]', 'boolean'], 'service batch adapter exists');
+select ok(has_function_privilege('authenticated', 'api.cmd_review_save_comment_draft_v1(uuid,jsonb,jsonb)', 'EXECUTE'), 'authenticated can execute review write adapter');
+select ok(not has_function_privilege('anon', 'api.cmd_review_save_comment_draft_v1(uuid,jsonb,jsonb)', 'EXECUTE'), 'anon cannot execute review write adapter');
+select ok(has_function_privilege('service_role', 'api.worker_list_jobs_by_concurrency_key_v1(text,text,text[],integer,boolean)', 'EXECUTE'), 'service role can execute Worker list adapter');
+select ok(not has_function_privilege('authenticated', 'api.worker_list_jobs_by_concurrency_key_v1(text,text,text[],integer,boolean)', 'EXECUTE'), 'authenticated cannot execute service Worker list adapter');
+select ok(not has_function_privilege('anon', 'api.worker_read_jobs_by_ids_v1(uuid[],boolean)', 'EXECUTE'), 'anon cannot execute service Worker batch adapter');
+
+select ok((
+  select not p.prosecdef and p.proconfig @> array['search_path=""']
+  from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'api' and p.proname = 'cmd_review_save_comment_draft_v1'
+), 'authenticated adapter is invoker-rights with an empty search_path');
+select ok((
+  select bool_and(not p.prosecdef and p.proconfig @> array['search_path=""'])
+  from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'api' and p.proname like 'worker_%_v1'
+), 'service adapters are invoker-rights with an empty search_path');
+
+select ok((
+  select exists (
+    select 1
+    from pg_rewrite rw
+    join pg_depend d on d.objid = rw.oid
+    where rw.ev_class = 'api.processes_v1'::regclass
+      and d.refobjid = 'public.processes'::regclass
+  )
+), 'Process DTO has an explicit dependency on the core public table');
+select ok((
+  select exists (
+    select 1
+    from pg_rewrite rw
+    join pg_depend d on d.objid = rw.oid
+    where rw.ev_class = 'api.review_comments_v1'::regclass
+      and d.refobjid = 'public.comments'::regclass
+  )
+), 'review DTO depends on the compatibility relation during Expand');
+select ok((
+  select exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.comments'::regclass
+      and confrelid = 'public.reviews'::regclass
+      and contype = 'f'
+  )
+), 'the underlying comment-to-review FK remains intact');
+select ok((
+  select exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.comments'::regclass
+      and tgname = 'comments_v2_kind_guard'
+      and not tgisinternal
+  )
+), 'the underlying comment guard trigger remains intact');
+
+select ok((
+  select not exists (
+    select 1 from pg_publication_tables
+    where schemaname in ('api', 'private')
+  )
+), 'DTO and private schemas are not accidental Realtime publication sources');
+select ok((
+  select pg_get_functiondef('public.worker_list_jobs_by_concurrency_key(text,text,text[],integer,boolean)'::regprocedure)
+    like '%null::public.worker_jobs%'
+), 'Expand preserves the public worker_jobs composite dependency until Contract');
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', '81000000-0000-0000-0000-000000000001', true);
+
+select is(
+  api.cmd_review_save_comment_draft_v1(
+    '81000000-0000-0000-0000-000000000099',
+    '[]'::jsonb,
+    '{}'::jsonb
+  ),
+  public.cmd_review_save_comment_draft(
+    '81000000-0000-0000-0000-000000000099',
+    '[]'::jsonb,
+    '{}'::jsonb
+  ),
+  'new and compatibility authenticated commands preserve the invalid-payload envelope'
+);
+
+insert into public.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json,
+  review_kind,
+  target_table,
+  submitted_revision_checksum,
+  target_owner_id,
+  scope_schema_version,
+  scope_history
+) values (
+  '81000000-0000-0000-0000-000000000010',
+  '81000000-0000-0000-0000-000000000020',
+  '01.00.000',
+  1,
+  '["81000000-0000-0000-0000-000000000001"]'::jsonb,
+  '{"user":{"id":"81000000-0000-0000-0000-000000000001"},"data":{"id":"81000000-0000-0000-0000-000000000020","version":"01.00.000"}}'::jsonb,
+  'root',
+  'processes',
+  repeat('a', 64),
+  '81000000-0000-0000-0000-000000000001',
+  'review_scope.v1',
+  '{"schema_version":"review_scope.v1","snapshots":[]}'::jsonb
+);
+
+set local role authenticated;
+create temporary table api_private_poc_write_result as
+select api.cmd_review_save_comment_draft_v1(
+  '81000000-0000-0000-0000-000000000010',
+  '{"schemaVersion":"review-comment.v1","comment":"api boundary POC"}'::jsonb,
+  '{"source":"api-private-poc"}'::jsonb
+) as result;
+reset role;
+
+select ok((select (result->>'ok')::boolean from api_private_poc_write_result), 'authenticated api command performs a real write');
+select is((
+  select json::jsonb->>'comment' from public.comments
+  where review_id = '81000000-0000-0000-0000-000000000010'
+    and reviewer_id = '81000000-0000-0000-0000-000000000001'
+), 'api boundary POC', 'write reaches the compatibility table through the existing trigger/FK contract');
+select is((
+  select count(*)::integer from public.command_audit_log
+  where command = 'cmd_review_save_comment_draft'
+    and target_id = '81000000-0000-0000-0000-000000000010'
+), 1, 'authenticated api command preserves audit behavior');
+
+select set_config('request.jwt.claim.role', 'service_role', true);
+set local role service_role;
+select is(
+  api.worker_read_jobs_by_ids_v1('{}'::uuid[], false),
+  jsonb_build_object('ok', true, 'data', '[]'::jsonb),
+  'service-role API batch adapter executes through the private Worker contract'
+);
+reset role;
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- create the additive `api` schema and explicit default-deny privileges
- add representative versioned core/read, authenticated-write, and service-only adapter contracts
- add 35 PGTAP assertions for ACL, invoker semantics, RLS/write parity, audit, FK/trigger/composite, and Realtime boundaries
- document the mandatory schema-first/config-second rollout because Supabase deploys `Configure` before `Migrate`

## Deployment phase
This is phase A of #340. It deliberately does **not** expose `api` in `config.toml`. After this PR is merged and migration `20260801023000` is proven on persistent Supabase dev, a second PR will change exposed schemas and run the hosted REST contract.

## Validation
- blank local replay through `20260801023000`: pass
- explicit `supabase db reset`: pass
- `supabase/tests/20260801_api_private_boundary_poc.sql`: 35/35 pass
- generated TypeScript types include the new views/RPCs: pass
- `supabase db lint --local --level warning`: no new `api` findings (existing advisor findings remain)
- `docpact validate-config --strict`: pass
- `docpact lint`: pass
- `git diff --check`: pass

## Risk / rollback
- additive only; existing `public` API and consumers remain unchanged
- no `api` Realtime publication and no exposure configuration change in this phase
- rollback is removal of the new adapters/schema before phase B, if required

Refs #340
Parent: tiangong-lca/workspace#484