### PR TITLE
feat: expose versioned api boundary on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-01"
-lastReviewedCommit: "cccdb4e90b65cc7b56dbae72946637cede599ba3"
-lastReviewedNote: "Reviewed for Issue #340 api/private boundary POC: config ownership and validation routes cover the staged api exposure contract while private/util/archive remain non-exposed."
+lastReviewedCommit: "1445889b2746c28fc80b77db8ee15213470da718"
+lastReviewedNote: "Reviewed for Issue #340 stage B: config ownership and validation routes cover api exposure plus migration-before-config deployment while private/util/archive remain non-exposed."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -2,7 +2,7 @@ version: 1
 layout: repo
 lastReviewedAt: "2026-08-01"
 lastReviewedCommit: "1445889b2746c28fc80b77db8ee15213470da718"
-lastReviewedNote: "Reviewed for Issue #340 stage B: config ownership and validation routes cover api exposure plus migration-before-config deployment while private/util/archive remain non-exposed."
+lastReviewedNote: "Reviewed for Issue #340 stage B: config ownership and validation routes cover the persistent-branch api exposure contract while private/util/archive remain non-exposed."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -29,9 +29,3 @@ jobs:
 
       - name: Push migrations to Supabase dev branch
         run: supabase db push --include-all
-
-      # Supabase's hosted deployment DAG configures services before migrations.
-      # Our persistent-dev path deliberately reverses that unsafe first-schema
-      # order: an exposed schema must already exist before PostgREST is updated.
-      - name: Push configuration to Supabase dev branch
-        run: supabase config push --project-ref "$SUPABASE_PROJECT_ID"

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -29,3 +29,9 @@ jobs:
 
       - name: Push migrations to Supabase dev branch
         run: supabase db push --include-all
+
+      # Supabase's hosted deployment DAG configures services before migrations.
+      # Our persistent-dev path deliberately reverses that unsafe first-schema
+      # order: an exposed schema must already exist before PostgREST is updated.
+      - name: Push configuration to Supabase dev branch
+        run: supabase config push --project-ref "$SUPABASE_PROJECT_ID"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
-lastReviewedNote: "Reviewed for Issue #340 api/private boundary POC: api is created before its separately deployed exposure; private, util, and archive remain non-exposed, and database ownership, dev-first delivery, and workspace integration remain unchanged."
+lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
+lastReviewedNote: "Reviewed for Issue #340 stage B: api is exposed only after its hosted schema deployment; private, util, and archive remain non-exposed, and database ownership, dev-first delivery, and workspace integration remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ checkPaths:
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
 lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
-lastReviewedNote: "Reviewed for Issue #340 stage B: api is exposed only after its hosted schema deployment; private, util, and archive remain non-exposed, and database ownership, dev-first delivery, and workspace integration remain unchanged."
+lastReviewedNote: "Reviewed for Issue #340 stage B: api is exposed through the persistent-branch binding only after its hosted schema deployment; private, util, and archive remain non-exposed."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It owns the checked-in database source of truth:
 - the GitHub Actions flow that pushes committed migrations to the persistent Supabase `dev` branch
 - the production Supabase GitHub integration contract that applies Git `main` migrations automatically
 
-The target Data API boundary is configuration-as-code: `api`, `public`, and `graphql_public` are exposed, while `private`, `util`, and `archive` remain non-exposed. New stable DTO/RPC contracts belong in `api`; internal runtime relations and routines belong in `private`. A new exposed schema must be deployed and validated before a later configuration deployment exposes it.
+The Data API boundary is configuration-as-code: `api`, `public`, and `graphql_public` are exposed, while `private`, `util`, and `archive` remain non-exposed. New stable DTO/RPC contracts belong in `api`; internal runtime relations and routines belong in `private`. A new exposed schema must be deployed and validated before a later configuration deployment exposes it.
 
 It does **not** own:
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,8 +28,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
-lastReviewedNote: "Reviewed for Issue #340 api/private boundary POC: record the staged api DTO/RPC layer and non-exposed private runtime boundary without changing repo ownership or source-of-truth paths."
+lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
+lastReviewedNote: "Reviewed for Issue #340 stage B: the already-hosted api DTO/RPC layer becomes exposed while the private runtime boundary and repository source-of-truth paths remain unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
 lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
