### PR TITLE
test: use canonical Worker fixtures for hosted qualification

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "2ff09eaec4381354af04f4ba333bf25f02a361e8"
-lastReviewedNote: "Reviewed for the Issue #380 hosted-trigger repair: existing hosted-proof routing covers the path-scoped canonical-dev push bootstrap, its offline trigger contract, and the required validation/architecture/branch documentation without changing ownership or schema routing."
+lastReviewedCommit: "c63f42aaa396792292c5a99f938331ece291cc4b"
+lastReviewedNote: "Reviewed for the Issue #380 canonical Worker fixture repair: existing hosted-proof routing covers the private Worker fixture, retired-relation regression, and dependency-ordered cleanup without changing ownership or schema routing."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 2ff09eaec4381354af04f4ba333bf25f02a361e8
-lastReviewedNote: "Reviewed for the Issue #380 hosted-trigger repair: the path-scoped canonical-dev push bootstrap remains database-owned proof automation, preserves the trusted secret boundary, and does not change schema or production ownership."
+lastReviewedCommit: c63f42aaa396792292c5a99f938331ece291cc4b
+lastReviewedNote: "Reviewed for the Issue #380 canonical Worker fixture repair: hosted proof removes the retired lca_jobs assumption, uses the physical private Worker contract, and does not change schema or production ownership."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
 lastReviewedCommit: 86ba7ee2c33e45df8008117a2dec3ee4deedc32c
-lastReviewedNote: "Reviewed for Issue #380: add the trusted persistent-Dev hosted qualification path without changing schema-source or generated-workspace boundaries."
+lastReviewedNote: "Reviewed for the Issue #380 canonical Worker fixture repair: hosted proof uses the private Worker source and no retired legacy-job relation without changing schema-source or generated-workspace boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -96,7 +96,10 @@ setup and in `finally`; it discovers actual remote state, cancels matching Worke
 jobs before dependency-ordered deletion, tolerates already-absent Storage/Auth
 resources, and aggregates every cleanup/readback error with the primary failure.
 It therefore does not depend on receiving successful create or enqueue
-responses. Preview, mock, or consumer-repo test output does not replace this
+responses. Hosted result fixtures use only canonical physical
+`private.worker_jobs` rows and bind `worker_job_id` across caches/results; the
+retired `lca_jobs` relation is not a valid fixture or cleanup dependency.
+Preview, mock, or consumer-repo test output does not replace this
 persistent Dev proof.
 
 The checked-in canonical entry point is:

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -21,9 +21,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-08-01
-lastReviewedCommit: d46daabe68ac3eaccbc889cf9cc35a746fc10d88
-lastReviewedNote: "Reviewed Issue #346: persistent dev explicitly serializes migration and allowlisted PostgREST config while production remains Supabase-integration owned."
+lastReviewedAt: 2026-08-02
+lastReviewedCommit: c63f42aaa396792292c5a99f938331ece291cc4b
+lastReviewedNote: "Reviewed for the Issue #380 canonical Worker fixture repair: hosted cleanup follows current private Worker ownership while persistent-dev and production branch bindings remain unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
@@ -340,7 +340,7 @@ def reconcile_namespace(client: HostedClient, run: RunNamespace) -> None:
     worker_rows = attempt(
         "discover-worker-jobs",
         lambda: _rows(
-            client.sql(f"select id::text from public.worker_jobs where {worker_predicate} order by id"),
+            client.sql(f"select id::text from private.worker_jobs where {worker_predicate} order by id"),
             "Worker discovery",
         ),
     )
