### PR TITLE
fix: 兼容 Worker Data API probe 的 opaque key

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-01"
-lastReviewedCommit: "a3b1f19aaceef1cb6037180dc55e454d00ac08eb"
-lastReviewedNote: "Reviewed through Issue #339 and the Issue #346 follow-up: ACL convergence and serialized persistent-dev PostgREST reconciliation, including rollback and readback of the prior allowlisted snapshot, remain covered by migration/test/tooling routes with redacted hosted evidence."
+lastReviewedCommit: "a46bb023873f3ae17cd5a9b34a443201515793c0"
+lastReviewedNote: "Reviewed for Issue #339 hosted follow-up: Worker Data API probes preserve explicit public profiles, opaque-key semantics, and credential-redacted schema reload failures."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: a3b1f19aaceef1cb6037180dc55e454d00ac08eb
-lastReviewedNote: "Reviewed through Issue #339 and the Issue #346 follow-up: ACL migration truth and serialized persistent-dev PostgREST reconciliation, including restoration and verification of the prior allowlisted snapshot after readback failure, preserve production integration, repository ownership, and hosted evidence boundaries."
+lastReviewedCommit: a46bb023873f3ae17cd5a9b34a443201515793c0
+lastReviewedNote: "Reviewed for the Issue #339 hosted follow-up: Worker Data API probes preserve explicit public profiles, opaque-key semantics, and credential-redacted schema reload failures without changing repository ownership or integration boundaries."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,8 +28,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: a3b1f19aaceef1cb6037180dc55e454d00ac08eb
-lastReviewedNote: "Reviewed through Issue #339 and the Issue #346 follow-up: ACL convergence and persistent Dev PostgREST reconciliation, including restoration and verification of the prior allowlisted snapshot on readback mismatch, preserve the api/private ownership model and operator evidence boundary."
+lastReviewedCommit: a46bb023873f3ae17cd5a9b34a443201515793c0
+lastReviewedNote: "Reviewed for Issue #339 hosted follow-up: opaque-key and explicit-public-profile probe behavior does not change the api/private ownership model."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: b32072d5a38509c4a25d866692958f0ced1303cf
-lastReviewedNote: "Reviewed for Issue #346: add offline failure/idempotency/redaction tests and hosted exact-ref readback for the allowlisted PostgREST config gate."
+lastReviewedCommit: a46bb023873f3ae17cd5a9b34a443201515793c0
+lastReviewedNote: "Reviewed for Issue #339 hosted follow-up: Worker probes cover api-first profile selection, opaque keys, and redacted schema-reload failures."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: b32072d5a38509c4a25d866692958f0ced1303cf
-lastReviewedNote: "Reviewed for Issue #346: document the allowlisted persistent-dev PostgREST diff/apply/readback gate and its offline tests."
+lastReviewedCommit: a46bb023873f3ae17cd5a9b34a443201515793c0
+lastReviewedNote: "Reviewed for Issue #339 hosted follow-up: document opaque-key-safe Worker Data API probes and credential-redacted reload failures."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -312,7 +312,9 @@ profile (independent of the reviewed `api`-first exposed-schema order), verifies
 the expected empty envelope, and proves anon calls fail closed. It reads local
 keys from `supabase status` and never prints them. Isolated stacks can instead
 set `DATABASE_URL`, `SUPABASE_REST_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and
-`SUPABASE_ANON_KEY` without changing tracked config.
+`SUPABASE_ANON_KEY` without changing tracked config. Legacy JWT keys are also
+sent as bearer tokens; opaque `sb_publishable_` and `sb_secret_` keys are sent
+only as gateway `apikey` values. Reload failures never print the database URL.
 
 ```bash
 python scripts/test_worker_control_plane_data_api.py

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: b32072d5a38509c4a25d866692958f0ced1303cf
-lastReviewedNote: "已为 Issue #346 复核：记录持久化 Dev PostgREST 配置的字段白名单 diff/apply/回读 gate 及其离线测试。"
+lastReviewedCommit: a46bb023873f3ae17cd5a9b34a443201515793c0
+lastReviewedNote: "已为 Issue #339 hosted follow-up 复核：Worker Data API probe 正确处理 opaque key、显式 public profile 和数据库 URL 脱敏。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/test_worker_control_plane_data_api.py
+++ b/scripts/test_worker_control_plane_data_api.py
@@ -27,9 +27,10 @@ RPC_CASES = {
 def request_headers(key: str, *, payload: dict | None, profile: str) -> dict[str, str]:
     headers = {
         "apikey": key,
-        "Authorization": f"Bearer {key}",
         "Accept": "application/openapi+json" if payload is None else "application/json",
     }
+    if key.startswith("eyJ"):
+        headers["Authorization"] = f"Bearer {key}"
     headers["Accept-Profile" if payload is None else "Content-Profile"] = profile
     if payload is not None:
         headers["Content-Type"] = "application/json"
@@ -44,6 +45,18 @@ def request(url: str, key: str, *, payload: dict | None = None, profile: str = "
             return response.status, json.loads(response.read())
     except urllib.error.HTTPError as error:
         return error.code, json.loads(error.read())
+
+
+def reload_schema(db_url: str) -> None:
+    result = subprocess.run(
+        ["psql", db_url, "-XAt", "-v", "ON_ERROR_STOP=1", "-c", "notify pgrst, 'reload schema'"],
+        cwd=ROOT,
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        raise SystemExit("PostgREST schema reload failed")
 
 
 def main() -> int:
@@ -65,10 +78,7 @@ def main() -> int:
     # A clean reset can commit migrations before the restarted PostgREST
     # listener subscribes. Reload only after the service is healthy, then poll
     # the actual role-filtered OpenAPI catalog instead of assuming delivery.
-    subprocess.run(
-        ["psql", db_url, "-XAt", "-v", "ON_ERROR_STOP=1", "-c", "notify pgrst, 'reload schema'"],
-        cwd=ROOT, check=True, stdout=subprocess.DEVNULL,
-    )
+    reload_schema(db_url)
     for _ in range(40):
         openapi_status, openapi = request(f"{rest_url}/", service_credential, profile="public")
         paths = openapi.get("paths", {}) if openapi_status == 200 else {}

--- a/scripts/test_worker_control_plane_data_api_unit.py
+++ b/scripts/test_worker_control_plane_data_api_unit.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import sys
 import tomllib
 import unittest
+from subprocess import CompletedProcess
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import test_worker_control_plane_data_api as target
@@ -29,6 +31,32 @@ class WorkerControlPlaneDataApiProfileTest(unittest.TestCase):
         )
         self.assertEqual(headers["Content-Profile"], "public")
         self.assertNotIn("Accept-Profile", headers)
+
+    def test_opaque_keys_are_not_sent_as_bearer_tokens(self) -> None:
+        for credential in ("sb_publishable_opaque", "sb_secret_opaque"):
+            with self.subTest(credential=credential.split("_")[1]):
+                headers = target.request_headers(
+                    credential, payload={"p_job_ids": []}, profile="public"
+                )
+                self.assertEqual(headers["apikey"], credential)
+                self.assertNotIn("Authorization", headers)
+
+    def test_legacy_jwt_is_sent_as_bearer_token(self) -> None:
+        credential = "eyJlegacy-jwt"
+        headers = target.request_headers(
+            credential, payload={"p_job_ids": []}, profile="public"
+        )
+        self.assertEqual(headers["Authorization"], f"Bearer {credential}")
+
+    def test_reload_failure_does_not_echo_database_url(self) -> None:
+        database_url = "postgresql://" + "operator:" + "must-not-leak" + "@example.invalid/postgres"
+        failed = CompletedProcess(args=["psql", database_url], returncode=2)
+        with mock.patch.object(target.subprocess, "run", return_value=failed):
+            with self.assertRaises(SystemExit) as raised:
+                target.reload_schema(database_url)
+        self.assertEqual(str(raised.exception), "PostgREST schema reload failed")
+        self.assertNotIn(database_url, str(raised.exception))
+        self.assertNotIn("must-not-leak", str(raised.exception))
 
 
 if __name__ == "__main__":

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: a3b1f19aaceef1cb6037180dc55e454d00ac08eb
-lastReviewedNote: "Reviewed through Issue #339 and the Issue #346 follow-up: ACL/catalog changes and persistent Dev PostgREST reconciliation, including rollback/readback semantics, do not change generated workspace behavior or source-of-truth boundaries."
+lastReviewedCommit: a46bb023873f3ae17cd5a9b34a443201515793c0
+lastReviewedNote: "Reviewed for Issue #339 hosted follow-up: Worker probe credential/profile behavior does not change generated workspace behavior or source-of-truth boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: a3b1f19aaceef1cb6037180dc55e454d00ac08eb
-lastReviewedNote: "已为 Issue #339 与 Issue #346 follow-up 复核：ACL/catalog 变更和持久化 Dev PostgREST 协调（包括回滚/readback 语义）不改变生成 workspace 的行为或真相源边界。"
+lastReviewedCommit: a46bb023873f3ae17cd5a9b34a443201515793c0
+lastReviewedNote: "已为 Issue #339 hosted follow-up 复核：Worker probe 的凭据/profile 行为不改变生成 workspace 的行为或真相源边界。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## 问题

#339 的 hosted Worker Data API 验证脚本仍把所有 API key 都作为 Bearer token 发送。Supabase 新式 `sb_publishable_` / `sb_secret_` opaque key 不是 JWT，这会让本应有效的 hosted 验证出现 401。数据库 schema reload 失败时，默认子进程异常也可能携带完整命令参数。

## 变更

- opaque key 仅作为 `apikey` 发送；只有 legacy JWT 才附带 `Authorization: Bearer`
- 保持 Worker RPC 显式使用 `public` profile，以验证兼容层而非默认暴露 schema
- schema reload 失败统一返回脱敏错误，不回显数据库 URL
- 增加 opaque key、legacy JWT、显式 profile 和连接串脱敏测试

## 验证

- `python3 scripts/test_worker_control_plane_data_api_unit.py`（5/5）
- `python3 scripts/test_hosted_security_acl.py`（8/8）
- `python3 scripts/test_apply_postgrest_config.py`（12/12）
- `python3 -m py_compile ...`
- `./scripts/docpact validate-config --root . --strict`
- `./scripts/docpact lint --root . --staged`
- `git diff --cached --check`

Refs #339