-lastReviewedNote: "Reviewed for Issue #340 stage B: the already-hosted api DTO/RPC layer becomes exposed while the private runtime boundary and repository source-of-truth paths remain unchanged."
+lastReviewedNote: "Reviewed for Issue #340 stage B: the persistent-branch binding exposes the already-hosted api DTO/RPC layer while the private runtime boundary and repository source-of-truth paths remain unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
-lastReviewedNote: "Reviewed for Issue #340 api/private boundary POC: add staged schema/config deployment plus SQL ACL/parity, local REST profile, and hosted exact-ref proof requirements."
+lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
+lastReviewedNote: "Reviewed for Issue #340 stage B: validate migration-before-config ordering, local REST profiles, and hosted exact-ref API/private boundary proof."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
 lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
-lastReviewedNote: "Reviewed for Issue #340 stage B: validate migration-before-config ordering, local REST profiles, and hosted exact-ref API/private boundary proof."
+lastReviewedNote: "Reviewed for Issue #340 stage B: validate the staged Branching deployment, local REST profiles, and hosted exact-ref API/private boundary proof."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -21,8 +21,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
-lastReviewedNote: "Reviewed Issue #340 api/private boundary POC: document the required schema-first, configuration-second rollout for the api/public/graphql_public exposure contract."
+lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
+lastReviewedNote: "Reviewed Issue #340 stage B: persistent dev now pushes configuration after migrations to implement the api/public/graphql_public exposure contract safely."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -77,16 +77,16 @@ When review changes an already-applied PR migration, add a later migration that 
 - Treat committed files in `supabase/migrations/` as the schema source of truth for production, `dev`, and preview branches.
 - Keep branch-specific overrides in `[remotes.<branch>]` inside `supabase/config.toml`.
 - Do not create a separate `supabase/` directory per Git branch.
-- Keep `.github/workflows/supabase-dev.yml` as the only GitHub Actions flow in this repo that runs `supabase db push` for the persistent Supabase `dev` branch.
+- Keep `.github/workflows/supabase-dev.yml` as the only GitHub Actions flow in this repo that runs `supabase db push` and `supabase config push` for the persistent Supabase `dev` branch. Migration push must precede configuration push.
 - Do not add a checked-in GitHub Actions production deploy for Git `main`; the production project is migrated by the Supabase GitHub integration bound to this repository.
 - Do not author normal schema changes by editing the remote database first and reconstructing migrations later.
-- Keep Data API schemas configuration-as-code: the target is `api`, `public`, and `graphql_public`; never add `private`, `util`, or `archive` to exposed schemas or `extra_search_path`.
+- Keep Data API schemas configuration-as-code: expose `api`, `public`, and `graphql_public`; never add `private`, `util`, or `archive` to exposed schemas or `extra_search_path`.
 - Supabase's GitHub deployment DAG applies `Configure` before `Migrate`. Therefore, first deploy and verify a new schema and its API objects with the existing exposure configuration; only a later commit/PR may expose that already-hosted schema. Never introduce a schema and expose it in the same deployment.
 
 ## Files to maintain
 
 - `supabase/config.toml`: shared baseline plus `[remotes.dev]`
-- `.github/workflows/supabase-dev.yml`: pushes committed migrations to the persistent Supabase `dev` branch on Git `dev`
+- `.github/workflows/supabase-dev.yml`: pushes committed migrations and then configuration to the persistent Supabase `dev` branch on Git `dev`
 - `supabase/migrations/*.sql`: committed migration history
 - `supabase/seed.sql`: shared seed data
 - `supabase/seeds/dev.sql`: optional persistent-dev-only seed data
@@ -144,9 +144,8 @@ Normal PR path:
    Supabase `dev` branch.
 5. After the PR merges, the resulting push to Git `dev` triggers
    `.github/workflows/supabase-dev.yml`.