@@ -350,7 +350,7 @@ def reconcile_namespace(client: HostedClient, run: RunNamespace) -> None:
         attempt(
             "cancel-worker-jobs",
             lambda: client.sql(
-                f"update public.worker_jobs set status='cancelled', finished_at=coalesce(finished_at,now()), "
+                f"update private.worker_jobs set status='cancelled', finished_at=coalesce(finished_at,now()), "
                 f"cancelled_at=coalesce(cancelled_at,now()), leased_by=null, lease_token=null, lease_expires_at=null, "
                 f"updated_at=now() where id in ({ids}) and status not in ('completed','failed','cancelled')"
             ),
@@ -362,7 +362,6 @@ def reconcile_namespace(client: HostedClient, run: RunNamespace) -> None:
         ("delete-result-cache", f"delete from public.lca_result_cache where snapshot_id in ({fixture},{create})"),
         ("delete-latest-results", f"delete from public.lca_latest_all_unit_results where snapshot_id in ({fixture},{create})"),
         ("delete-results", f"delete from public.lca_results where snapshot_id in ({fixture},{create})"),
-        ("delete-lca-jobs", f"delete from public.lca_jobs where snapshot_id in ({fixture},{create})"),
     ):
         attempt(label, lambda query=query: client.sql(query))
     if worker_ids:
@@ -370,10 +369,10 @@ def reconcile_namespace(client: HostedClient, run: RunNamespace) -> None:
         attempt(
             "detach-worker-job-lineage",
             lambda: client.sql(
-                f"update public.worker_jobs set root_job_id=null,parent_job_id=null where id in ({ids})"
+                f"update private.worker_jobs set root_job_id=null,parent_job_id=null where id in ({ids})"
             ),
         )
