### PR TITLE
feat: 根审核分组队列与引用审核子表查询

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "2510d66a67f9f6dd8933a8282c11c36d4d398009"
-lastReviewedNote: "Reviewed for Issue #372 first real Expand slice: the existing migration/test routing covers the transactional api/private move, explicit ACL convergence, compatibility wrappers, and focused plus baseline-differential validation without changing governance rules."
+lastReviewedCommit: "1ff6d2775bed146379d50dc91eaf43c7915dca0f"
+lastReviewedNote: "Reviewed for Issue #323: the existing migration and SQL-test routing covers the additive Root/Reference Review v2 grouped-queue RPCs and focused regression proof without changing governance rules."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 2510d66a67f9f6dd8933a8282c11c36d4d398009
-lastReviewedNote: "Reviewed for Issue #372 first real Expand slice: repository ownership, migration discipline, Preview qualification, and dev-branch delivery rules already govern the bounded api/private change; no contract change is required."
+lastReviewedCommit: 1ff6d2775bed146379d50dc91eaf43c7915dca0f
+lastReviewedNote: "Reviewed for Issue #323: repository ownership, additive migration discipline, local database proof, dev-branch delivery, and later workspace integration already govern the root-grouped review queue change; no contract rule changes are required."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 2510d66a67f9f6dd8933a8282c11c36d4d398009
-lastReviewedNote: "Reviewed for Issue #372 first real Expand slice: a JWT-preserving api facade and private Worker implementation with a public compatibility wrapper follow the existing five-schema architecture and Expand/Contract boundary."
+lastReviewedCommit: 1ff6d2775bed146379d50dc91eaf43c7915dca0f
+lastReviewedNote: "Reviewed for Issue #323: the additive root-grouped queue RPCs stay within the existing Root/Reference Review v2 database boundary and do not change the repository shape or cross-repo ownership."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 2510d66a67f9f6dd8933a8282c11c36d4d398009
-lastReviewedNote: "Reviewed for Issue #372 first real Expand slice: blank/populated upgrades, retry, forced failure atomicity, rollback/roll-forward, JWT/direct-SQL checks, focused pgTAP, baseline differential, lint, and hosted Preview remain the required validation layers."
+lastReviewedCommit: 1ff6d2775bed146379d50dc91eaf43c7915dca0f
+lastReviewedNote: "Reviewed for Issue #323: local fresh-stack reset plus the Root/Reference Review v2 and root-grouped queue pgTAP suites remain the minimum proof; hosted Preview and persistent-dev proof stay deferred to deployment."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/migrations/20260802090000_root_grouped_review_queue.sql
+++ b/supabase/migrations/20260802090000_root_grouped_review_queue.sql
@@ -1,0 +1,542 @@
+-- Group review-management queues by Root Review while preserving the existing
+-- row-oriented queue RPCs for compatibility with other consumers.
+
+-- Normalize every supported ILCD dataset name into the Process/Flow-style
+-- shape consumed by the review UI.  The previous implementation looked for a
+-- literal `name` field on the four Common-schema datasets, so their review
+-- snapshots contained an empty name object.
+create or replace function public.cmd_review_get_dataset_name(
+  p_table text,
+  p_row jsonb
+) returns jsonb
+language sql
+immutable
+set search_path = ''
+as $$
+  select case p_table
+    when 'contacts' then pg_catalog.jsonb_build_object(
+      'baseName', coalesce(
+        nullif(nullif(p_row#>'{json,contactDataSet,contactInformation,dataSetInformation,common:shortName}', '{}'::jsonb), '[]'::jsonb),
+        nullif(nullif(p_row#>'{json,contactDataSet,contactInformation,dataSetInformation,common:name}', '{}'::jsonb), '[]'::jsonb),
+        nullif(nullif(p_row#>'{json_ordered,contactDataSet,contactInformation,dataSetInformation,common:shortName}', '{}'::jsonb), '[]'::jsonb),
+        nullif(nullif(p_row#>'{json_ordered,contactDataSet,contactInformation,dataSetInformation,common:name}', '{}'::jsonb), '[]'::jsonb),
+        '[]'::jsonb
+      )
+    )
+    when 'sources' then pg_catalog.jsonb_build_object(
+      'baseName', coalesce(
+        nullif(nullif(p_row#>'{json,sourceDataSet,sourceInformation,dataSetInformation,common:shortName}', '{}'::jsonb), '[]'::jsonb),
+        nullif(nullif(p_row#>'{json_ordered,sourceDataSet,sourceInformation,dataSetInformation,common:shortName}', '{}'::jsonb), '[]'::jsonb),
+        '[]'::jsonb
+      )
+    )
+    when 'unitgroups' then pg_catalog.jsonb_build_object(
+      'baseName', coalesce(
+        nullif(nullif(p_row#>'{json,unitGroupDataSet,unitGroupInformation,dataSetInformation,common:name}', '{}'::jsonb), '[]'::jsonb),
+        nullif(nullif(p_row#>'{json_ordered,unitGroupDataSet,unitGroupInformation,dataSetInformation,common:name}', '{}'::jsonb), '[]'::jsonb),
+        '[]'::jsonb
+      )
+    )
+    when 'flowproperties' then pg_catalog.jsonb_build_object(
+      'baseName', coalesce(
+        nullif(nullif(p_row#>'{json,flowPropertyDataSet,flowPropertiesInformation,dataSetInformation,common:name}', '{}'::jsonb), '[]'::jsonb),
+        nullif(nullif(p_row#>'{json_ordered,flowPropertyDataSet,flowPropertiesInformation,dataSetInformation,common:name}', '{}'::jsonb), '[]'::jsonb),
+        '[]'::jsonb
+      )
+    )
+    when 'flows' then coalesce(
+      p_row#>'{json,flowDataSet,flowInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,flowDataSet,flowInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    when 'processes' then coalesce(
+      p_row#>'{json,processDataSet,processInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,processDataSet,processInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    when 'lifecyclemodels' then coalesce(
+      p_row#>'{json,lifeCycleModelDataSet,lifeCycleModelInformation,dataSetInformation,name}',
+      p_row#>'{json_ordered,lifeCycleModelDataSet,lifeCycleModelInformation,dataSetInformation,name}',
+      '{}'::jsonb
+    )
+    else '{}'::jsonb
+  end
+$$;
+
+alter function public.cmd_review_get_dataset_name(text, jsonb) owner to postgres;
+
+create or replace function public.qry_review_get_admin_root_queue_items_v2(
+  p_status text default null,
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'modified_at',
+  p_sort_order text default 'desc'
+)
+returns table (
+  id uuid,
+  data_id uuid,
+  data_version text,
+  state_code integer,
+  review_kind text,
+  target_table text,
+  reviewer_id jsonb,
+  "json" jsonb,
+  deadline timestamptz,
+  created_at timestamptz,
+  modified_at timestamptz,
+  comment_state_codes jsonb,
+  root_matches_status boolean,
+  root_can_read boolean,
+  total_count bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_sort_key text := case lower(coalesce(p_sort_by, ''))
+    when 'created_at' then 'created_at'
+    when 'createat' then 'created_at'
+    when 'deadline' then 'deadline'
+    when 'state_code' then 'state_code'
+    when 'statecode' then 'state_code'
+    else 'modified_at'
+  end;
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+  v_status text := lower(coalesce(p_status, ''));
+  v_state_code integer;
+begin
+  if v_actor is null or not public.cmd_review_is_review_admin(v_actor) then
+    return;
+  end if;
+
+  case v_status
+    when '', 'all' then v_state_code := null;
+    when 'unassigned' then v_state_code := 0;
+    when 'assigned' then v_state_code := 1;
+    when 'admin-rejected' then v_state_code := -1;
+    else return;
+  end case;
+
+  return query
+      with root_matches as (
+        select
+          root_review.id as root_review_id,
+          true as root_matches_status,
+          root_review.modified_at as matching_task_modified_at
+        from public.reviews as root_review
+        where root_review.review_kind = 'root'
+          and (v_state_code is null or root_review.state_code = v_state_code)
+
+        union all
+
+        select
+          root_review.id as root_review_id,
+          false as root_matches_status,
+          reference_review.modified_at as matching_task_modified_at
+        from public.reviews as reference_review
+        join public.reviews as root_review
+          on root_review.review_kind = 'root'
+          and root_review.current_reference_review_ids
+            @> array[reference_review.id]::uuid[]
+        where v_state_code is not null
+          and reference_review.review_kind = 'reference'
+          and reference_review.state_code = v_state_code
+      ),
+      root_candidates as (
+        select
+          root_match.root_review_id,
+          pg_catalog.bool_or(root_match.root_matches_status)
+            as root_matches_status,
+          pg_catalog.max(root_match.matching_task_modified_at)
+            as matching_task_modified_at
+        from root_matches as root_match
+        group by root_match.root_review_id
+      ),
+      q as (
+        select
+          root_review.id,
+          root_review.data_id,
+          pg_catalog.btrim(root_review.data_version::text) as data_version,
+          root_review.state_code,
+          root_review.review_kind,
+          root_review.target_table,
+          coalesce(root_review.reviewer_id, '[]'::jsonb) as reviewer_id,
+          coalesce(root_review.json, '{}'::jsonb) as json,
+          root_review.deadline,
+          root_review.created_at,
+          root_candidate.matching_task_modified_at as modified_at,
+          coalesce(root_comments.comment_state_codes, '[]'::jsonb)
+            as comment_state_codes,
+          root_candidate.root_matches_status,
+          true as root_can_read
+        from root_candidates as root_candidate
+        join public.reviews as root_review
+          on root_review.id = root_candidate.root_review_id
+          and root_review.review_kind = 'root'
+        left join lateral (
+          select pg_catalog.jsonb_agg(
+            pg_catalog.to_jsonb(root_comment.state_code)
+            order by root_comment.created_at, root_comment.reviewer_id
+          ) filter (where root_comment.reviewer_id is not null)
+            as comment_state_codes
+          from public.comments as root_comment
+          where root_comment.review_id = root_review.id
+        ) as root_comments on true
+      )
+      select q.*, pg_catalog.count(*) over() as total_count
+      from q
+      order by
+        case when v_sort_key = 'created_at' and v_order_dir = 'asc'
+          then q.created_at end asc nulls last,
+        case when v_sort_key = 'created_at' and v_order_dir = 'desc'
+          then q.created_at end desc nulls last,
+        case when v_sort_key = 'deadline' and v_order_dir = 'asc'
+          then q.deadline end asc nulls last,
+        case when v_sort_key = 'deadline' and v_order_dir = 'desc'
+          then q.deadline end desc nulls last,
+        case when v_sort_key = 'state_code' and v_order_dir = 'asc'
+          then q.state_code end asc nulls last,
+        case when v_sort_key = 'state_code' and v_order_dir = 'desc'
+          then q.state_code end desc nulls last,
+        case when v_sort_key = 'modified_at' and v_order_dir = 'asc'
+          then q.modified_at end asc nulls last,
+        case when v_sort_key = 'modified_at' and v_order_dir = 'desc'
+          then q.modified_at end desc nulls last,
+        q.id asc
+      limit v_limit offset v_offset;
+end;
+$$;
+
+alter function public.qry_review_get_admin_root_queue_items_v2(
+  text, integer, integer, text, text
+) owner to postgres;
+revoke all on function public.qry_review_get_admin_root_queue_items_v2(
+  text, integer, integer, text, text
+) from public, anon;
+grant execute on function public.qry_review_get_admin_root_queue_items_v2(
+  text, integer, integer, text, text
+) to authenticated, service_role;
+
+create or replace function public.qry_review_get_member_root_queue_items_v2(
+  p_status text default 'pending',
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'modified_at',
+  p_sort_order text default 'desc'
+)
+returns table (
+  id uuid,
+  data_id uuid,
+  data_version text,
+  review_state_code integer,
+  review_kind text,
+  target_table text,
+  reviewer_id jsonb,
+  "json" jsonb,
+  deadline timestamptz,
+  created_at timestamptz,
+  modified_at timestamptz,
+  comment_state_code integer,
+  comment_json jsonb,
+  comment_created_at timestamptz,
+  comment_modified_at timestamptz,
+  root_matches_status boolean,
+  root_can_read boolean,
+  total_count bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_sort_key text := case lower(coalesce(p_sort_by, ''))
+    when 'created_at' then 'created_at'
+    when 'createat' then 'created_at'
+    when 'deadline' then 'deadline'
+    when 'state_code' then 'state_code'
+    when 'statecode' then 'state_code'
+    when 'comment_modified_at' then 'comment_modified_at'
+    when 'commentmodifiedat' then 'comment_modified_at'
+    else 'modified_at'
+  end;
+  v_order_dir text := public.cmd_membership_resolve_sort_direction(p_sort_order);
+  v_status text := lower(coalesce(p_status, 'pending'));
+begin
+  if v_actor is null or not public.cmd_review_is_review_member(v_actor) then
+    return;
+  end if;
+  if v_status not in ('pending', 'reviewed', 'reviewer-rejected') then
+    return;
+  end if;
+
+  return query
+      with matching_tasks as (
+        select
+          review_row.id,
+          review_row.review_kind,
+          comment_row.state_code as comment_state_code,
+          coalesce(comment_row.json::jsonb, '{}'::jsonb) as comment_json,
+          comment_row.created_at as comment_created_at,
+          comment_row.modified_at as comment_modified_at,
+          greatest(review_row.modified_at, comment_row.modified_at) as task_modified_at
+        from public.comments as comment_row
+        join public.reviews as review_row on review_row.id = comment_row.review_id
+        where review_row.review_kind in ('root', 'reference')
+          and comment_row.reviewer_id = v_actor
+          and public.policy_review_can_read(review_row.id, v_actor)
+          and (
+            (v_status = 'pending' and comment_row.state_code = 0 and review_row.state_code > 0)
+            or (v_status = 'reviewed'
+              and comment_row.state_code = any (array[1, 2, -3])
+              and review_row.state_code > 0)
+            or (v_status = 'reviewer-rejected'
+              and comment_row.state_code = -1
+              and review_row.state_code = -1)
+          )
+      ),
+      root_matches as (
+        select
+          task.id as root_review_id,
+          true as root_matches_status,
+          task.task_modified_at
+        from matching_tasks as task
+        where task.review_kind = 'root'
+
+        union all
+
+        select
+          root_review.id as root_review_id,
+          false as root_matches_status,
+          task.task_modified_at
+        from matching_tasks as task
+        join public.reviews as root_review
+          on root_review.review_kind = 'root'
+          and root_review.current_reference_review_ids
+            @> array[task.id]::uuid[]
+        where task.review_kind = 'reference'
+      ),
+      root_candidates as (
+        select
+          root_match.root_review_id,
+          pg_catalog.bool_or(root_match.root_matches_status)
+            as root_matches_status,
+          pg_catalog.max(root_match.task_modified_at) as matching_task_modified_at
+        from root_matches as root_match
+        group by root_match.root_review_id
+      ),
+      q as (
+        select
+          root_review.id,
+          root_review.data_id,
+          pg_catalog.btrim(root_review.data_version::text) as data_version,
+          root_review.state_code,
+          root_review.review_kind,
+          root_review.target_table,
+          coalesce(root_review.reviewer_id, '[]'::jsonb) as reviewer_id,
+          case
+            when public.policy_review_can_read(root_review.id, v_actor) then
+              coalesce(root_review.json, '{}'::jsonb)
+            else pg_catalog.jsonb_build_object(
+              'review_kind', 'root',
+              'data', pg_catalog.jsonb_build_object(
+                'id', root_review.data_id,
+                'version', pg_catalog.btrim(root_review.data_version::text),
+                'name', root_review.json #> '{data,name}',
+                'table', root_review.target_table
+              ),
+              'user', pg_catalog.jsonb_build_object(
+                'id', root_review.target_owner_id,
+                'name', root_review.json #> '{user,name}'
+              ),
+              'team', pg_catalog.jsonb_build_object(
+                'id', root_review.target_team_id,
+                'name', root_review.json #> '{team,name}'
+              )
+            )
+          end as json,
+          root_review.deadline,
+          root_review.created_at,
+          root_candidate.matching_task_modified_at as modified_at,
+          direct_task.comment_state_code,
+          coalesce(direct_task.comment_json, '{}'::jsonb) as comment_json,
+          direct_task.comment_created_at,
+          root_candidate.matching_task_modified_at as comment_modified_at,
+          root_candidate.root_matches_status,
+          public.policy_review_can_read(root_review.id, v_actor) as root_can_read
+        from root_candidates as root_candidate
+        join public.reviews as root_review
+          on root_review.id = root_candidate.root_review_id
+          and root_review.review_kind = 'root'
+        left join matching_tasks as direct_task
+          on direct_task.id = root_review.id
+          and direct_task.review_kind = 'root'
+      )
+      select
+        q.id,
+        q.data_id,
+        q.data_version,
+        q.state_code as review_state_code,
+        q.review_kind,
+        q.target_table,
+        q.reviewer_id,
+        q.json,
+        q.deadline,
+        q.created_at,
+        q.modified_at,
+        q.comment_state_code,
+        q.comment_json,
+        q.comment_created_at,
+        q.comment_modified_at,
+        q.root_matches_status,
+        q.root_can_read,
+        pg_catalog.count(*) over() as total_count
+      from q
+      order by
+        case when v_sort_key = 'created_at' and v_order_dir = 'asc'
+          then q.created_at end asc nulls last,
+        case when v_sort_key = 'created_at' and v_order_dir = 'desc'
+          then q.created_at end desc nulls last,
+        case when v_sort_key = 'deadline' and v_order_dir = 'asc'
+          then q.deadline end asc nulls last,
+        case when v_sort_key = 'deadline' and v_order_dir = 'desc'
+          then q.deadline end desc nulls last,
+        case when v_sort_key = 'state_code' and v_order_dir = 'asc'
+          then q.state_code end asc nulls last,
+        case when v_sort_key = 'state_code' and v_order_dir = 'desc'
+          then q.state_code end desc nulls last,
+        case when v_sort_key = 'comment_modified_at' and v_order_dir = 'asc'
+          then q.comment_modified_at end asc nulls last,
+        case when v_sort_key = 'comment_modified_at' and v_order_dir = 'desc'
+          then q.comment_modified_at end desc nulls last,
+        case when v_sort_key = 'modified_at' and v_order_dir = 'asc'
+          then q.modified_at end asc nulls last,
+        case when v_sort_key = 'modified_at' and v_order_dir = 'desc'
+          then q.modified_at end desc nulls last,
+        q.id asc
+      limit v_limit offset v_offset;
+end;
+$$;
+
+alter function public.qry_review_get_member_root_queue_items_v2(
+  text, integer, integer, text, text
+) owner to postgres;
+revoke all on function public.qry_review_get_member_root_queue_items_v2(
+  text, integer, integer, text, text
+) from public, anon;
+grant execute on function public.qry_review_get_member_root_queue_items_v2(
+  text, integer, integer, text, text
+) to authenticated, service_role;
+
+create or replace function public.qry_root_review_reference_progress_v2(
+  p_root_review_id uuid
+)
+returns table (
+  reference_review_id uuid,
+  target_table text,
+  data_id uuid,
+  data_version text,
+  data_name jsonb,
+  submitted_revision_checksum text,
+  state_code integer,
+  reviewer_count integer,
+  completed_reviewer_count integer,
+  actor_comment_state_code integer,
+  actor_comment_modified_at timestamptz
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_is_admin boolean;
+  v_is_member boolean;
+begin
+  v_is_admin := v_actor is not null
+    and public.cmd_review_is_review_admin(v_actor);
+  v_is_member := v_actor is not null
+    and public.cmd_review_is_review_member(v_actor);
+
+  if not v_is_admin and not v_is_member then
+    raise exception using errcode = '42501', message = 'REVIEW_ROLE_REQUIRED';
+  end if;
+
+  return query
+  select
+    reference_review.id,
+    reference_review.target_table,
+    reference_review.data_id,
+    pg_catalog.btrim(reference_review.data_version::text),
+    coalesce(reference_review.json #> '{data,name}', '{}'::jsonb),
+    reference_review.submitted_revision_checksum,
+    reference_review.state_code,
+    pg_catalog.jsonb_array_length(
+      coalesce(reference_review.reviewer_id, '[]'::jsonb)
+    )::integer,
+    (
+      select pg_catalog.count(*)::integer
+      from public.comments as completed_comment
+      where completed_comment.review_id = reference_review.id
+        and completed_comment.state_code in (1, -3, 2)
+    ),
+    actor_comment.state_code,
+    actor_comment.modified_at
+  from public.reviews as root_review
+  cross join lateral pg_catalog.unnest(
+    coalesce(root_review.current_reference_review_ids, '{}'::uuid[])
+  ) with ordinality as current_reference(reference_review_id, ordinal_position)
+  join public.reviews as reference_review
+    on reference_review.id = current_reference.reference_review_id
+    and reference_review.review_kind = 'reference'
+  left join lateral (
+    select comment_row.state_code, comment_row.modified_at
+    from public.comments as comment_row
+    where comment_row.review_id = reference_review.id
+      and comment_row.reviewer_id = v_actor
+    order by comment_row.modified_at desc, comment_row.created_at desc
+    limit 1
+  ) as actor_comment on true
+  where root_review.id = p_root_review_id
+    and root_review.review_kind = 'root'
+    and (
+      v_is_admin
+      or (
+        v_is_member
+        and public.policy_review_can_read(reference_review.id, v_actor)
+        and actor_comment.state_code is not null
+        and actor_comment.state_code <> -2
+      )
+    )
+  order by
+    current_reference.ordinal_position,
+    reference_review.target_table,
+    reference_review.id;
+end;
+$$;
+
+alter function public.qry_root_review_reference_progress_v2(uuid) owner to postgres;
+revoke all on function public.qry_root_review_reference_progress_v2(uuid)
+  from public, anon;
+grant execute on function public.qry_root_review_reference_progress_v2(uuid)
+  to authenticated, service_role;
+
+comment on function public.qry_review_get_admin_root_queue_items_v2(
+  text, integer, integer, text, text
+) is
+  'Server-paginated Review Admin queue with one row per Root Review; a matching current Reference Review includes its Root.';
+comment on function public.qry_review_get_member_root_queue_items_v2(
+  text, integer, integer, text, text
+) is
+  'Server-paginated Review Member queue grouped by Root Review without exposing unassigned sibling Reference Reviews.';
+comment on function public.qry_root_review_reference_progress_v2(uuid) is
+  'Current Reference Review child rows for Review Management; intentionally excludes relation paths and aggregate overview fields.';

--- a/supabase/tests/20260802_root_grouped_review_queue.sql
+++ b/supabase/tests/20260802_root_grouped_review_queue.sql
@@ -1,0 +1,501 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(27);
+
+select is(
+  public.cmd_review_get_dataset_name(
+    'contacts',
+    '{"json":{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Contact name"}]}}}}}'::jsonb
+  ),
+  '{"baseName":[{"@xml:lang":"en","#text":"Contact name"}]}'::jsonb,
+  'Contact review snapshots normalize common:shortName as baseName'
+);
+select is(
+  public.cmd_review_get_dataset_name(
+    'sources',
+    '{"json":{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"en","#text":"Source name"}]}}}}}'::jsonb
+  ),
+  '{"baseName":[{"@xml:lang":"en","#text":"Source name"}]}'::jsonb,
+  'Source review snapshots normalize common:shortName as baseName'
+);
+select is(
+  public.cmd_review_get_dataset_name(
+    'unitgroups',
+    '{"json":{"unitGroupDataSet":{"unitGroupInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Unit group name"}]}}}}}'::jsonb
+  ),
+  '{"baseName":[{"@xml:lang":"en","#text":"Unit group name"}]}'::jsonb,
+  'Unit Group review snapshots normalize common:name as baseName'
+);
+select is(
+  public.cmd_review_get_dataset_name(
+    'flowproperties',
+    '{"json":{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Flow property name"}]}}}}}'::jsonb
+  ),
+  '{"baseName":[{"@xml:lang":"en","#text":"Flow property name"}]}'::jsonb,
+  'Flow Property review snapshots normalize common:name as baseName'
+);
+
+insert into auth.users (
+  instance_id, id, aud, role, email, encrypted_password,
+  email_confirmed_at, raw_app_meta_data, raw_user_meta_data,
+  created_at, updated_at, is_sso_user, is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '48200000-0000-4000-8000-000000000001',
+    'authenticated', 'authenticated', 'queue-owner@example.com', 'test',
+    now(), '{"provider":"email","providers":["email"]}',
+    '{"display_name":"Queue Owner"}', now(), now(), false, false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '48200000-0000-4000-8000-000000000002',
+    'authenticated', 'authenticated', 'reviewer-a@example.com', 'test',
+    now(), '{"provider":"email","providers":["email"]}',
+    '{"display_name":"Reviewer A"}', now(), now(), false, false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '48200000-0000-4000-8000-000000000003',
+    'authenticated', 'authenticated', 'reviewer-b@example.com', 'test',
+    now(), '{"provider":"email","providers":["email"]}',
+    '{"display_name":"Reviewer B"}', now(), now(), false, false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '48200000-0000-4000-8000-000000000004',
+    'authenticated', 'authenticated', 'queue-admin@example.com', 'test',
+    now(), '{"provider":"email","providers":["email"]}',
+    '{"display_name":"Queue Admin"}', now(), now(), false, false
+  );
+
+insert into public.users (id, raw_user_meta_data)
+values
+  ('48200000-0000-4000-8000-000000000001', '{"display_name":"Queue Owner"}'),
+  ('48200000-0000-4000-8000-000000000002', '{"display_name":"Reviewer A"}'),
+  ('48200000-0000-4000-8000-000000000003', '{"display_name":"Reviewer B"}'),
+  ('48200000-0000-4000-8000-000000000004', '{"display_name":"Queue Admin"}');
+
+insert into public.teams (id, json, rank, is_public)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  '{"name":"System Team"}', 0, false
+)
+on conflict (id) do nothing;
+
+insert into public.roles (user_id, team_id, role)
+values
+  (
+    '48200000-0000-4000-8000-000000000002',
+    '00000000-0000-0000-0000-000000000000',
+    'review-member'
+  ),
+  (
+    '48200000-0000-4000-8000-000000000003',
+    '00000000-0000-0000-0000-000000000000',
+    'review-member'
+  ),
+  (
+    '48200000-0000-4000-8000-000000000004',
+    '00000000-0000-0000-0000-000000000000',
+    'review-admin'
+  );
+
+-- One unassigned shared Reference Review and two independently assigned
+-- Reference Reviews provide mixed-status and access-isolation fixtures.
+insert into public.reviews (
+  id, data_id, data_version, state_code, reviewer_id, json,
+  review_kind, target_table, submitted_revision_checksum, target_owner_id,
+  created_at, modified_at
+)
+values
+  (
+    '48200000-0000-4000-8000-000000000101',
+    '48200000-0000-4000-8000-000000000201', '01.00.000', 0, '[]',
+    '{"review_kind":"reference","data":{"id":"48200000-0000-4000-8000-000000000201","version":"01.00.000","table":"flows","name":{"baseName":{"en":"Shared Flow"}}}}',
+    'reference', 'flows', repeat('1', 64),
+    '48200000-0000-4000-8000-000000000001', now(), now()
+  ),
+  (
+    '48200000-0000-4000-8000-000000000102',
+    '48200000-0000-4000-8000-000000000202', '01.00.000', 1,
+    '["48200000-0000-4000-8000-000000000002"]',
+    '{"review_kind":"reference","data":{"id":"48200000-0000-4000-8000-000000000202","version":"01.00.000","table":"sources","name":{"baseName":{"en":"Reviewer A Source"}}}}',
+    'reference', 'sources', repeat('2', 64),
+    '48200000-0000-4000-8000-000000000001', now(), now()
+  ),
+  (
+    '48200000-0000-4000-8000-000000000103',
+    '48200000-0000-4000-8000-000000000203', '01.00.000', 1,
+    '["48200000-0000-4000-8000-000000000003"]',
+    '{"review_kind":"reference","data":{"id":"48200000-0000-4000-8000-000000000203","version":"01.00.000","table":"contacts","name":{"baseName":{"en":"Reviewer B Contact"}}}}',
+    'reference', 'contacts', repeat('3', 64),
+    '48200000-0000-4000-8000-000000000001', now(), now()
+  );
+
+insert into public.comments (review_id, reviewer_id, json, state_code)
+values
+  (
+    '48200000-0000-4000-8000-000000000102',
+    '48200000-0000-4000-8000-000000000002', '{}', 0
+  ),
+  (
+    '48200000-0000-4000-8000-000000000103',
+    '48200000-0000-4000-8000-000000000003', '{}', 0
+  );
+
+create temporary table grouped_root_fixture (
+  root_review_id uuid primary key,
+  root_state_code integer not null,
+  reference_ids uuid[] not null
+) on commit drop;
+
+insert into grouped_root_fixture (root_review_id, root_state_code, reference_ids)
+values
+  (
+    '48200000-0000-4000-8000-000000000111', 1,
+    array[
+      '48200000-0000-4000-8000-000000000101'::uuid,
+      '48200000-0000-4000-8000-000000000102'::uuid,
+      '48200000-0000-4000-8000-000000000103'::uuid
+    ]
+  ),
+  (
+    '48200000-0000-4000-8000-000000000112', 0,
+    array['48200000-0000-4000-8000-000000000101'::uuid]
+  ),
+  (
+    '48200000-0000-4000-8000-000000000113', 1,
+    array['48200000-0000-4000-8000-000000000102'::uuid]
+  );
+
+with root_items as (
+  select
+    fixture.root_review_id,
+    fixture.root_state_code,
+    pg_catalog.jsonb_build_array(
+      pg_catalog.jsonb_build_object(
+        'item_kind', 'root',
+        'target_table', 'processes',
+        'data_id', fixture.root_review_id,
+        'data_version', '01.00.000',
+        'submitted_revision_checksum', repeat('a', 64),
+        'target_owner_id', '48200000-0000-4000-8000-000000000001'
+      )
+    ) || coalesce((
+      select pg_catalog.jsonb_agg(
+        pg_catalog.jsonb_build_object(
+          'item_kind', 'reference',
+          'target_table', reference_review.target_table,
+          'data_id', reference_review.data_id,
+          'data_version', pg_catalog.btrim(reference_review.data_version::text),
+          'submitted_revision_checksum', reference_review.submitted_revision_checksum,
+          'reference_review_id', reference_review.id,
+          'target_owner_id', reference_review.target_owner_id
+        )
+        order by reference_review.id
+      )
+      from pg_catalog.unnest(fixture.reference_ids) as related(reference_review_id)
+      join public.reviews as reference_review
+        on reference_review.id = related.reference_review_id
+    ), '[]'::jsonb) as items
+  from grouped_root_fixture as fixture
+),
+root_histories as (
+  select
+    root_item.root_review_id,
+    root_item.root_state_code,
+    pg_catalog.jsonb_build_object(
+      'schema_version', 'review_scope.v1',
+      'current_version', 1,
+      'snapshots', pg_catalog.jsonb_build_array(
+        pg_catalog.jsonb_build_object(
+          'version_no', 1,
+          'scope_basis', 'submitted',
+          'root_revision_checksum', repeat('a', 64),
+          'scope_checksum', public.review_scope_checksum_v1(root_item.items),
+          'created_by', '48200000-0000-4000-8000-000000000001',
+          'created_at', pg_catalog.to_jsonb(now()),
+          'items', root_item.items
+        )
+      )
+    ) as scope_history
+  from root_items as root_item
+)
+insert into public.reviews (
+  id, data_id, data_version, state_code, reviewer_id, json,
+  review_kind, target_table, submitted_revision_checksum, target_owner_id,
+  scope_schema_version, scope_history, created_at, modified_at
+)
+select
+  root_history.root_review_id,
+  root_history.root_review_id,
+  '01.00.000',
+  root_history.root_state_code,
+  '[]',
+  pg_catalog.jsonb_build_object(
+    'review_kind', 'root',
+    'data', pg_catalog.jsonb_build_object(
+      'id', root_history.root_review_id,
+      'version', '01.00.000',
+      'table', 'processes',
+      'name', pg_catalog.jsonb_build_object(
+        'baseName', pg_catalog.jsonb_build_object(
+          'en', 'Root ' || root_history.root_review_id::text
+        )
+      )
+    ),
+    'user', pg_catalog.jsonb_build_object(
+      'id', '48200000-0000-4000-8000-000000000001',
+      'name', 'Queue Owner'
+    )
+  ),
+  'root', 'processes', repeat('a', 64),
+  '48200000-0000-4000-8000-000000000001',
+  'review_scope.v1', root_history.scope_history, now(), now()
+from root_histories as root_history;
+
+select has_function(
+  'public', 'qry_review_get_admin_root_queue_items_v2',
+  array['text', 'integer', 'integer', 'text', 'text'],
+  'grouped Review Admin queue function exists'
+);
+select has_function(
+  'public', 'qry_review_get_member_root_queue_items_v2',
+  array['text', 'integer', 'integer', 'text', 'text'],
+  'grouped Review Member queue function exists'
+);
+select has_function(
+  'public', 'qry_root_review_reference_progress_v2', array['uuid'],
+  'versioned root child query function exists'
+);
+select has_function(
+  'public', 'qry_root_review_reference_progress', array['uuid'],
+  'legacy root child query remains available for compatibility'
+);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '48200000-0000-4000-8000-000000000004',
+  true
+);
+set local role authenticated;
+
+select is(
+  (
+    select pg_catalog.count(*)::integer
+    from public.qry_review_get_admin_root_queue_items_v2(
+      'unassigned', 1, 10, 'modified_at', 'desc'
+    )
+  ),
+  2,
+  'Admin unassigned queue includes roots matched directly or through a child'
+);
+select is(
+  (
+    select pg_catalog.count(*)::integer
+    from public.qry_review_get_admin_root_queue_items_v2(
+      'unassigned', 1, 10, 'modified_at', 'desc'
+    )
+    where review_kind = 'root'
+  ),
+  2,
+  'Admin main queue contains only Root Reviews'
+);
+select is(
+  (
+    select root_matches_status
+    from public.qry_review_get_admin_root_queue_items_v2(
+      'unassigned', 1, 10, 'modified_at', 'desc'
+    )
+    where id = '48200000-0000-4000-8000-000000000111'
+  ),
+  false,
+  'an assigned root is marked as included by its unassigned child'
+);
+select is(
+  (
+    select root_matches_status
+    from public.qry_review_get_admin_root_queue_items_v2(
+      'unassigned', 1, 10, 'modified_at', 'desc'
+    )
+    where id = '48200000-0000-4000-8000-000000000112'
+  ),
+  true,
+  'an unassigned root is marked as directly matching the tab'
+);
+select is(
+  (
+    select pg_catalog.max(total_count)::integer
+    from public.qry_review_get_admin_root_queue_items_v2(
+      'unassigned', 1, 10, 'modified_at', 'desc'
+    )
+  ),
+  2,
+  'Admin total_count counts grouped roots rather than individual reviews'
+);
+select is(
+  (
+    select pg_catalog.count(*)::integer
+    from public.qry_review_get_admin_root_queue_items_v2(
+      'unassigned', 1, 1, 'modified_at', 'desc'
+    )
+  ),
+  1,
+  'Admin pagination is applied after root grouping'
+);
+select is(
+  (
+    select pg_catalog.max(total_count)::integer
+    from public.qry_review_get_admin_root_queue_items_v2(
+      'unassigned', 1, 1, 'modified_at', 'desc'
+    )
+  ),
+  2,
+  'paginated Admin rows retain the grouped total'
+);
+select is(
+  (
+    select pg_catalog.count(*)::integer
+    from public.qry_root_review_reference_progress_v2(
+      '48200000-0000-4000-8000-000000000111'
+    )
+  ),
+  3,
+  'Review Admin sees all current Reference Reviews under a root'
+);
+select ok(
+  pg_catalog.strpos(
+    pg_catalog.pg_get_function_result(
+      'public.qry_root_review_reference_progress_v2(uuid)'::regprocedure
+    ),
+    'relation_paths'
+  ) = 0,
+  'the child-row contract does not expose relation paths'
+);
+select is(
+  (
+    select child_a.reference_review_id
+    from public.qry_root_review_reference_progress_v2(
+      '48200000-0000-4000-8000-000000000111'
+    ) as child_a
+    where child_a.reference_review_id =
+      '48200000-0000-4000-8000-000000000101'
+  ),
+  (
+    select child_b.reference_review_id
+    from public.qry_root_review_reference_progress_v2(
+      '48200000-0000-4000-8000-000000000112'
+    ) as child_b
+    where child_b.reference_review_id =
+      '48200000-0000-4000-8000-000000000101'
+  ),
+  'a shared Reference Review keeps the same review id under both roots'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claim.sub',
+  '48200000-0000-4000-8000-000000000002',
+  true
+);
+set local role authenticated;
+
+select is(
+  (
+    select pg_catalog.count(*)::integer
+    from public.qry_review_get_member_root_queue_items_v2(
+      'pending', 1, 10, 'modified_at', 'desc'
+    )
+  ),
+  2,
+  'one assigned Reference Review places every related root in the member queue'
+);
+select ok(
+  not exists (
+    select 1
+    from public.qry_review_get_member_root_queue_items_v2(
+      'pending', 1, 10, 'modified_at', 'desc'
+    )
+    where root_matches_status or root_can_read
+  ),
+  'Reference-only member results do not expose root actions or full root access'
+);
+select is(
+  (
+    select pg_catalog.max(total_count)::integer
+    from public.qry_review_get_member_root_queue_items_v2(
+      'pending', 1, 1, 'modified_at', 'desc'
+    )
+  ),
+  2,
+  'Review Member pagination also counts grouped roots'
+);
+select is(
+  (
+    select pg_catalog.count(*)::integer
+    from public.qry_root_review_reference_progress_v2(
+      '48200000-0000-4000-8000-000000000111'
+    )
+  ),
+  1,
+  'Review Member child query hides unassigned and sibling reviewer tasks'
+);
+select is(
+  (
+    select reference_review_id
+    from public.qry_root_review_reference_progress_v2(
+      '48200000-0000-4000-8000-000000000111'
+    )
+  ),
+  '48200000-0000-4000-8000-000000000102'::uuid,
+  'Review Member sees only their assigned Reference Review id'
+);
+select is(
+  (
+    select actor_comment_state_code
+    from public.qry_root_review_reference_progress_v2(
+      '48200000-0000-4000-8000-000000000111'
+    )
+  ),
+  0,
+  'member child row includes the actor comment state needed for tab matching'
+);
+
+reset role;
+select set_config('request.jwt.claim.sub', '', true);
+set local role authenticated;
+select throws_ok(
+  $$select * from public.qry_root_review_reference_progress_v2(
+    '48200000-0000-4000-8000-000000000111'
+  )$$,
+  '42501',
+  'REVIEW_ROLE_REQUIRED',
+  'child query rejects callers without a review role'
+);
+
+reset role;
+select ok(
+  not has_function_privilege(
+    'anon',
+    'public.qry_review_get_admin_root_queue_items_v2(text,integer,integer,text,text)',
+    'EXECUTE'
+  ),
+  'anonymous callers cannot execute the grouped Admin queue'
+);
+select ok(
+  not has_function_privilege(
+    'anon',
+    'public.qry_review_get_member_root_queue_items_v2(text,integer,integer,text,text)',
+    'EXECUTE'
+  ),
+  'anonymous callers cannot execute the grouped Member queue'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Closes tiangong-lca/database-engine#323

## Summary
- 新增管理员与审核员使用的 v2 根审核分组队列 RPC，主列表只返回根审核。
- 新增根审核关联引用审核进度 RPC，支持前端在根审核子表中展示引用审核。

## Key Decisions
- 页签命中由根审核或其当前引用审核聚合判断，分页始终以根审核为单位。
- 引用关系继续以 reviews.current_reference_review_ids 为规范来源，不新增引用概况、引用路径或非必要索引。
- 审核员队列在数据库层保持成员权限隔离，并返回 root_can_read 控制根数据入口。

## Validation
- 本地 Supabase db reset 通过。
- 两份 pgTAP 测试文件共 41 项测试全部通过。

## Risks / Rollback
- 仅新增 v2 RPC，旧 RPC 保留，回滚时可撤回新增 migration；本 PR 不执行远程数据库迁移或存量数据迁移。

## Follow-ups
- 合并后先将 migration 部署到 Preview/持久 dev 环境，再与 [前端 PR #761](https://github.com/linancn/tiangong-lca-next/pull/761) 联调。

## Workspace Integration
- database-engine dev 提升到 main 后，再由根工作区更新子模块指针。