-6. The workflow links to `SUPABASE_DEV_PROJECT_ID` and runs `supabase db push --include-all`.
-7. Pending checked-in migrations are then applied to the persistent Supabase
-   `dev` branch.
+6. The workflow links to `SUPABASE_DEV_PROJECT_ID`, runs `supabase db push --include-all`, and only after it succeeds runs `supabase config push`.
+7. Pending checked-in migrations and then the checked-in service configuration are applied to the persistent Supabase `dev` branch.
 
 An existing Preview branch applies newly added migration files on later PR
 pushes. Editing a migration already recorded in that Preview's migration

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,7 +22,7 @@ checkPaths:
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-01
 lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
-lastReviewedNote: "Reviewed Issue #340 stage B: persistent dev now pushes configuration after migrations to implement the api/public/graphql_public exposure contract safely."
+lastReviewedNote: "Reviewed Issue #340 stage B: the persistent dev binding applies the api/public/graphql_public exposure contract only after the schema-first PR is hosted."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -77,7 +77,7 @@ When review changes an already-applied PR migration, add a later migration that 
 - Treat committed files in `supabase/migrations/` as the schema source of truth for production, `dev`, and preview branches.
 - Keep branch-specific overrides in `[remotes.<branch>]` inside `supabase/config.toml`.
 - Do not create a separate `supabase/` directory per Git branch.
-- Keep `.github/workflows/supabase-dev.yml` as the only GitHub Actions flow in this repo that runs `supabase db push` and `supabase config push` for the persistent Supabase `dev` branch. Migration push must precede configuration push.
+- Keep `.github/workflows/supabase-dev.yml` as the only GitHub Actions flow in this repo that runs `supabase db push` for the persistent Supabase `dev` branch. Branch configuration remains owned by the Supabase GitHub integration and `[remotes.dev]`; do not add an unconditional `supabase config push` that could apply unrelated remote config drift.
 - Do not add a checked-in GitHub Actions production deploy for Git `main`; the production project is migrated by the Supabase GitHub integration bound to this repository.
 - Do not author normal schema changes by editing the remote database first and reconstructing migrations later.
 - Keep Data API schemas configuration-as-code: expose `api`, `public`, and `graphql_public`; never add `private`, `util`, or `archive` to exposed schemas or `extra_search_path`.
@@ -86,7 +86,7 @@ When review changes an already-applied PR migration, add a later migration that 
 ## Files to maintain
 
 - `supabase/config.toml`: shared baseline plus `[remotes.dev]`
-- `.github/workflows/supabase-dev.yml`: pushes committed migrations and then configuration to the persistent Supabase `dev` branch on Git `dev`
+- `.github/workflows/supabase-dev.yml`: pushes committed migrations to the persistent Supabase `dev` branch on Git `dev`
 - `supabase/migrations/*.sql`: committed migration history
 - `supabase/seed.sql`: shared seed data
 - `supabase/seeds/dev.sql`: optional persistent-dev-only seed data
@@ -144,8 +144,8 @@ Normal PR path:
    Supabase `dev` branch.
 5. After the PR merges, the resulting push to Git `dev` triggers
    `.github/workflows/supabase-dev.yml`.
-6. The workflow links to `SUPABASE_DEV_PROJECT_ID`, runs `supabase db push --include-all`, and only after it succeeds runs `supabase config push`.
-7. Pending checked-in migrations and then the checked-in service configuration are applied to the persistent Supabase `dev` branch.
+6. The workflow links to `SUPABASE_DEV_PROJECT_ID` and runs `supabase db push --include-all`.
+7. Pending checked-in migrations are applied by the workflow; Supabase Branching independently applies checked-in configuration to the persistent ref declared by `[remotes.dev]`.
 
 An existing Preview branch applies newly added migration files on later PR
 pushes. Editing a migration already recorded in that Preview's migration

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: cccdb4e90b65cc7b56dbae72946637cede599ba3
-lastReviewedNote: "已针对 Issue #340 api/private 边界 POC 复核：记录 api/public/graphql_public 暴露合同必须先部署 schema、再单独部署配置。"
+lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
+lastReviewedNote: "已针对 Issue #340 阶段 B 复核：持久化 dev 现在先推送 migration、再推送配置，以安全落实 api/public/graphql_public 暴露合同。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -75,10 +75,10 @@ related:
 - 把 `supabase/migrations/` 中已提交的文件视为 production、`dev` 和 preview 分支共同遵循的 schema 真相源。
 - 分支差异放在 `supabase/config.toml` 的 `[remotes.<branch>]` 中。
 - 不要为不同 Git 分支复制多套 `supabase/` 目录。