-        attempt("delete-worker-jobs", lambda: client.sql(f"delete from public.worker_jobs where id in ({ids})"))
+        attempt("delete-worker-jobs", lambda: client.sql(f"delete from private.worker_jobs where id in ({ids})"))
     for label, query in (
         ("delete-active", f"delete from private.lca_active_snapshots where snapshot_id in ({fixture},{create})"),
         ("delete-artifacts", f"delete from private.lca_snapshot_artifacts where snapshot_id in ({fixture},{create})"),
@@ -437,8 +436,7 @@ def reconcile_namespace(client: HostedClient, run: RunNamespace) -> None:
                 f"(select count(*)::int from private.lca_snapshot_artifacts where snapshot_id in ({fixture},{create})) artifact,"
                 f"(select count(*)::int from private.lca_active_snapshots where snapshot_id in ({fixture},{create})) active,"
                 f"(select count(*)::int from public.lca_result_cache where snapshot_id in ({fixture},{create})) result_cache,"
-                f"(select count(*)::int from public.worker_jobs where {worker_predicate}) worker_jobs,"
-                f"(select count(*)::int from public.lca_jobs where snapshot_id in ({fixture},{create})) lca_jobs,"
+                f"(select count(*)::int from private.worker_jobs where {worker_predicate}) worker_jobs,"
                 f"(select count(*)::int from public.lca_results where snapshot_id in ({fixture},{create})) lca_results,"
                 f"(select count(*)::int from public.lca_latest_all_unit_results where snapshot_id in ({fixture},{create})) latest_results,"
                 f"(select count(*)::int from storage.objects where bucket_id={sql_literal(run.bucket)}) storage_objects,"
@@ -466,6 +464,35 @@ def finish_with_reconcile(primary_error: BaseException | None, client: HostedCli
         raise ExceptionGroup("hosted qualification or namespace reconciliation failed", errors)
 
 
+def canonical_worker_fixture_sql(
+    snapshot_id: uuid.UUID,
+    requested_by: str,
+    marker: str,
+    jobs: list[tuple[uuid.UUID, str, str, dict[str, Any]]],
+) -> str:
+    rows: list[str] = []
+    for job_id, job_kind, payload_schema_version, payload in jobs:
+        payload_json = json.dumps(payload, separators=(",", ":"))
+        rows.append(
+            "("
+            f"'{job_id}',{sql_literal(job_kind)},'calculator','solver',0,{sql_literal(str(snapshot_id))},"
+            f"'lca_job','{job_id}','{snapshot_id}','user','{requested_by}',"
+            f"{sql_literal(marker + ':' + str(job_id))},{sql_literal(canonical_hash(payload))},"
+            f"'completed','user',1,3,{sql_literal(payload_schema_version)},{sql_literal(payload_json)}::jsonb,"
+            "'{}'::jsonb,now(),now(),now(),now()"
+            ")"
+        )
+    return (
+        "insert into private.worker_jobs("
+        "id,job_kind,worker_runtime,worker_queue,priority,queue_key,subject_type,subject_id,"
+        "subject_version,requester_type,requested_by,idempotency_key,request_hash,status,visibility,"
+        "attempt_count,max_attempts,payload_schema_version,payload_json,diagnostics,created_at,updated_at,"
+        "started_at,finished_at) values "
+        + ",".join(rows)
+        + ";"
+    )
+
+
 def qualify(config: Config) -> None:
     config.validate()
     publishable_key, secret_key = resolve_keys(config)
@@ -475,6 +502,8 @@ def qualify(config: Config) -> None:
     fixture_id, create_id = run.fixture_id, run.create_id
     artifact_id, impact_id = uuid.uuid5(namespace, "artifact"), uuid.uuid5(namespace, "impact")
     solve_job, contribution_job, all_unit_job = (uuid.uuid5(namespace, name) for name in ("solve-job", "contribution-job", "all-unit-job"))
+    solve_result_id = uuid.uuid5(namespace, "solve-result")
+    contribution_result_id = uuid.uuid5(namespace, "contribution-result")
     result_id = uuid.uuid5(namespace, "all-unit-result")
     bucket, email, marker = run.bucket, run.email, run.marker
     password = f"Issue380-{secrets.token_urlsafe(24)}-Aa1!"
@@ -570,10 +599,19 @@ def qualify(config: Config) -> None:
         solve_request = {"version": "lca_solve_v2", "scope": "prod", "snapshot_id": str(fixture_id), "demand_mode": "all_unit", "solve": {"return_x": False, "return_g": False, "return_h": True}, "print_level": 0}
         contribution_request = {"version": "lca_contribution_path_v1", "scope": "prod", "snapshot_id": str(fixture_id), "data_scope": "open_data", "process_id": process_id, "process_version": process_version, "process_index": 0, "impact_id": str(impact_id), "impact_index": 0, "amount": 1, "options": {"max_depth": 4, "top_k_children": 5, "cutoff_share": 0.01, "max_nodes": 200}, "print_level": 0}
         client.sql(
-            f"insert into public.lca_jobs(id,job_type,snapshot_id,status,requested_by) values('{solve_job}','solve_all_unit','{fixture_id}','completed','{user_id}'),('{contribution_job}','analyze_contribution_path','{fixture_id}','completed','{user_id}'),('{all_unit_job}','solve_all_unit','{fixture_id}','completed','{user_id}');"
-            f"insert into public.lca_result_cache(scope,snapshot_id,request_key,request_payload,status,job_id) values('prod','{fixture_id}','{canonical_hash(solve_request)}','{json.dumps(solve_request, separators=(',', ':'))}'::jsonb,'pending','{solve_job}'),('prod','{fixture_id}','{canonical_hash(contribution_request)}','{json.dumps(contribution_request, separators=(',', ':'))}'::jsonb,'pending','{contribution_job}');"
-            f"insert into public.lca_results(id,job_id,snapshot_id,payload) values('{result_id}','{all_unit_job}','{fixture_id}','{{}}');"
-            f"insert into public.lca_latest_all_unit_results(snapshot_id,job_id,result_id,query_artifact_url,query_artifact_sha256,query_artifact_byte_size,query_artifact_format,status,computed_at) values('{fixture_id}','{all_unit_job}','{result_id}','https://{DEV_REF}.supabase.co/storage/v1/s3/{bucket}/{run.prefix}/query.json','{'b' * 64}',{len(json.dumps(query_envelope, separators=(',', ':')).encode())},'all-unit-query:v1','ready','2099-08-02T00:00:03Z');"
+            canonical_worker_fixture_sql(
+                fixture_id,
+                user_id,
+                marker,
+                [
+                    (solve_job, "lca.solve_all_unit", "lca.solve_all_unit.request.v1", {"type": "solve_all_unit", "snapshot_id": str(fixture_id), "namespace": marker}),
+                    (contribution_job, "lca.contribution_path", "lca.contribution_path.request.v1", {"type": "analyze_contribution_path", "snapshot_id": str(fixture_id), "namespace": marker}),
+                    (all_unit_job, "lca.solve_all_unit", "lca.solve_all_unit.request.v1", {"type": "solve_all_unit", "snapshot_id": str(fixture_id), "namespace": marker, "artifact": "query"}),
+                ],
+            )
+            + f"insert into public.lca_results(id,job_id,worker_job_id,snapshot_id,payload) values('{solve_result_id}','{solve_job}','{solve_job}','{fixture_id}','{{}}'),('{contribution_result_id}','{contribution_job}','{contribution_job}','{fixture_id}','{{}}'),('{result_id}','{all_unit_job}','{all_unit_job}','{fixture_id}','{{}}');"
+            f"insert into public.lca_result_cache(scope,snapshot_id,request_key,request_payload,status,job_id,worker_job_id,result_id) values('prod','{fixture_id}','{canonical_hash(solve_request)}','{json.dumps(solve_request, separators=(',', ':'))}'::jsonb,'ready','{solve_job}','{solve_job}','{solve_result_id}'),('prod','{fixture_id}','{canonical_hash(contribution_request)}','{json.dumps(contribution_request, separators=(',', ':'))}'::jsonb,'ready','{contribution_job}','{contribution_job}','{contribution_result_id}');"
+            f"insert into public.lca_latest_all_unit_results(snapshot_id,job_id,worker_job_id,result_id,query_artifact_url,query_artifact_sha256,query_artifact_byte_size,query_artifact_format,status,computed_at) values('{fixture_id}','{all_unit_job}','{all_unit_job}','{result_id}','https://{DEV_REF}.supabase.co/storage/v1/s3/{bucket}/{run.prefix}/query.json','{'b' * 64}',{len(json.dumps(query_envelope, separators=(',', ':')).encode())},'all-unit-query:v1','ready','2099-08-02T00:00:03Z');"
         )
 
         bodies = {
@@ -585,10 +623,14 @@ def qualify(config: Config) -> None:
             if client.edge(name, method="OPTIONS", body=None, bearer=None)[0] not in (200, 204):
                 raise QualificationError(f"Edge CORS mismatch: {name}")
             require_response(client.edge(name, method="POST", body=body, bearer=None), 401, {"error": "unauthorized"})
-        for name in ("lca_solve", "lca_contribution_path"):
+        expected_endpoint_results = {
+            "lca_solve": str(solve_result_id),
+            "lca_contribution_path": str(contribution_result_id),
+        }
+        for name, expected_result_id in expected_endpoint_results.items():
             first = require_response(client.edge(name, method="POST", body=bodies[name], bearer=access_token), 200)
             second = require_response(client.edge(name, method="POST", body=bodies[name], bearer=access_token), 200)
-            if first != second or first.get("mode") != "in_progress" or first.get("snapshot_id") != str(fixture_id) or not first.get("cache_key") or not first.get("job_id"):
+            if first != second or first.get("mode") != "cache_hit" or first.get("snapshot_id") != str(fixture_id) or not first.get("cache_key") or first.get("result_id") != expected_result_id:
                 raise QualificationError(f"Edge success/retry identity mismatch: {name}")
         for attempt in range(2):
             query = require_response(client.edge("lca_query_results", method="POST", body=bodies["lca_query_results"], bearer=access_token), 200)

--- a/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
@@ -7,6 +7,7 @@ from supabase.tests.hosted.lca_snapshot_hosted_qualification import (
     Config,
     QualificationError,
     RunNamespace,
+    canonical_worker_fixture_sql,
     finish_with_reconcile,
     reconcile_namespace,
     require_response,
@@ -101,7 +102,7 @@ class CleanupTests(unittest.TestCase):
                 if self.fail_actor:
                     raise RuntimeError("lost recovery transport")
                 return [{"id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}] if self.actor else []
-            if query.startswith("select id::text from public.worker_jobs"):
+            if query.startswith("select id::text from private.worker_jobs"):
                 return [{"id": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"}] if self.worker else []
             if query.startswith("select name from storage.objects"):
                 return [{"name": "runs/marker/query.json"}] if self.storage else []
@@ -110,7 +111,7 @@ class CleanupTests(unittest.TestCase):
             if query.startswith("select (select count"):
                 return [{
                     "network": 0, "artifact": 0, "active": 0, "result_cache": 0,
-                    "worker_jobs": 0, "lca_jobs": 0, "lca_results": 0,
+                    "worker_jobs": 0, "lca_results": 0,
                     "latest_results": 0, "storage_objects": 0, "storage_buckets": 0,
                     "users": 0, "sessions": 0,
                 }]
@@ -143,8 +144,32 @@ class CleanupTests(unittest.TestCase):
         worker_sql = "\n".join(client.sql_calls)
         self.assertIn("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", worker_sql)
         self.assertIn("status='cancelled'", worker_sql)
-        self.assertIn("delete from public.worker_jobs", worker_sql)
+        self.assertIn("delete from private.worker_jobs", worker_sql)
         self.assertIn("subject_version", worker_sql)
+
+    def test_canonical_worker_fixture_has_no_retired_legacy_dependency(self):
+        import uuid
+
+        runner = (ROOT / "supabase/tests/hosted/lca_snapshot_hosted_qualification.py").read_text()
+        self.assertNotIn("public.lca_jobs", runner)
+        snapshot_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+        actor_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        sql = canonical_worker_fixture_sql(
+            snapshot_id,
+            actor_id,
+            "marker",
+            [
+                (uuid.UUID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"), "lca.solve_all_unit", "lca.solve_all_unit.request.v1", {"snapshot_id": str(snapshot_id)}),
+                (uuid.UUID("cccccccc-cccc-4ccc-8ccc-cccccccccccc"), "lca.contribution_path", "lca.contribution_path.request.v1", {"snapshot_id": str(snapshot_id)}),
+            ],
+        )
+        self.assertIn("insert into private.worker_jobs", sql)
+        for column in ("worker_runtime", "worker_queue", "requester_type", "requested_by", "subject_version", "payload_json", "attempt_count", "visibility", "diagnostics"):
+            self.assertIn(column, sql)
+        self.assertIn("'lca.solve_all_unit'", sql)
+        self.assertIn("'lca.contribution_path'", sql)
+        self.assertIn("'calculator','solver'", sql)
+        self.assertNotIn("lca_jobs", sql)
 
     def test_storage_cleanup_is_unconditional_and_404_idempotent(self):
         client = self.FakeClient(actor=False, worker=False, storage=True)


### PR DESCRIPTION
Closes #380

## 摘要

修复 persistent Dev hosted qualification 对已退役 `public.lca_jobs` 的错误依赖。fixture、清理和零残留 readback 改用物理 `private.worker_jobs`，并通过 `worker_job_id` 绑定 LCA result/cache/latest 投影。

## 关键约束

- 仅固定 canonical `dev` / persistent Dev 项目，未放宽 production guard 或凭据边界。
- 三类 completed Worker fixture 使用现行 job kind、payload schema、CHECK/FK。
- solve/contribution 走 ready cache，验证两次真实 Edge 响应均为相同 `cache_hit` 与 exact `result_id`。
- cleanup 按 cache → latest → results → worker → snapshot 执行并 fail-closed。

## 验证

- focused unittest：14/14
- 真实本地 PG `BEGIN/ROLLBACK`：canonical workers 及完整 result/cache/latest fixture 约束通过、零残留
- canonical-local：67 files / 2,138 pgTAP assertions
- Worker/Identity Data API、8 sessions / 800 parity、lint/export/schema/inventory/security audits 通过
- Docpact strict 与 staged enforce 通过
- 独立复审：GO，P0=0，P1=0，P2=1（非阻断：后续可将 cache_key 加强为 exact canonical hash）

## 风险与回滚

合并到 `dev` 会触发 trusted hosted qualification。若真实 hosted run 失败，Issue #380 将保持/恢复打开并按失败证据继续修复；不会触碰 production。