### PR TITLE
fix: bootstrap hosted qualification on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "2e7b3ba2a3fcdcbc59cb26416512808465262049"
-lastReviewedNote: "Reviewed for Issue #376 after Issue #323 integration and fresh-stack CI repair: existing routing covers the three-table Expand, inherited Issue #323 SECURITY DEFINER registration/search-path hardening, physical-catalog assertions after the schema move, regenerated catalog/audit/hash evidence, populated qualification, canonical manifest evidence, and credential-free runner examples without changing governance rules."
+lastReviewedCommit: "2ff09eaec4381354af04f4ba333bf25f02a361e8"
+lastReviewedNote: "Reviewed for the Issue #380 hosted-trigger repair: existing hosted-proof routing covers the path-scoped canonical-dev push bootstrap, its offline trigger contract, and the required validation/architecture/branch documentation without changing ownership or schema routing."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/lca-snapshot-hosted-qualification.yml
+++ b/.github/workflows/lca-snapshot-hosted-qualification.yml
@@ -2,6 +2,12 @@ name: Persistent Dev LCA Snapshot Hosted Qualification
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - dev
+    paths:
+      - .github/workflows/lca-snapshot-hosted-qualification.yml
+      - supabase/tests/hosted/lca_snapshot_hosted_qualification.py
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 86ba7ee2c33e45df8008117a2dec3ee4deedc32c
-lastReviewedNote: "Reviewed for Issue #380: the trusted persistent-Dev consumer qualification remains database-owned proof automation, uses canonical dev and repository secrets as its current boundary, and does not change schema or production ownership."
+lastReviewedCommit: 2ff09eaec4381354af04f4ba333bf25f02a361e8
+lastReviewedNote: "Reviewed for the Issue #380 hosted-trigger repair: the path-scoped canonical-dev push bootstrap remains database-owned proof automation, preserves the trusted secret boundary, and does not change schema or production ownership."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -59,7 +59,7 @@ This repo is organized around one checked-in Supabase project plus a generated s
 | `scripts/**` | export, refresh, change-copy, and migration-generation helpers |
 | `.github/workflows/supabase-dev.yml` | serialized automation for pushing committed migrations to persistent remote `dev`, then reconciling and readback-verifying only the reviewed PostgREST fields |
 | `.github/workflows/database-validation.yml` | PR fresh-stack reset, manifest-owned canonical database contract, and freeze-activated focused validation before merge |
-| `.github/workflows/lca-snapshot-hosted-qualification.yml` | manual, canonical-`dev`-only trusted probe for the fixed persistent Dev LCA snapshot/Edge contract; it never checks out consumer code or accepts repository/ref/script/project selectors |
+| `.github/workflows/lca-snapshot-hosted-qualification.yml` | canonical-`dev`-only trusted probe for the fixed persistent Dev LCA snapshot/Edge contract, triggered manually or by a path-scoped trusted-runner/workflow push; it never checks out consumer code or accepts repository/ref/script/project selectors |
 | `supabase/workspace/changes/**` | manual overlay area used when generating migrations from workspace files |
 | `supabase/workspace/remote_schema.sql` | generated full raw dump from the remote database |
 | `supabase/workspace/global/**` | generated split-out global objects rebuilt on workspace refresh |

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -63,7 +63,11 @@ supabase migration list
 
 `.github/workflows/lca-snapshot-hosted-qualification.yml` is the narrow hosted
 proof path for database-engine Issue #380. It can run only by manual dispatch
-from the canonical repository's `dev` branch. It checks the fixed persistent
+from the canonical repository's `dev` branch or by a canonical `dev` push that
+changes only the workflow definition or its trusted runner. The scoped push
+trigger bootstraps and continuously requalifies the runner even while the
+workflow is absent from GitHub's default-branch workflow registry. Static
+concurrency prevents overlapping hosted runs. It checks the fixed persistent
 Dev project, migration head, database contract SHA, and deployed Edge evidence
 before using only this repository's trusted probe. The workflow proves that the
 fixed contract commit is an ancestor of the checked-out `dev` commit and binds

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -134,8 +134,9 @@ Repository configuration expected by `.github/workflows/supabase-dev.yml`:
 - secret `SUPABASE_ACCESS_TOKEN`
 - secret `SUPABASE_DEV_DB_PASSWORD`
 
-The manual Issue #380 hosted consumer qualification additionally uses the same
-repository variable and access token, but never deploys migrations. It resolves
+The Issue #380 hosted consumer qualification runs by manual dispatch or by a
+path-scoped push to canonical `dev` that changes its workflow/trusted runner.
+It additionally uses the same repository variable and access token, but never deploys migrations. It resolves
 current modern API keys through the Management API. If the access token lacks
 key-reveal permission, configure both project-specific repository secrets
 `SUPABASE_DEV_PUBLISHABLE_KEY` and `SUPABASE_DEV_SECRET_KEY`; absence or an

--- a/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
@@ -165,6 +165,12 @@ class CleanupTests(unittest.TestCase):
 class WorkflowSecurityTests(unittest.TestCase):
     def test_workflow_is_dev_only_and_has_no_arbitrary_selector(self):
         text = (ROOT / ".github/workflows/lca-snapshot-hosted-qualification.yml").read_text()
+        trigger = text.split("permissions:", 1)[0]
+        self.assertIn("  workflow_dispatch:\n", trigger)
+        self.assertIn("  push:\n    branches:\n      - dev\n", trigger)
+        self.assertIn("      - .github/workflows/lca-snapshot-hosted-qualification.yml\n", trigger)
+        self.assertIn("      - supabase/tests/hosted/lca_snapshot_hosted_qualification.py\n", trigger)
+        self.assertEqual(trigger.count("      - "), 3)
         self.assertIn("github.ref }}\" != 'refs/heads/dev'", text)
         self.assertIn("permissions:\n  contents: read", text)
         self.assertNotIn("repository:", text)


### PR DESCRIPTION
Closes #380

## Problem

After PR #381 merged to canonical `dev`, GitHub rejected the immediate manual dispatch with:

`HTTP 404: workflow lca-snapshot-hosted-qualification.yml not found on the default branch`

The repository default branch is `main`, where the new workflow is not registered. The trusted runner exists only on `dev`, so `workflow_dispatch` alone cannot bootstrap its first run.

## Minimal platform fix

- Preserve `workflow_dispatch`.
- Add a `push` trigger restricted to canonical branch `dev`.
- Restrict push paths to exactly:
  - `.github/workflows/lca-snapshot-hosted-qualification.yml`
  - `supabase/tests/hosted/lca_snapshot_hosted_qualification.py`
- Preserve the static concurrency group and `cancel-in-progress: false` so hosted runs cannot overlap.
- Add offline assertions for the exact trigger shape.
- Update only affected validation/architecture/branch guidance and Docpact review metadata.

The hosted runner business logic and migrations are unchanged. Merging this PR to `dev` changes the workflow path and therefore bootstraps the hosted run through the scoped push event. It does not promote the workflow to `main`.

## Validation

- Workflow YAML parsed with exact `workflow_dispatch`, `push.branches=[dev]`, and the two reviewed paths
- Hosted focused tests: 13/13 passed
- Manifest classification passed
- Docpact strict validation: 10 rules passed
- Docpact staged enforcement: 7 paths / 8 matched rules; coverage and freshness passed
- Push preflight Docpact gate passed

## Safety

No hosted run was manually forced, no credentials were probed, and production was not touched. After CI/review, merge to `dev` is expected to create the first hosted qualification run; #380 remains incomplete until that run passes.