-- 把 `.github/workflows/supabase-dev.yml` 作为本仓唯一会对持久化 Supabase `dev` 分支执行 `supabase db push` 的 GitHub Actions 流程。
+- 把 `.github/workflows/supabase-dev.yml` 作为本仓唯一会对持久化 Supabase `dev` 分支执行 `supabase db push` 与 `supabase config push` 的 GitHub Actions 流程；必须先推送 migration，再推送配置。
 - 不要为 Git `main` 增加 checked-in 的 GitHub Actions 生产部署流程；生产项目由绑定到本仓的 Supabase GitHub integration 自动迁移。
 - 不要先手改远端数据库再回头补 migration。
-- Data API schema 必须配置即代码：目标只暴露 `api`、`public` 和 `graphql_public`；不得把 `private`、`util` 或 `archive` 加入 exposed schemas 或 `extra_search_path`。
+- Data API schema 必须配置即代码：只暴露 `api`、`public` 和 `graphql_public`；不得把 `private`、`util` 或 `archive` 加入 exposed schemas 或 `extra_search_path`。
 - Supabase GitHub 部署 DAG 会先执行 `Configure`，后执行 `Migrate`。因此必须先用现有暴露配置部署并验证新 schema 及其 API 对象，后续再通过单独的 commit/PR 暴露已存在的 schema；不得在同一次部署中首次创建并暴露 schema。
 
 ## 需要维护的文件

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -22,7 +22,7 @@ checkPaths:
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-01
 lastReviewedCommit: 1445889b2746c28fc80b77db8ee15213470da718
-lastReviewedNote: "已针对 Issue #340 阶段 B 复核：持久化 dev 现在先推送 migration、再推送配置，以安全落实 api/public/graphql_public 暴露合同。"
+lastReviewedNote: "已针对 Issue #340 阶段 B 复核：持久化 dev 仅在 schema-first PR 已托管后，通过分支绑定落实 api/public/graphql_public 暴露合同。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -75,7 +75,7 @@ related:
 - 把 `supabase/migrations/` 中已提交的文件视为 production、`dev` 和 preview 分支共同遵循的 schema 真相源。
 - 分支差异放在 `supabase/config.toml` 的 `[remotes.<branch>]` 中。
 - 不要为不同 Git 分支复制多套 `supabase/` 目录。
-- 把 `.github/workflows/supabase-dev.yml` 作为本仓唯一会对持久化 Supabase `dev` 分支执行 `supabase db push` 与 `supabase config push` 的 GitHub Actions 流程；必须先推送 migration，再推送配置。
+- 把 `.github/workflows/supabase-dev.yml` 作为本仓唯一会对持久化 Supabase `dev` 分支执行 `supabase db push` 的 GitHub Actions 流程。分支配置由 Supabase GitHub integration 与 `[remotes.dev]` 负责；不得增加会连同无关远端配置漂移一起提交的无条件 `supabase config push`。
 - 不要为 Git `main` 增加 checked-in 的 GitHub Actions 生产部署流程；生产项目由绑定到本仓的 Supabase GitHub integration 自动迁移。
 - 不要先手改远端数据库再回头补 migration。
 - Data API schema 必须配置即代码：只暴露 `api`、`public` 和 `graphql_public`；不得把 `private`、`util` 或 `archive` 加入 exposed schemas 或 `extra_search_path`。

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -16,7 +16,7 @@ enabled = true
 port = 55321
 # Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
