### PR TITLE
ci: 为 Dev 验证获取不可变来源历史

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-01"
-lastReviewedCommit: "1a0fc514e41724bd513b4126429c38dff10339c0"
+lastReviewedCommit: "d46daabe68ac3eaccbc889cf9cc35a746fc10d88"
 lastReviewedNote: "Reviewed for Issues #355/#339 and PR #367 findings: the canonical gate requires exact source-catalog actor-RLS plus rollback/reapply proof, while layered global/five-schema restore, ACL-identity grantability folding, and dynamic owner-only snapshot convergence remain covered by existing ownership rules."
 
 # Keep deterministic governance facts here.

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "Reviewed for Issues #355/#339 and PR #367 findings: the canonical opt-in runner enforces dual-predecessor actor-RLS proof before rollback/roll-forward proof, while exact layered default-ACL restore and dynamic snapshot ACL convergence remain repo-owned; Issue #352 stays separate."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,7 +29,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "Reviewed for Issues #355/#339 and PR #367 findings: canonical enforcement binds actor-RLS to rollback/roll-forward proof, while global/five-schema ACL layer restore, bool_or effective grantability, and owner-only snapshot proof fit the current architecture."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,7 +32,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "Reviewed for Issue #355 mandatory destructive qualification: the canonical opt-in gate now runs both exact public.users predecessors, actor-level source/projection RLS parity, retry/unknown atomic rejection, and the rollback/roll-forward harness."
 related:
   - ../../AGENTS.md
@@ -113,6 +113,11 @@ not a skippable test result. They also prefetch the digest-pinned PostgREST
 v14.7 conformance image before starting the suite. The conformance test refuses
 to pull an image itself, so a missing or tag-only image cannot silently change
 the runtime under test or become a skipped result.
+
+Every workflow that invokes the canonical runner must check out full Git
+history (`fetch-depth: 0`). The immutable public-inventory provenance gate
+verifies its recorded source commit with Git; a shallow checkout is an invalid
+validation environment and must fail before any hosted deployment job starts.
 
 ## Proof Matrix
 

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,7 +22,7 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "Reviewed Issue #346: persistent dev explicitly serializes migration and allowlisted PostgREST config while production remains Supabase-integration owned."
 related:
   - ../../AGENTS.md

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -22,7 +22,7 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "已针对 Issue #346 复核：持久化 dev 显式串行执行 migration 与白名单 PostgREST 配置，production 仍由 Supabase integration 管理。"
 related:
   - ../../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "Reviewed for Issue #355 mandatory destructive qualification: the canonical opt-in gate invokes the dual exact-hash/actor-RLS harness before the rollback/roll-forward harness and propagates either failure."
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-01
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "已为 Issue #355 mandatory destructive qualification 复核：canonical opt-in gate 先调用 dual exact-hash/逐角色 RLS harness，再调用 rollback/roll-forward harness，并传播任一失败。"
 related:
   - ../AGENTS.md

--- a/scripts/test_database_contract_manifest.py
+++ b/scripts/test_database_contract_manifest.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import re
 import subprocess
 import sys
 import tempfile
@@ -33,6 +34,22 @@ class DatabaseContractManifestTest(unittest.TestCase):
         self.assertEqual(len(classified["canonical-pgtap"]), 83)
         self.assertEqual(len(suite["excludedFiles"]), 19)
         self.assertEqual(len(selected), 64)
+
+    def test_persistent_dev_validation_fetches_immutable_provenance_history(self) -> None:
+        workflow = (runner.ROOT / ".github/workflows/supabase-dev.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertRegex(
+            workflow,
+            re.compile(
+                r"- name: Checkout repository\n"
+                r"\s+uses: actions/checkout@v6\n"
+                r"\s+with:\n"
+                r"\s+fetch-depth: 0\n"
+                r".*?- name: Setup Python",
+                re.DOTALL,
+            ),
+        )
 
     def test_suite_evidence_binds_commit_head_cli_manifest_and_file_list(self) -> None:
         files = ["supabase/tests/example.sql"]

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "Reviewed for Issue #369: manifest-owned validation, PR CI, and Issue #357 phase gates do not change generated workspace ownership or refresh semantics."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 1a0fc514e41724bd513b4126429c38dff10339c0
+lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
 lastReviewedNote: "已为 Issue #369 复核：manifest 门禁、PR CI 与 #357 phase gate 不改变生成 workspace 的所有权或刷新语义。"
 related:
   - ../../AGENTS.md


### PR DESCRIPTION
## 摘要

- 为 persistent Dev 的 canonical validation checkout 增加 `fetch-depth: 0`。
- 增加离线回归测试，确保任何调用 canonical runner 的 Dev validation 都保留 public inventory immutable provenance 所需的 Git 历史。
- 记录 shallow checkout 是无效验证环境；必须在 hosted deployment 前 fail closed。

Refs #369

## 失败原因

PR #370 的 pull-request workflow 使用 full-history checkout，因此 64 files / 2044 tests 与 inventory gate 全绿；merge 后的 push workflow 使用 actions/checkout 默认 shallow history，导致 `public_inventory_closure.py --check` 无法解析已冻结来源 commit `1516ad7…`。验证 job 因此失败，deploy job 被正确跳过，hosted Dev 未修改。

## 验证

- `python -m unittest scripts.test_database_contract_manifest`：10/10 PASS
- workflow YAML parse：PASS
- `git diff --check`：PASS
- docpact strict + worktree lint：12/12 paths covered
- pre-push docpact gate：PASS

## 风险与边界

- 不包含 migration、schema/config 变更或 hosted/production mutation。
- 合并后必须由新的 Supabase Dev run 证明 canonical validation 通过，随后才允许无新增 migration 的既有 deploy/readback 流程执行。