### PR TITLE
test: qualify hosted LCA snapshot consumers

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -43,6 +43,7 @@ ownership:
           - .env.supabase.dev.local.example
           - .env.supabase.main.local.example
           - .github/workflows/supabase-dev.yml
+          - .github/workflows/lca-snapshot-hosted-qualification.yml
           - .github/workflows/database-validation.yml
       ownerRepo: database-engine
     - id: schema-workspace-and-migration-tooling
@@ -91,6 +92,7 @@ coverage:
     - .env.supabase.main.local.example
     - .github/workflows/ai-doc-lint.yml
     - .github/workflows/supabase-dev.yml
+    - .github/workflows/lca-snapshot-hosted-qualification.yml
     - .github/workflows/database-validation.yml
   exclude:
     - .git/**
@@ -194,6 +196,7 @@ routing:
         - .env.supabase.dev.local.example
         - .env.supabase.main.local.example
         - .github/workflows/supabase-dev.yml
+        - .github/workflows/lca-snapshot-hosted-qualification.yml
         - .github/workflows/database-validation.yml
         - docs/agents/supabase-branching.md
         - docs/agents/supabase-branching_CN.md
@@ -235,6 +238,7 @@ routing:
         - supabase/tests/**
         - .github/workflows/database-validation.yml
         - .github/workflows/supabase-dev.yml
+        - .github/workflows/lca-snapshot-hosted-qualification.yml
     root-integration:
       paths:
         - AGENTS.md
@@ -327,6 +331,28 @@ rules:
       - path: docs/agents/supabase-branching_CN.md
         mode: review_or_update
     reason: Branch bindings and persistent dev automation change repo routing, proof, and branch-operation guidance together.
+  - id: database-engine-hosted-consumer-qualification
+    scope: repo
+    repo: database-engine
+    triggers:
+      - path: .github/workflows/lca-snapshot-hosted-qualification.yml
+        kind: hosted-proof-automation
+      - path: supabase/tests/hosted/lca_snapshot_hosted_qualification.py
+        kind: hosted-proof-runner
+      - path: supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
+        kind: hosted-proof-test
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+      - path: docs/agents/repo-architecture.md
+        mode: review_or_update
+      - path: docs/agents/supabase-branching.md
+        mode: review_or_update
+    reason: The canonical-dev-only secret-bearing hosted proof must keep targeting, credential, cleanup, and source-trust boundaries aligned.
   - id: database-engine-migration-and-seed-contract
     scope: repo
     repo: database-engine

--- a/.github/workflows/lca-snapshot-hosted-qualification.yml
+++ b/.github/workflows/lca-snapshot-hosted-qualification.yml
@@ -1,0 +1,74 @@
+name: Persistent Dev LCA Snapshot Hosted Qualification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: persistent-dev-lca-snapshot-hosted-qualification
+  cancel-in-progress: false
+
+jobs:
+  qualify:
+    name: Qualify trusted LCA snapshot consumers on persistent Dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+    steps:
+      - name: Refuse non-canonical repository, non-dev branch, or production target
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REPOSITORY}" != "tiangong-lca/database-engine" ]]; then
+            echo "Refusing non-canonical repository." >&2
+            exit 1
+          fi
+          if [[ "${{ github.ref }}" != 'refs/heads/dev' ]]; then
+            echo "Refusing any branch other than refs/heads/dev." >&2
+            exit 1
+          fi
+
+      - name: Checkout trusted database-engine dev code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Bind checkout to the database contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          contract_sha='86ba7ee2c33e45df8008117a2dec3ee4deedc32c'
+          migration='supabase/migrations/20260802091342_issue_376_lca_snapshot_family_expand.sql'
+          expected_blob='15d4af7d46420eaac477c679d62a7d48d13c4911'
+          expected_sha256='86f38ad2a5828b33d5ff0f0f7e21353469cdb143dc4a4f94890f651104e11ecc'
+          git merge-base --is-ancestor "$contract_sha" HEAD
+          [[ "$(git rev-parse "$contract_sha:$migration")" == "$expected_blob" ]]
+          [[ "$(git hash-object "$migration")" == "$expected_blob" ]]
+          [[ "$(sha256sum "$migration" | cut -d' ' -f1)" == "$expected_sha256" ]]
+          [[ "$migration" == supabase/migrations/20260802091342_* ]]
+          {
+            echo '### Immutable database qualification evidence'
+            echo "- workflow checkout: \`${GITHUB_SHA}\`"
+            echo "- contract ancestor: \`${contract_sha}\`"
+            echo "- migration: \`${migration}\`"
+            echo "- git blob: \`${expected_blob}\`"
+            echo "- file sha256: \`${expected_sha256}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.1.0
+        with:
+          python-version: "3.12"
+
+      - name: Run fail-closed hosted qualification
+        run: python supabase/tests/hosted/lca_snapshot_hosted_qualification.py
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_DEV_PROJECT_ID }}
+          SUPABASE_DEV_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          SUPABASE_DEV_SECRET_KEY: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 2e7b3ba2a3fcdcbc59cb26416512808465262049
-lastReviewedNote: "Reviewed for Issue #376 after Issue #323 integration and CI repair: repository ownership, migration discipline, exact consumer binding, canonical manifest evidence, credential-safe docs, Preview qualification, and dev delivery rules already govern this change."
+lastReviewedCommit: 86ba7ee2c33e45df8008117a2dec3ee4deedc32c
+lastReviewedNote: "Reviewed for Issue #380: the trusted persistent-Dev consumer qualification remains database-owned proof automation, uses canonical dev and repository secrets as its current boundary, and does not change schema or production ownership."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -147,6 +147,7 @@ At a human-readable level, this repo owns:
 - `scripts/**` for schema export, workspace refresh, change copying, and migration generation
 - `.github/workflows/supabase-dev.yml`
 - `.github/workflows/database-validation.yml`
+- `.github/workflows/lca-snapshot-hosted-qualification.yml`
 - production Supabase GitHub integration contract for Git `main`
 - `.env.supabase.dev.local.example`
 - `.env.supabase.main.local.example`

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,13 +24,14 @@ checkPaths:
   - scripts/**
   - .github/workflows/supabase-dev.yml
   - .github/workflows/database-validation.yml
+  - .github/workflows/lca-snapshot-hosted-qualification.yml
   - .githooks/pre-push
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 2e7b3ba2a3fcdcbc59cb26416512808465262049
-lastReviewedNote: "Reviewed for Issue #376 after Issue #323 integration and fresh-stack CI repair: service-role api facades, private canonical tables, public compatibility views, and the three receipt-bound Issue #323 transition-native SECURITY DEFINER lineages follow the existing five-schema architecture."
+lastReviewedCommit: 86ba7ee2c33e45df8008117a2dec3ee4deedc32c
+lastReviewedNote: "Reviewed for Issue #380: add the trusted persistent-Dev hosted qualification path without changing schema-source or generated-workspace boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -58,6 +59,7 @@ This repo is organized around one checked-in Supabase project plus a generated s
 | `scripts/**` | export, refresh, change-copy, and migration-generation helpers |
 | `.github/workflows/supabase-dev.yml` | serialized automation for pushing committed migrations to persistent remote `dev`, then reconciling and readback-verifying only the reviewed PostgREST fields |
 | `.github/workflows/database-validation.yml` | PR fresh-stack reset, manifest-owned canonical database contract, and freeze-activated focused validation before merge |
+| `.github/workflows/lca-snapshot-hosted-qualification.yml` | manual, canonical-`dev`-only trusted probe for the fixed persistent Dev LCA snapshot/Edge contract; it never checks out consumer code or accepts repository/ref/script/project selectors |
 | `supabase/workspace/changes/**` | manual overlay area used when generating migrations from workspace files |
 | `supabase/workspace/remote_schema.sql` | generated full raw dump from the remote database |
 | `supabase/workspace/global/**` | generated split-out global objects rebuilt on workspace refresh |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,6 +25,7 @@ checkPaths:
   - supabase/seeds/**
   - scripts/**
   - .github/workflows/supabase-dev.yml
+  - .github/workflows/lca-snapshot-hosted-qualification.yml
   - .github/workflows/database-validation.yml
   - .github/workflows/ai-doc-lint.yml
   - .githooks/pre-push
@@ -57,6 +58,42 @@ supabase start
 supabase db reset
 supabase migration list
 ```
+
+## Persistent Dev consumer qualification
+
+`.github/workflows/lca-snapshot-hosted-qualification.yml` is the narrow hosted
+proof path for database-engine Issue #380. It can run only by manual dispatch
+from the canonical repository's `dev` branch. It checks the fixed persistent
+Dev project, migration head, database contract SHA, and deployed Edge evidence
+before using only this repository's trusted probe. The workflow proves that the
+fixed contract commit is an ancestor of the checked-out `dev` commit and binds
+the exact migration path, Git blob, and file SHA-256. The probe independently
+compares the five deployed functions' IDs, versions, update times, and immutable
+bundle digests with the deployment-time receipt. That receipt records exact
+source-worktree and remote deployment metadata; it does not claim a standalone
+cryptographic proof from Git commit to deployed bundle. It has no repository,
+ref, script, project, or endpoint input and never checks out consumer code.
+
+The current security boundary is the canonical `dev` branch plus repository
+variables/secrets already used by Supabase Dev automation. The probe first uses
+`SUPABASE_ACCESS_TOKEN` to request the current revealed publishable and secret
+keys from the Supabase Management API and masks them before use. If that token
+cannot reveal both modern keys, operators must configure the two project-only
+repository secrets `SUPABASE_DEV_PUBLISHABLE_KEY` and
+`SUPABASE_DEV_SECRET_KEY`; the run must fail until both exist and are valid.
+This repository does not currently rely on a GitHub Environment for this path.
+
+The proof must finish with independent zero residue for network snapshots,
+snapshot artifacts, active snapshots, result caches, jobs, results, Storage
+objects/buckets, Auth users, and Auth sessions. One unique run namespace binds
+the snapshot IDs, cache/worker subject identity, Storage bucket/prefix, and Auth
+email/metadata marker. The same unconditional reconciler runs before fixture
+setup and in `finally`; it discovers actual remote state, cancels matching Worker
+jobs before dependency-ordered deletion, tolerates already-absent Storage/Auth
+resources, and aggregates every cleanup/readback error with the primary failure.
+It therefore does not depend on receiving successful create or enqueue
+responses. Preview, mock, or consumer-repo test output does not replace this
+persistent Dev proof.
 
 The checked-in canonical entry point is:
 

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -134,6 +134,15 @@ Repository configuration expected by `.github/workflows/supabase-dev.yml`:
 - secret `SUPABASE_ACCESS_TOKEN`
 - secret `SUPABASE_DEV_DB_PASSWORD`
 
+The manual Issue #380 hosted consumer qualification additionally uses the same
+repository variable and access token, but never deploys migrations. It resolves
+current modern API keys through the Management API. If the access token lacks
+key-reveal permission, configure both project-specific repository secrets
+`SUPABASE_DEV_PUBLISHABLE_KEY` and `SUPABASE_DEV_SECRET_KEY`; absence or an
+invalid key is a hard blocker, not a reason to retry legacy disabled keys. The
+workflow refuses every ref except canonical `refs/heads/dev` and explicitly
+rejects production project `qgzvkongdjqiiamzbbts`.
+
 ## PR to Supabase migration path
 
 Committed migration files do not affect any remote database until one of the

--- a/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Fail-closed hosted qualification for the persistent Dev LCA snapshot family.
+
+This runner is intentionally specific to database-engine Issue #380.  It never
+loads consumer code and has no repository, ref, script, project, or endpoint
+selector supplied by a caller.
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import os
+import secrets
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+REPOSITORY = "tiangong-lca/database-engine"
+DEV_REF = "fotofiyqnuyvgtotswie"
+PRODUCTION_REF = "qgzvkongdjqiiamzbbts"
+DATABASE_CONTRACT_SHA = "86ba7ee2c33e45df8008117a2dec3ee4deedc32c"
+MIGRATION_HEAD = "20260802091342"
+EDGE_SOURCE_HEAD = "6080b4c2c95b00c2666f98af6bb90610042fc3da"
+EDGE_DEPLOYMENT_RECEIPT = {
+    "lca_solve": ("878d7c40-f675-4c87-9687-2abd2ea71c2c", 22, 1785671706196, "56fc024e624450c054158cdf37a0c0a9329cec6b9fb5116210e123a70f6fac67"),
+    "lca_query_results": ("3683b3d0-6242-43c0-9976-9817503ce4a2", 22, 1785671715093, "938590e9b5ea0f2cf60c9bf08223d31781bccb3f7625a7373af5c2f1fcc0651f"),
+    "lca_contribution_path": ("48c78d31-8037-4901-bd86-d6fd5fc159f9", 21, 1785671723627, "d33fd33bdfa182a0143d731ef518ebf30e9a6d093a03f8484ec7a494d2fde4a6"),
+    "app_data_product_commands": ("03f88df7-2cfd-48f5-80db-b7b7976e9a49", 17, 1785671732171, "8d30ff95aa2ba1f057fb490b5b7dfc1d211920a866c2da0e3c8378dc4090d22d"),
+    "data_product_results": ("9c00a8d9-68d5-49c6-84eb-9044970d728b", 12, 1785671740181, "24eba3a6b60a62cb6e3b2299b57f361dd03e07d85261b5bfd5b5c1f744bc7525"),
+}
+RPC_CASES = (
+    ("lca_snapshot_active_read_v1", {"p_scope": "issue380-hosted"}),
+    ("lca_snapshot_scope_read_v1", None),
+    ("lca_snapshot_resolve_v1", {"p_scope": "prod", "p_process_filter": {"issue380": True}}),
+    ("lca_snapshot_artifact_read_v1", None),
+    ("lca_snapshot_artifact_latest_v1", {}),
+    ("cmd_lca_snapshot_create_v1", None),
+)
+
+
+class QualificationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Config:
+    repository: str
+    git_ref: str
+    project_ref: str
+    access_token: str
+    publishable_key: str | None
+    secret_key: str | None
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        return cls(
+            repository=os.environ.get("GITHUB_REPOSITORY", ""),
+            git_ref=os.environ.get("GITHUB_REF", ""),
+            project_ref=os.environ.get("SUPABASE_PROJECT_ID", ""),
+            access_token=os.environ.get("SUPABASE_ACCESS_TOKEN", ""),
+            publishable_key=os.environ.get("SUPABASE_DEV_PUBLISHABLE_KEY") or None,
+            secret_key=os.environ.get("SUPABASE_DEV_SECRET_KEY") or None,
+        )
+
+    def validate(self) -> None:
+        expected = {
+            "repository": (self.repository, REPOSITORY),
+            "git ref": (self.git_ref, "refs/heads/dev"),
+            "project ref": (self.project_ref, DEV_REF),
+        }
+        for label, (actual, wanted) in expected.items():
+            if actual != wanted:
+                raise QualificationError(f"refusing unexpected {label}")
+        if self.project_ref == PRODUCTION_REF:
+            raise QualificationError("production project is forbidden")
+        if not self.access_token:
+            raise QualificationError("SUPABASE_ACCESS_TOKEN is required")
+
+
+@dataclass(frozen=True)
+class RunNamespace:
+    marker: str
+    fixture_id: uuid.UUID
+    create_id: uuid.UUID
+    email: str
+    bucket: str
+    prefix: str
+
+    @classmethod
+    def create(cls) -> "RunNamespace":
+        root = uuid.uuid4()
+        marker = root.hex
+        return cls(
+            marker=marker,
+            fixture_id=uuid.uuid5(root, "fixture"),
+            create_id=uuid.uuid5(root, "create"),
+            email=f"issue380-{root}@example.invalid",
+            bucket=f"issue380-{marker}",
+            prefix=f"runs/{marker}",
+        )
+
+
+def mask(value: str) -> None:
+    if value:
+        print(f"::add-mask::{value}")
+
+
+def _json_request(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: Any | None = None,
+    timeout: int = 45,
+) -> tuple[int, Any]:
+    encoded = None if body is None else json.dumps(body, separators=(",", ":")).encode()
+    request_headers = {"Accept": "application/json", "User-Agent": "database-engine-issue-380"}
+    request_headers.update(headers or {})
+    if encoded is not None:
+        request_headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=encoded, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = response.read()
+            return response.status, json.loads(payload) if payload else None
+    except urllib.error.HTTPError as error:
+        payload = error.read()
+        try:
+            parsed = json.loads(payload) if payload else None
+        except json.JSONDecodeError:
+            parsed = None
+        return error.code, parsed
+
+
+def select_current_keys(rows: Any) -> tuple[str, str]:
+    if not isinstance(rows, list):
+        raise QualificationError("Management API key response is not a list")
+
+    def choose(kind: str, prefix: str) -> str:
+        candidates: list[tuple[bool, str]] = []
+        for row in rows:
+            if not isinstance(row, dict) or str(row.get("type", "")).lower() != kind:
+                continue
+            if row.get("disabled") is True or str(row.get("status", "active")).lower() != "active":
+                continue
+            value = row.get("api_key") or row.get("key") or row.get("value")
+            if isinstance(value, str) and value.startswith(prefix):
+                candidates.append((str(row.get("name", "")) == "default", value))
+        candidates.sort(key=lambda candidate: candidate[0], reverse=True)
+        if not candidates:
+            raise QualificationError(f"no revealed active {kind} key")
+        return candidates[0][1]
+
+    return choose("publishable", "sb_publishable_"), choose("secret", "sb_secret_")
+
+
+def resolve_keys(config: Config, requester: Callable[..., tuple[int, Any]] = _json_request) -> tuple[str, str]:
+    if bool(config.publishable_key) != bool(config.secret_key):
+        raise QualificationError("both project-specific key secrets must be configured together")
+    status, payload = requester(
+        f"https://api.supabase.com/v1/projects/{DEV_REF}/api-keys?reveal=true",
+        headers={"Authorization": f"Bearer {config.access_token}"},
+    )
+    try:
+        keys = select_current_keys(payload) if status == 200 else None
+    except QualificationError:
+        keys = None
+    if keys is None:
+        if not config.publishable_key or not config.secret_key:
+            raise QualificationError(
+                "Management token cannot reveal current keys; configure repository secrets "
+                "SUPABASE_DEV_PUBLISHABLE_KEY and SUPABASE_DEV_SECRET_KEY"
+            )
+        keys = (config.publishable_key, config.secret_key)
+    if not keys[0].startswith("sb_publishable_") or not keys[1].startswith("sb_secret_"):
+        raise QualificationError("refusing legacy or wrong-role API key")
+    mask(keys[0])
+    mask(keys[1])
+    return keys
+
+
+class HostedClient:
+    def __init__(self, config: Config, publishable_key: str, secret_key: str) -> None:
+        self.config = config
+        self.publishable_key = publishable_key
+        self.secret_key = secret_key
+        self.base_url = f"https://{DEV_REF}.supabase.co"
+
+    def management(self, path: str, *, method: str = "GET", body: Any | None = None) -> tuple[int, Any]:
+        return _json_request(
+            f"https://api.supabase.com{path}",
+            method=method,
+            headers={"Authorization": f"Bearer {self.config.access_token}"},
+            body=body,
+        )
+
+    def sql(self, query: str) -> Any:
+        status, payload = self.management(
+            f"/v1/projects/{DEV_REF}/database/query", method="POST", body={"query": query}
+        )
+        if status != 201 and status != 200:
+            raise QualificationError(f"hosted SQL query failed with HTTP {status}")
+        return payload
+
+    def rest(
+        self,
+        routine: str,
+        args: dict[str, Any],
+        *,
+        key: str,
+        bearer: str | None = None,
+    ) -> tuple[int, Any]:
+        headers = {"apikey": key, "Content-Profile": "api"}
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return _json_request(
+            f"{self.base_url}/rest/v1/rpc/{routine}", method="POST", headers=headers, body=args
+        )
+
+    def auth(self, path: str, *, method: str, key: str, body: Any | None = None, bearer: str | None = None) -> tuple[int, Any]:
+        headers = {"apikey": key}
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return _json_request(f"{self.base_url}/auth/v1/{path}", method=method, headers=headers, body=body)
+
+    def edge(self, name: str, *, method: str, body: Any | None, bearer: str | None) -> tuple[int, Any]:
+        headers = {"apikey": self.publishable_key}
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return _json_request(
+            f"{self.base_url}/functions/v1/{name}", method=method, headers=headers, body=body
+        )
+
+    def storage_json(self, path: str, *, method: str, body: Any | None = None) -> tuple[int, Any]:
+        return _json_request(
+            f"{self.base_url}/storage/v1/{path}",
+            method=method,
+            headers={"apikey": self.secret_key, "Authorization": f"Bearer {self.secret_key}"},
+            body=body,
+        )
+
+    def upload_json(self, bucket: str, path: str, payload: Any) -> None:
+        data = json.dumps(payload, separators=(",", ":")).encode()
+        request = urllib.request.Request(
+            f"{self.base_url}/storage/v1/object/{bucket}/{path}",
+            data=data,
+            method="POST",
+            headers={
+                "apikey": self.secret_key,
+                "Authorization": f"Bearer {self.secret_key}",
+                "Content-Type": "application/json",
+                "x-upsert": "false",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=45) as response:
+                if response.status not in (200, 201):
+                    raise QualificationError("storage upload failed")
+        except urllib.error.HTTPError as error:
+            raise QualificationError(f"storage upload failed with HTTP {error.code}") from None
+
+
+def require_response(actual: tuple[int, Any], status: int, payload: Any | None = None) -> Any:
+    actual_status, actual_payload = actual
+    if actual_status != status:
+        raise QualificationError(f"unexpected hosted response status {actual_status}; wanted {status}")
+    if payload is not None and actual_payload != payload:
+        raise QualificationError("hosted response DTO mismatch")
+    return actual_payload
+
+
+def _single_row(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, list) and len(payload) == 1 and isinstance(payload[0], dict):
+        return payload[0]
+    if isinstance(payload, dict):
+        return payload
+    raise QualificationError("unexpected hosted query response shape")
+
+
+def canonical_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(payload, separators=(",", ":")).encode()).hexdigest()
+
+
+def sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _rows(payload: Any, label: str) -> list[dict[str, Any]]:
+    if not isinstance(payload, list) or any(not isinstance(row, dict) for row in payload):
+        raise QualificationError(f"{label} response is not a row list")
+    return payload
+
+
+def _allow_status(actual: tuple[int, Any], allowed: tuple[int, ...], label: str) -> Any:
+    status, payload = actual
+    if status not in allowed:
+        raise QualificationError(f"{label} failed with HTTP {status}")
+    return payload
+
+
+def reconcile_namespace(client: HostedClient, run: RunNamespace) -> None:
+    """Discover and remove all hosted state belonging to one run namespace."""
+    errors: list[BaseException] = []
+
+    def attempt(label: str, action: Callable[[], Any]) -> Any:
+        try:
+            return action()
+        except BaseException as error:
+            errors.append(QualificationError(f"namespace reconcile failed: {label}: {type(error).__name__}"))
+            return None
+
+    actor_rows = attempt(
+        "discover-auth-actors",
+        lambda: _rows(
+            client.sql(
+                "select id::text from auth.users "
+                f"where email={sql_literal(run.email)} "
+                f"and raw_user_meta_data->>'issue380_marker'={sql_literal(run.marker)} order by id"
+            ),
+            "Auth actor discovery",
+        ),
+    )
+    actor_ids = [str(row["id"]) for row in (actor_rows or []) if row.get("id")]
+    actor_filter = (
+        " or requested_by in (" + ",".join(sql_literal(value) + "::uuid" for value in actor_ids) + ")"
+        if actor_ids
+        else ""
+    )
+    snapshot_values = f"{sql_literal(str(run.fixture_id))},{sql_literal(str(run.create_id))}"
+    worker_predicate = (
+        f"subject_version in ({snapshot_values},{sql_literal(run.marker)}) "
+        f"or payload_json->>'snapshot_id' in ({snapshot_values}){actor_filter}"
+    )
+    worker_rows = attempt(
+        "discover-worker-jobs",
+        lambda: _rows(
+            client.sql(f"select id::text from public.worker_jobs where {worker_predicate} order by id"),
+            "Worker discovery",
+        ),
+    )
+    worker_ids = [str(row["id"]) for row in (worker_rows or []) if row.get("id")]
+    if worker_ids:
+        ids = ",".join(sql_literal(value) + "::uuid" for value in worker_ids)
+        attempt(
+            "cancel-worker-jobs",
+            lambda: client.sql(
+                f"update public.worker_jobs set status='cancelled', finished_at=coalesce(finished_at,now()), "
+                f"cancelled_at=coalesce(cancelled_at,now()), leased_by=null, lease_token=null, lease_expires_at=null, "
+                f"updated_at=now() where id in ({ids}) and status not in ('completed','failed','cancelled')"
+            ),
+        )
+
+    fixture = sql_literal(str(run.fixture_id))
+    create = sql_literal(str(run.create_id))
+    for label, query in (
+        ("delete-result-cache", f"delete from public.lca_result_cache where snapshot_id in ({fixture},{create})"),
+        ("delete-latest-results", f"delete from public.lca_latest_all_unit_results where snapshot_id in ({fixture},{create})"),
+        ("delete-results", f"delete from public.lca_results where snapshot_id in ({fixture},{create})"),
+        ("delete-lca-jobs", f"delete from public.lca_jobs where snapshot_id in ({fixture},{create})"),
+    ):
+        attempt(label, lambda query=query: client.sql(query))
+    if worker_ids:
+        ids = ",".join(sql_literal(value) + "::uuid" for value in worker_ids)
+        attempt(
+            "detach-worker-job-lineage",
+            lambda: client.sql(
+                f"update public.worker_jobs set root_job_id=null,parent_job_id=null where id in ({ids})"
+            ),
+        )
+        attempt("delete-worker-jobs", lambda: client.sql(f"delete from public.worker_jobs where id in ({ids})"))
+    for label, query in (
+        ("delete-active", f"delete from private.lca_active_snapshots where snapshot_id in ({fixture},{create})"),
+        ("delete-artifacts", f"delete from private.lca_snapshot_artifacts where snapshot_id in ({fixture},{create})"),
+        ("delete-snapshots", f"delete from private.lca_network_snapshots where id in ({fixture},{create})"),
+    ):
+        attempt(label, lambda query=query: client.sql(query))
+
+    storage_rows = attempt(
+        "discover-storage-objects",
+        lambda: _rows(
+            client.sql(
+                f"select name from storage.objects where bucket_id={sql_literal(run.bucket)} order by name"
+            ),
+            "Storage object discovery",
+        ),
+    )
+    object_names = [str(row["name"]) for row in (storage_rows or []) if row.get("name")]
+    if object_names:
+        attempt(
+            "delete-storage-objects",
+            lambda: _allow_status(
+                client.storage_json(f"object/{run.bucket}", method="DELETE", body={"prefixes": object_names}),
+                (200, 404),
+                "Storage object delete",
+            ),
+        )
+    bucket_rows = attempt(
+        "discover-storage-bucket",
+        lambda: _rows(
+            client.sql(f"select id from storage.buckets where id={sql_literal(run.bucket)}"),
+            "Storage bucket discovery",
+        ),
+    )
+    if bucket_rows:
+        attempt(
+            "delete-storage-bucket",
+            lambda: _allow_status(
+                client.storage_json(f"bucket/{run.bucket}", method="DELETE"),
+                (200, 404),
+                "Storage bucket delete",
+            ),
+        )
+
+    for actor_id in actor_ids:
+        attempt("revoke-auth-sessions", lambda actor_id=actor_id: client.sql(f"delete from auth.sessions where user_id={sql_literal(actor_id)}::uuid"))
+        attempt(
+            "delete-auth-user",
+            lambda actor_id=actor_id: _allow_status(
+                client.auth(f"admin/users/{actor_id}", method="DELETE", key=client.secret_key),
+                (200, 404),
+                "Auth user delete",
+            ),
+        )
+
+    residue = attempt(
+        "readback",
+        lambda: _single_row(
+            client.sql(
+                "select "
+                f"(select count(*)::int from private.lca_network_snapshots where id in ({fixture},{create})) network,"
+                f"(select count(*)::int from private.lca_snapshot_artifacts where snapshot_id in ({fixture},{create})) artifact,"
+                f"(select count(*)::int from private.lca_active_snapshots where snapshot_id in ({fixture},{create})) active,"
+                f"(select count(*)::int from public.lca_result_cache where snapshot_id in ({fixture},{create})) result_cache,"
+                f"(select count(*)::int from public.worker_jobs where {worker_predicate}) worker_jobs,"
+                f"(select count(*)::int from public.lca_jobs where snapshot_id in ({fixture},{create})) lca_jobs,"
+                f"(select count(*)::int from public.lca_results where snapshot_id in ({fixture},{create})) lca_results,"
+                f"(select count(*)::int from public.lca_latest_all_unit_results where snapshot_id in ({fixture},{create})) latest_results,"
+                f"(select count(*)::int from storage.objects where bucket_id={sql_literal(run.bucket)}) storage_objects,"
+                f"(select count(*)::int from storage.buckets where id={sql_literal(run.bucket)}) storage_buckets,"
+                f"(select count(*)::int from auth.users where email={sql_literal(run.email)} and raw_user_meta_data->>'issue380_marker'={sql_literal(run.marker)}) users,"
+                f"(select count(*)::int from auth.sessions where user_id in (select id from auth.users where email={sql_literal(run.email)} and raw_user_meta_data->>'issue380_marker'={sql_literal(run.marker)})) sessions"
+            )
+        ),
+    )
+    if residue is not None and any(int(value) != 0 for value in residue.values()):
+        errors.append(QualificationError("namespace reconcile readback is non-zero"))
+    if errors:
+        raise ExceptionGroup("namespace reconciliation failed", errors)
+
+
+def finish_with_reconcile(primary_error: BaseException | None, client: HostedClient, run: RunNamespace) -> None:
+    errors: list[BaseException] = [primary_error] if primary_error is not None else []
+    try:
+        reconcile_namespace(client, run)
+    except ExceptionGroup as cleanup:
+        errors.extend(cleanup.exceptions)
+    except BaseException as cleanup:
+        errors.append(cleanup)
+    if errors:
+        raise ExceptionGroup("hosted qualification or namespace reconciliation failed", errors)
+
+
+def qualify(config: Config) -> None:
+    config.validate()
+    publishable_key, secret_key = resolve_keys(config)
+    client = HostedClient(config, publishable_key, secret_key)
+    run = RunNamespace.create()
+    namespace = uuid.UUID(run.marker)
+    fixture_id, create_id = run.fixture_id, run.create_id
+    artifact_id, impact_id = uuid.uuid5(namespace, "artifact"), uuid.uuid5(namespace, "impact")
+    solve_job, contribution_job, all_unit_job = (uuid.uuid5(namespace, name) for name in ("solve-job", "contribution-job", "all-unit-job"))
+    result_id = uuid.uuid5(namespace, "all-unit-result")
+    bucket, email, marker = run.bucket, run.email, run.marker
+    password = f"Issue380-{secrets.token_urlsafe(24)}-Aa1!"
+    mask(password)
+    user_id: str | None = None
+    access_token: str | None = None
+    primary_error: BaseException | None = None
+
+    try:
+        reconcile_namespace(client, run)
+        head = _single_row(client.sql("select max(version)::text migration_head from supabase_migrations.schema_migrations"))["migration_head"]
+        if head != MIGRATION_HEAD:
+            raise QualificationError("persistent Dev migration head mismatch")
+
+        status, functions = client.management(f"/v1/projects/{DEV_REF}/functions")
+        if status != 200 or not isinstance(functions, list):
+            raise QualificationError("cannot read deployed Edge function metadata")
+        deployed = {str(row.get("slug") or row.get("name")): row for row in functions if isinstance(row, dict)}
+        for name, expected in EDGE_DEPLOYMENT_RECEIPT.items():
+            row = deployed.get(name, {})
+            actual = (str(row.get("id", "")), int(row.get("version", -1)), int(row.get("updated_at", -1)), str(row.get("ezbr_sha256", "")))
+            if actual != expected:
+                raise QualificationError(f"deployed Edge receipt mismatch: {name}")
+        print(f"Edge receipt matched exact remote metadata for source worktree {EDGE_SOURCE_HEAD}; receipt is deployment-time evidence, not a commit-to-bundle proof")
+
+        client.sql(
+            "do $$ begin if (select count(*) from pg_proc p join pg_namespace n on n.oid=p.pronamespace "
+            "where n.nspname='api' and p.proname in ('lca_snapshot_active_read_v1','lca_snapshot_scope_read_v1','lca_snapshot_resolve_v1','lca_snapshot_artifact_read_v1','lca_snapshot_artifact_latest_v1','cmd_lca_snapshot_create_v1') "
+            "and has_function_privilege('service_role',p.oid,'execute') and not has_function_privilege('anon',p.oid,'execute') and not has_function_privilege('authenticated',p.oid,'execute')) <> 6 "
+            "then raise exception 'issue380_acl_mismatch'; end if; end $$;"
+        )
+        artifact_url = f"https://{DEV_REF}.supabase.co/storage/v1/s3/{bucket}/{run.prefix}/snapshot.h5"
+        client.sql(
+            f"insert into private.lca_network_snapshots(id,scope,process_filter,source_hash,status,created_by,created_at,updated_at) values('{fixture_id}','full_library','{{\"issue380\":true}}','issue380-source','ready','{uuid.uuid5(namespace, 'actor')}','2099-08-02T00:00:00Z','2099-08-02T00:00:00Z');"
+            f"insert into private.lca_snapshot_artifacts(id,snapshot_id,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,process_count,flow_count,impact_count,a_nnz,b_nnz,c_nnz,status,created_at,updated_at) values('{artifact_id}','{fixture_id}','{artifact_url}','{'a' * 64}',256,'hdf5',1,1,1,1,1,1,'ready','2099-08-02T00:00:01Z','2099-08-02T00:00:01Z');"
+            f"insert into private.lca_active_snapshots(scope,snapshot_id,source_hash,activated_at,activated_by,note) values('issue380-hosted','{fixture_id}','issue380-source','2099-08-02T00:00:02Z','{uuid.uuid5(namespace, 'actor')}','Issue 380 hosted qualification');"
+        )
+
+        rpc_args = {
+            "lca_snapshot_active_read_v1": {"p_scope": "issue380-hosted"},
+            "lca_snapshot_scope_read_v1": {"p_snapshot_id": str(fixture_id)},
+            "lca_snapshot_resolve_v1": {"p_scope": "prod", "p_process_filter": {"issue380": True}},
+            "lca_snapshot_artifact_read_v1": {"p_snapshot_id": str(fixture_id)},
+            "lca_snapshot_artifact_latest_v1": {},
+            "cmd_lca_snapshot_create_v1": {"p_snapshot_id": str(create_id), "p_scope": "full_library", "p_process_filter": {"issue380Create": True}, "p_created_by": str(uuid.uuid5(namespace, "actor"))},
+        }
+        expected_keys = {
+            "lca_snapshot_active_read_v1": {"snapshot_id", "source_hash", "activated_at"},
+            "lca_snapshot_scope_read_v1": {"id", "scope", "process_filter", "status"},
+            "lca_snapshot_resolve_v1": {"id", "created_at", "process_filter"},
+            "lca_snapshot_artifact_read_v1": {"snapshot_id", "artifact_url", "artifact_format", "process_count", "status", "created_at"},
+            "lca_snapshot_artifact_latest_v1": {"snapshot_id", "artifact_url", "artifact_format", "process_count", "status", "created_at"},
+        }
+        for name, args in rpc_args.items():
+            payload = require_response(client.rest(name, args, key=secret_key), 200)
+            if name == "cmd_lca_snapshot_create_v1":
+                if payload != {"created": True, "snapshotId": str(create_id)}:
+                    raise QualificationError("create RPC DTO mismatch")
+            else:
+                row = _single_row(payload)
+                if set(row) != expected_keys[name] or str(row.get("snapshot_id") or row.get("id")) != str(fixture_id):
+                    raise QualificationError(f"RPC DTO/fixture mismatch: {name}")
+                if "process_count" in row and row["process_count"] != 1:
+                    raise QualificationError(f"RPC process_count mismatch: {name}")
+        require_response(client.rest("cmd_lca_snapshot_create_v1", rpc_args["cmd_lca_snapshot_create_v1"], key=secret_key), 200, {"created": False, "snapshotId": str(create_id)})
+        for name, args in rpc_args.items():
+            status, payload = client.rest(name, args, key=publishable_key)
+            if status not in (401, 403) or not isinstance(payload, dict) or payload.get("code") != "42501":
+                raise QualificationError(f"anonymous RPC boundary mismatch: {name}")
+
+        created = require_response(client.auth("admin/users", method="POST", key=secret_key, body={"email": email, "password": password, "email_confirm": True, "user_metadata": {"issue380_marker": marker}}), 200)
+        user = created.get("user", created) if isinstance(created, dict) else None
+        if not isinstance(user, dict) or not user.get("id"):
+            raise QualificationError("Auth admin create response missing user")
+        user_id = str(user["id"])
+        signed_in = require_response(client.auth("token?grant_type=password", method="POST", key=publishable_key, body={"email": email, "password": password}), 200)
+        if not isinstance(signed_in, dict) or not signed_in.get("access_token"):
+            raise QualificationError("Auth sign-in response missing access token")
+        access_token = str(signed_in["access_token"]); mask(access_token)
+        for name, args in rpc_args.items():
+            status, payload = client.rest(name, args, key=publishable_key, bearer=access_token)
+            if status not in (401, 403) or not isinstance(payload, dict) or payload.get("code") != "42501":
+                raise QualificationError(f"authenticated RPC boundary mismatch: {name}")
+
+        process = _single_row(client.sql("select id::text, btrim(version)::text version from public.processes where state_code between 100 and 199 and btrim(version) <> '' order by id,version limit 1"))
+        process_id, process_version = process["id"], process["version"]
+        snapshot_index = {"version": 1, "snapshot_id": str(fixture_id), "process_count": 1, "impact_count": 1, "process_map": [{"process_id": process_id, "process_version": process_version, "process_index": 0}], "impact_map": [{"impact_id": str(impact_id), "impact_index": 0, "impact_key": "issue380", "impact_name": "Issue 380", "unit": "kg"}]}
+        query_envelope = {"version": 1, "format": "all-unit-query:v1", "snapshot_id": str(fixture_id), "job_id": str(all_unit_job), "process_count": 1, "impact_count": 1, "h_matrix": [[42.5]]}
+        require_response(client.storage_json("bucket", method="POST", body={"id": bucket, "name": bucket, "public": False}), 200)
+        client.upload_json(bucket, f"{run.prefix}/snapshot-index-v1.json", snapshot_index)
+        client.upload_json(bucket, f"{run.prefix}/query.json", query_envelope)
+
+        solve_request = {"version": "lca_solve_v2", "scope": "prod", "snapshot_id": str(fixture_id), "demand_mode": "all_unit", "solve": {"return_x": False, "return_g": False, "return_h": True}, "print_level": 0}
+        contribution_request = {"version": "lca_contribution_path_v1", "scope": "prod", "snapshot_id": str(fixture_id), "data_scope": "open_data", "process_id": process_id, "process_version": process_version, "process_index": 0, "impact_id": str(impact_id), "impact_index": 0, "amount": 1, "options": {"max_depth": 4, "top_k_children": 5, "cutoff_share": 0.01, "max_nodes": 200}, "print_level": 0}
+        client.sql(
+            f"insert into public.lca_jobs(id,job_type,snapshot_id,status,requested_by) values('{solve_job}','solve_all_unit','{fixture_id}','completed','{user_id}'),('{contribution_job}','analyze_contribution_path','{fixture_id}','completed','{user_id}'),('{all_unit_job}','solve_all_unit','{fixture_id}','completed','{user_id}');"
+            f"insert into public.lca_result_cache(scope,snapshot_id,request_key,request_payload,status,job_id) values('prod','{fixture_id}','{canonical_hash(solve_request)}','{json.dumps(solve_request, separators=(',', ':'))}'::jsonb,'pending','{solve_job}'),('prod','{fixture_id}','{canonical_hash(contribution_request)}','{json.dumps(contribution_request, separators=(',', ':'))}'::jsonb,'pending','{contribution_job}');"
+            f"insert into public.lca_results(id,job_id,snapshot_id,payload) values('{result_id}','{all_unit_job}','{fixture_id}','{{}}');"
+            f"insert into public.lca_latest_all_unit_results(snapshot_id,job_id,result_id,query_artifact_url,query_artifact_sha256,query_artifact_byte_size,query_artifact_format,status,computed_at) values('{fixture_id}','{all_unit_job}','{result_id}','https://{DEV_REF}.supabase.co/storage/v1/s3/{bucket}/{run.prefix}/query.json','{'b' * 64}',{len(json.dumps(query_envelope, separators=(',', ':')).encode())},'all-unit-query:v1','ready','2099-08-02T00:00:03Z');"
+        )
+
+        bodies = {
+            "lca_solve": {"snapshot_id": str(fixture_id), "demand_mode": "all_unit"},
+            "lca_query_results": {"snapshot_id": str(fixture_id), "data_scope": "open_data", "mode": "process_all_impacts", "process_id": process_id, "process_version": process_version},
+            "lca_contribution_path": {"snapshot_id": str(fixture_id), "data_scope": "open_data", "process_id": process_id, "process_version": process_version, "impact_id": str(impact_id)},
+        }
+        for name, body in bodies.items():
+            if client.edge(name, method="OPTIONS", body=None, bearer=None)[0] not in (200, 204):
+                raise QualificationError(f"Edge CORS mismatch: {name}")
+            require_response(client.edge(name, method="POST", body=body, bearer=None), 401, {"error": "unauthorized"})
+        for name in ("lca_solve", "lca_contribution_path"):
+            first = require_response(client.edge(name, method="POST", body=bodies[name], bearer=access_token), 200)
+            second = require_response(client.edge(name, method="POST", body=bodies[name], bearer=access_token), 200)
+            if first != second or first.get("mode") != "in_progress" or first.get("snapshot_id") != str(fixture_id) or not first.get("cache_key") or not first.get("job_id"):
+                raise QualificationError(f"Edge success/retry identity mismatch: {name}")
+        for attempt in range(2):
+            query = require_response(client.edge("lca_query_results", method="POST", body=bodies["lca_query_results"], bearer=access_token), 200)
+            if query.get("snapshot_id") != str(fixture_id) or query.get("result_id") != str(result_id) or query.get("mode") != "process_all_impacts" or query.get("data", {}).get("values", [{}])[0].get("value") != 42.5:
+                raise QualificationError(f"Edge query DTO mismatch on attempt {attempt + 1}")
+        bad = dict(bodies["lca_solve"]); bad.update({"demand_mode": "single", "demand": {"process_index": 1, "amount": 1}})
+        require_response(client.edge("lca_solve", method="POST", body=bad, bearer=access_token), 400, {"error": "process_index_out_of_range", "process_index": 1, "process_count": 1})
+    except BaseException as error:
+        primary_error = error
+    finally:
+        finish_with_reconcile(primary_error, client, run)
+
+
+def main() -> int:
+    try:
+        qualify(Config.from_env())
+    except BaseException as error:
+        if isinstance(error, QualificationError):
+            detail = str(error)
+        elif isinstance(error, ExceptionGroup):
+            details = [str(item) for item in error.exceptions if isinstance(item, QualificationError)]
+            detail = "; ".join(details) if details else "aggregate failure"
+        else:
+            detail = type(error).__name__
+        print(f"hosted qualification failed: {detail}", file=sys.stderr)
+        return 1
+    print("persistent Dev hosted qualification passed; residue=0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
@@ -1,0 +1,180 @@
+import unittest
+from pathlib import Path
+
+from supabase.tests.hosted.lca_snapshot_hosted_qualification import (
+    DEV_REF,
+    PRODUCTION_REF,
+    Config,
+    QualificationError,
+    RunNamespace,
+    finish_with_reconcile,
+    reconcile_namespace,
+    require_response,
+    resolve_keys,
+    select_current_keys,
+)
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def config(**overrides):
+    values = {
+        "repository": "tiangong-lca/database-engine",
+        "git_ref": "refs/heads/dev",
+        "project_ref": DEV_REF,
+        "access_token": "masked-token",
+        "publishable_key": None,
+        "secret_key": None,
+    }
+    values.update(overrides)
+    return Config(**values)
+
+
+class TargetingTests(unittest.TestCase):
+    def test_exact_target_is_accepted(self):
+        config().validate()
+
+    def test_production_and_wrong_ref_fail_closed(self):
+        for candidate in (PRODUCTION_REF, "wrong-project"):
+            with self.subTest(candidate=candidate), self.assertRaises(QualificationError):
+                config(project_ref=candidate).validate()
+        with self.assertRaises(QualificationError):
+            config(git_ref="refs/heads/main").validate()
+
+class KeyTests(unittest.TestCase):
+    def test_selects_current_default_modern_keys(self):
+        rows = [
+            {"type": "secret", "name": "old", "api_key": "sb_secret_old", "disabled": True},
+            {"type": "publishable", "name": "default", "api_key": "sb_publishable_current"},
+            {"type": "secret", "name": "default", "api_key": "sb_secret_current"},
+        ]
+        self.assertEqual(select_current_keys(rows), ("sb_publishable_current", "sb_secret_current"))
+
+    def test_rejects_wrong_role_or_legacy_keys(self):
+        with self.assertRaises(QualificationError):
+            select_current_keys([{"type": "legacy", "api_key": "eyJlegacy"}])
+
+    def test_invalid_current_key_semantics_fail_closed(self):
+        with self.assertRaises(QualificationError):
+            require_response((401, {"message": "Invalid API key"}), 200)
+
+    def test_management_first_and_fallback(self):
+        calls = []
+        def management(url, **kwargs):
+            calls.append(url)
+            return 200, [
+                {"type": "publishable", "name": "default", "api_key": "sb_publishable_managed"},
+                {"type": "secret", "name": "default", "api_key": "sb_secret_managed"},
+            ]
+        self.assertEqual(resolve_keys(config(publishable_key="sb_publishable_fallback", secret_key="sb_secret_fallback"), management), ("sb_publishable_managed", "sb_secret_managed"))
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(resolve_keys(config(publishable_key="sb_publishable_fallback", secret_key="sb_secret_fallback"), lambda *a, **k: (503, {})), ("sb_publishable_fallback", "sb_secret_fallback"))
+
+    def test_single_sided_and_role_swapped_fallback_fail(self):
+        with self.assertRaises(QualificationError):
+            resolve_keys(config(publishable_key="sb_publishable_only"), lambda *a, **k: (503, {}))
+        with self.assertRaises(QualificationError):
+            resolve_keys(config(publishable_key="sb_secret_swapped", secret_key="sb_publishable_swapped"), lambda *a, **k: (503, {}))
+
+    def test_management_transport_failure_without_fallback_fails(self):
+        with self.assertRaises(QualificationError):
+            resolve_keys(config(), lambda *a, **k: (401, {"message": "wrong secret"}))
+
+
+class CleanupTests(unittest.TestCase):
+    class FakeClient:
+        secret_key = "sb_secret_test"
+
+        def __init__(self, *, actor=True, worker=True, storage=True, fail_actor=False):
+            self.actor = actor
+            self.worker = worker
+            self.storage = storage
+            self.fail_actor = fail_actor
+            self.sql_calls = []
+            self.storage_calls = []
+            self.auth_calls = []
+
+        def sql(self, query):
+            self.sql_calls.append(query)
+            if query.startswith("select id::text from auth.users"):
+                if self.fail_actor:
+                    raise RuntimeError("lost recovery transport")
+                return [{"id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}] if self.actor else []
+            if query.startswith("select id::text from public.worker_jobs"):
+                return [{"id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"}] if self.worker else []
+            if query.startswith("select name from storage.objects"):
+                return [{"name": "runs/marker/query.json"}] if self.storage else []
+            if query.startswith("select id from storage.buckets"):
+                return [{"id": "bucket"}] if self.storage else []
+            if query.startswith("select (select count"):
+                return [{
+                    "network": 0, "artifact": 0, "active": 0, "result_cache": 0,
+                    "worker_jobs": 0, "lca_jobs": 0, "lca_results": 0,
+                    "latest_results": 0, "storage_objects": 0, "storage_buckets": 0,
+                    "users": 0, "sessions": 0,
+                }]
+            return []
+
+        def storage_json(self, path, *, method, body=None):
+            self.storage_calls.append((path, method, body))
+            return 404, {"message": "already absent"}
+
+        def auth(self, path, *, method, key, body=None, bearer=None):
+            self.auth_calls.append((path, method))
+            return 404, {"message": "already absent"}
+
+    def setUp(self):
+        self.run = RunNamespace(
+            marker="marker", fixture_id=__import__("uuid").UUID("11111111-1111-4111-8111-111111111111"),
+            create_id=__import__("uuid").UUID("22222222-2222-4222-8222-222222222222"),
+            email="issue380-marker@example.invalid", bucket="issue380-marker", prefix="runs/marker",
+        )
+
+    def test_lost_create_response_recovers_actor_and_revokes_it(self):
+        client = self.FakeClient(worker=False, storage=False)
+        reconcile_namespace(client, self.run)
+        self.assertTrue(any("delete from auth.sessions" in query for query in client.sql_calls))
+        self.assertEqual(client.auth_calls, [("admin/users/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "DELETE")])
+
+    def test_random_worker_id_is_discovered_cancelled_and_deleted(self):
+        client = self.FakeClient(actor=False, storage=False)
+        reconcile_namespace(client, self.run)
+        worker_sql = "\n".join(client.sql_calls)
+        self.assertIn("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", worker_sql)
+        self.assertIn("status='cancelled'", worker_sql)
+        self.assertIn("delete from public.worker_jobs", worker_sql)
+        self.assertIn("subject_version", worker_sql)
+
+    def test_storage_cleanup_is_unconditional_and_404_idempotent(self):
+        client = self.FakeClient(actor=False, worker=False, storage=True)
+        reconcile_namespace(client, self.run)
+        self.assertEqual(client.storage_calls[0][0], "object/issue380-marker")
+        self.assertEqual(client.storage_calls[0][2], {"prefixes": ["runs/marker/query.json"]})
+        self.assertEqual(client.storage_calls[1][0], "bucket/issue380-marker")
+
+    def test_primary_and_recovery_errors_are_aggregated(self):
+        client = self.FakeClient(actor=False, worker=False, storage=False, fail_actor=True)
+        with self.assertRaises(ExceptionGroup) as raised:
+            finish_with_reconcile(QualificationError("primary"), client, self.run)
+        messages = [str(error) for error in raised.exception.exceptions]
+        self.assertTrue(any("primary" in message for message in messages))
+        self.assertTrue(any("discover-auth-actors" in message for message in messages))
+
+
+class WorkflowSecurityTests(unittest.TestCase):
+    def test_workflow_is_dev_only_and_has_no_arbitrary_selector(self):
+        text = (ROOT / ".github/workflows/lca-snapshot-hosted-qualification.yml").read_text()
+        self.assertIn("github.ref }}\" != 'refs/heads/dev'", text)
+        self.assertIn("permissions:\n  contents: read", text)
+        self.assertNotIn("repository:", text)
+        self.assertNotIn("script:", text)
+        self.assertNotIn("ref:", text)
+        self.assertIn("actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803", text)
+        self.assertIn("actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1", text)
+        self.assertEqual(text.count("secrets.SUPABASE_ACCESS_TOKEN"), 1)
+        self.assertLess(text.index("Run fail-closed hosted qualification"), text.index("secrets.SUPABASE_ACCESS_TOKEN"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/supabase/tests/manifest.json
+++ b/supabase/tests/manifest.json
@@ -7,6 +7,7 @@
     {"name": "preview", "glob": "supabase/tests/preview/*"},
     {"name": "benchmark", "glob": "supabase/tests/benchmarks/*"},
     {"name": "fixture", "glob": "supabase/tests/fixtures/*"}
+    ,{"name": "hosted-python", "glob": "supabase/tests/hosted/*.py"}
     ,{"name": "runner-contract", "glob": "supabase/tests/manifest.json"}
     ,{"name": "catalog-contract", "glob": "supabase/tests/contracts/*"}
   ],


### PR DESCRIPTION
Closes #380

## Goal

Add a trusted, persistent-Dev-only qualification for the Issue #376 LCA snapshot facade and its real Edge consumers, without exposing production or allowing caller-controlled repository, ref, script, project, or endpoint selection.

## Implementation

- Adds a manually dispatched canonical `dev` workflow with minimum `contents: read` permission, immutable action pins, and secrets/variables scoped only to the final trusted probe step.
- Binds the checked-out database contract through exact ancestry, migration path, Git blob, file SHA-256, and migration-head checks.
- Compares the five deployed Edge functions against the reviewed deployment-time receipt (`id`, `version`, `updated_at`, and `ezbr_sha256`). This is explicit source-worktree/deployment metadata evidence, not a standalone cryptographic commit-to-bundle claim.
- Exercises all six service-role RPC facades with exact fixture/DTO assertions, idempotent create replay, and anon/authenticated denial.
- Exercises real authenticated `lca_solve`, `lca_query_results`, and `lca_contribution_path` success/retry paths, including exact process-count and numeric query-result evidence.
- Uses one stop-loss run namespace across Auth, snapshot IDs, cache/Worker identity, and Storage bucket/prefix. The same unconditional reconciler runs before setup and in `finally`, discovers actual remote resources, cancels matching Worker jobs, deletes in FK order, tolerates already-absent Auth/Storage resources, and aggregates cleanup/readback failures with the primary failure.
- Selects an exact published process version in state-code range 100–199.
- Uses Management API key reveal first; if unavailable, requires both project-specific repository secrets `SUPABASE_DEV_PUBLISHABLE_KEY` and `SUPABASE_DEV_SECRET_KEY` as the paired fallback.

## Validation

- Hosted runner focused tests: 13/13 passed
- Canonical local contract: 67 files / 2,138 pgTAP assertions passed
- Worker and Identity Data API checks passed
- Identity concurrency: 8 sessions / 800 parity calls passed
- Database lint, export, schema-boundary, inventory, and security audits passed
- Docpact strict validation: 10 rules passed
- Docpact staged enforcement: 9 changed paths / 11 matched rules; coverage and freshness passed
- Independent final review: GO, P0=0 / P1=0 / P2=0

## Post-merge hosted gate and safety

The hosted qualification has not yet been executed, and production was not touched. The workflow intentionally hard-guards `refs/heads/dev`, so the hosted run is an immediate post-merge gate after CI/review and merge to `dev`; this PR delivers the trusted runner, and the merge alone does not complete E4 or the parent Goal. If that post-merge hosted run fails, #380 must remain open or be reopened and move back to In Progress for repair, and Edge #257 must not merge. This PR does not deploy migrations.