-schemas = ["public", "graphql_public"]
+schemas = ["api", "public", "graphql_public"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size

--- a/supabase/tests/20260801_api_private_boundary_config_contract.mjs
+++ b/supabase/tests/20260801_api_private_boundary_config_contract.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const configUrl = new URL('../config.toml', import.meta.url);
+const migrationUrl = new URL(
+  '../migrations/20260801023000_api_private_boundary_poc.sql',
+  import.meta.url,
+);
+const devWorkflowUrl = new URL('../../.github/workflows/supabase-dev.yml', import.meta.url);
+
+test('api is the only application custom schema exposed by config', async () => {
+  const config = await readFile(configUrl, 'utf8');
+  const schemasMatch = config.match(/^schemas\s*=\s*\[([^\]]+)\]/m);
+  assert.ok(schemasMatch, 'config.toml must declare api.schemas');
+  const schemas = [...schemasMatch[1].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+  assert.deepEqual(schemas, ['api', 'public', 'graphql_public']);
+  assert.ok(!schemas.includes('private'));
+  assert.ok(!schemas.includes('util'));
+  assert.ok(!schemas.includes('archive'));
+
+  const searchPathMatch = config.match(/^extra_search_path\s*=\s*\[([^\]]+)\]/m);
+  assert.ok(searchPathMatch, 'config.toml must declare api.extra_search_path');
+  assert.doesNotMatch(searchPathMatch[1], /private|util|archive/);
+});
+
+test('migration keeps the contract additive and reloads PostgREST', async () => {
+  const migration = await readFile(migrationUrl, 'utf8');
+  assert.match(migration, /with \(security_invoker = true\)/);
+  assert.match(migration, /security invoker/);
+  assert.match(migration, /notify pgrst, 'reload schema'/);
+  assert.doesNotMatch(migration, /drop\s+(table|view|function|schema)/i);
+});
+
+test('persistent dev deploys migrations before pushing Data API configuration', async () => {
+  const workflow = await readFile(devWorkflowUrl, 'utf8');
+  const migrationPush = workflow.indexOf('supabase db push --include-all');
+  const configPush = workflow.indexOf(
+    'supabase config push --project-ref "$SUPABASE_PROJECT_ID"',
+  );
+
+  assert.notEqual(migrationPush, -1, 'persistent dev workflow must push migrations');
+  assert.notEqual(configPush, -1, 'persistent dev workflow must push config');
+  assert.ok(migrationPush < configPush, 'schema migrations must precede exposed-schema config');
+});

--- a/supabase/tests/20260801_api_private_boundary_config_contract.mjs
+++ b/supabase/tests/20260801_api_private_boundary_config_contract.mjs
@@ -7,7 +7,6 @@ const migrationUrl = new URL(
   '../migrations/20260801023000_api_private_boundary_poc.sql',
   import.meta.url,
 );
-const devWorkflowUrl = new URL('../../.github/workflows/supabase-dev.yml', import.meta.url);
 
 test('api is the only application custom schema exposed by config', async () => {
   const config = await readFile(configUrl, 'utf8');
@@ -32,14 +31,10 @@ test('migration keeps the contract additive and reloads PostgREST', async () => 
   assert.doesNotMatch(migration, /drop\s+(table|view|function|schema)/i);
 });
 
-test('persistent dev deploys migrations before pushing Data API configuration', async () => {
-  const workflow = await readFile(devWorkflowUrl, 'utf8');
-  const migrationPush = workflow.indexOf('supabase db push --include-all');
-  const configPush = workflow.indexOf(
-    'supabase config push --project-ref "$SUPABASE_PROJECT_ID"',
+test('persistent dev binding targets the exact hosted branch', async () => {
+  const config = await readFile(configUrl, 'utf8');
+  assert.match(
+    config,
+    /\[remotes\.dev\][\s\S]*?project_id\s*=\s*"fotofiyqnuyvgtotswie"/,
   );
-
-  assert.notEqual(migrationPush, -1, 'persistent dev workflow must push migrations');
-  assert.notEqual(configPush, -1, 'persistent dev workflow must push config');
-  assert.ok(migrationPush < configPush, 'schema migrations must precede exposed-schema config');
 });

--- a/supabase/tests/20260801_api_private_boundary_rest_contract.mjs
+++ b/supabase/tests/20260801_api_private_boundary_rest_contract.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const baseUrl = process.env.SUPABASE_URL?.replace(/\/$/, '');
+const publishableKey = process.env.SUPABASE_PUBLISHABLE_KEY;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const expectedProjectRef = process.env.EXPECTED_PROJECT_REF;
+
+assert.ok(baseUrl, 'SUPABASE_URL is required');
+assert.ok(publishableKey, 'SUPABASE_PUBLISHABLE_KEY is required');
+
+if (expectedProjectRef) {
+  assert.equal(new URL(baseUrl).hostname.split('.')[0], expectedProjectRef);
+}
+
+async function request({ key, path, method = 'GET', profile, body }) {
+  const headers = {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+  };
+  if (profile) {
+    headers[method === 'GET' || method === 'HEAD' ? 'Accept-Profile' : 'Content-Profile'] = profile;
+  }
+  if (body !== undefined) headers['Content-Type'] = 'application/json';
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    payload = text;
+  }
+  return { status: response.status, payload };
+}
+
+test('api profile is present in the PostgREST schema cache', async () => {
+  const result = await request({
+    key: publishableKey,
+    path: '/rest/v1/processes_v1?select=id&limit=1',
+    profile: 'api',
+  });
+  assert.equal(result.status, 200);
+  assert.ok(Array.isArray(result.payload));
+});
+
+for (const [schema, relation] of [
+  ['private', 'worker_jobs'],
+  ['util', 'pending_embedding_jobs'],
+  ['archive', 'worker_legacy_job_table_rows'],
+]) {
+  test(`${schema} is not exposed by the Data API`, async () => {
+    const result = await request({
+      key: publishableKey,
+      path: `/rest/v1/${relation}?select=*&limit=1`,
+      profile: schema,
+    });
+    assert.equal(result.status, 406);
+    assert.equal(result.payload?.code, 'PGRST106');
+  });
+}
+
+test('anonymous callers cannot execute a service-only api RPC', async () => {
+  const result = await request({
+    key: publishableKey,
+    path: '/rest/v1/rpc/worker_read_jobs_by_ids_v1',
+    method: 'POST',
+    profile: 'api',
+    body: { p_job_ids: [], p_include_internal: false },
+  });
+  assert.equal(result.status, 401);
+  assert.equal(result.payload?.code, '42501');
+});
+
+test('service role can execute the bounded api adapter', { skip: !serviceRoleKey }, async () => {
+  const result = await request({
+    key: serviceRoleKey,
+    path: '/rest/v1/rpc/worker_read_jobs_by_ids_v1',
+    method: 'POST',
+    profile: 'api',
+    body: { p_job_ids: [], p_include_internal: false },
+  });
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.payload, { ok: true, data: [] });
+});


### PR DESCRIPTION
## Summary
- expose only `api`, `public`, and `graphql_public` through configuration-as-code
- keep `private`, `util`, and `archive` absent from exposed schemas and PostgREST extra search path
- bind persistent dev to exact project `fotofiyqnuyvgtotswie` through `[remotes.dev]` and the Supabase GitHub integration
- add reusable static and REST contracts for schema profiles, anonymous denial, and service-role positive access

## Preconditions
Phase A was merged in #342 and persistent Supabase dev run 30680609513 successfully applied migration `20260801023000` at exact Git SHA `1445889b2746c28fc80b77db8ee15213470da718`. The `api` schema therefore exists before this configuration can be deployed.

## Validation
- isolated blank `supabase start` plus explicit `supabase db reset`: pass
- PGTAP API boundary contract: 35/35 pass
- local REST profile/ACL contract: 6/6 pass
- static exposure/persistent-binding contract: 3/3 pass
- generated TypeScript types include both DTO views and all three RPC adapters
- catalog: exactly two `api` views and three `api` functions
- `docpact validate-config --strict`: pass
- `docpact lint`: pass
- `git diff --check`: pass

## Hosted completion gate
After merge, Supabase Branching must apply the configuration to exact persistent ref `fotofiyqnuyvgtotswie`. Then rerun the read-only REST contract against that ref; do not consider this POC evidenced until `api` returns 200, non-exposed schemas return PGRST106, anonymous service RPC returns 42501, and service role returns the bounded positive envelope.

## Risk / rollback
- existing `public` exposure and all compatibility objects remain available
- rollback is a config-only removal of `api`; no physical data move occurs here
- no unconditional `supabase config push` is added: that command could apply unrelated local/remote Auth configuration drift

Closes #340
Parent: tiangong-lca/workspace#484