### PR TITLE
test: report hosted qualification phase failures safely

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "c63f42aaa396792292c5a99f938331ece291cc4b"
-lastReviewedNote: "Reviewed for the Issue #380 canonical Worker fixture repair: existing hosted-proof routing covers the private Worker fixture, retired-relation regression, and dependency-ordered cleanup without changing ownership or schema routing."
+lastReviewedCommit: "0e4000b68abe97f11bf10f0ff972e8a453af643b"
+lastReviewedNote: "Reviewed for the Issue #380 hosted phase diagnostics: existing hosted-proof routing covers secret-safe phase/type reporting and nested cleanup failures without changing ownership, targeting, or schema routing."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: c63f42aaa396792292c5a99f938331ece291cc4b
-lastReviewedNote: "Reviewed for the Issue #380 canonical Worker fixture repair: hosted proof removes the retired lca_jobs assumption, uses the physical private Worker contract, and does not change schema or production ownership."
+lastReviewedCommit: 0e4000b68abe97f11bf10f0ff972e8a453af643b
+lastReviewedNote: "Reviewed for the Issue #380 hosted phase diagnostics: secret-safe phase/type reporting preserves trusted targeting, cleanup, and production ownership without exposing response or exception values."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 86ba7ee2c33e45df8008117a2dec3ee4deedc32c
-lastReviewedNote: "Reviewed for the Issue #380 canonical Worker fixture repair: hosted proof uses the private Worker source and no retired legacy-job relation without changing schema-source or generated-workspace boundaries."
+lastReviewedCommit: 0e4000b68abe97f11bf10f0ff972e8a453af643b
+lastReviewedNote: "Reviewed for the Issue #380 hosted phase diagnostics: diagnostic-only error classification does not change schema sources, generated workspaces, or repository ownership boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 2e7b3ba2a3fcdcbc59cb26416512808465262049
-lastReviewedNote: "Reviewed for Issue #376 after Issue #323 integration and fresh-stack CI repair: blank/populated upgrades, OID/full-row parity, compatibility/API behavior, physical-catalog/global-inventory assertions, receipt-bound SECURITY DEFINER lineage and PostgREST evidence, regenerated catalog/audit hashes, failure/retry/rollback, canonical manifest evidence, secret scanning, the complete canonical pgTAP suite, lint, and hosted Preview remain the required layers."
+lastReviewedCommit: 0e4000b68abe97f11bf10f0ff972e8a453af643b
+lastReviewedNote: "Reviewed for Issue #380 hosted phase diagnostics: fixed phase/type labels and recursive nested-error reporting remain secret-safe while preserving the canonical hosted cleanup and fail-closed validation contract."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: c63f42aaa396792292c5a99f938331ece291cc4b
-lastReviewedNote: "Reviewed for the Issue #380 canonical Worker fixture repair: hosted cleanup follows current private Worker ownership while persistent-dev and production branch bindings remain unchanged."
+lastReviewedCommit: 0e4000b68abe97f11bf10f0ff972e8a453af643b
+lastReviewedNote: "Reviewed for the Issue #380 hosted phase diagnostics: diagnostic-only reporting preserves canonical dev targeting, serialized persistent-dev execution, and the unchanged production boundary."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
@@ -493,6 +493,18 @@ def canonical_worker_fixture_sql(
     )
 
 
+def unexpected_phase_error(phase: str, error: BaseException) -> QualificationError:
+    return QualificationError(f"hosted phase failed: {phase}: {type(error).__name__}")
+
+
+def safe_diagnostic_details(error: BaseException) -> list[str]:
+    if isinstance(error, BaseExceptionGroup):
+        return [detail for nested in error.exceptions for detail in safe_diagnostic_details(nested)]
+    if isinstance(error, QualificationError):
+        return [str(error)]
+    return [type(error).__name__]
+
+
 def qualify(config: Config) -> None:
     config.validate()
     publishable_key, secret_key = resolve_keys(config)
@@ -511,9 +523,11 @@ def qualify(config: Config) -> None:
     user_id: str | None = None
     access_token: str | None = None
     primary_error: BaseException | None = None
+    phase = "namespace-preflight"
 
     try:
         reconcile_namespace(client, run)
+        phase = "deployed-contract"
         head = _single_row(client.sql("select max(version)::text migration_head from supabase_migrations.schema_migrations"))["migration_head"]
         if head != MIGRATION_HEAD:
             raise QualificationError("persistent Dev migration head mismatch")
@@ -535,6 +549,7 @@ def qualify(config: Config) -> None:
             "and has_function_privilege('service_role',p.oid,'execute') and not has_function_privilege('anon',p.oid,'execute') and not has_function_privilege('authenticated',p.oid,'execute')) <> 6 "
             "then raise exception 'issue380_acl_mismatch'; end if; end $$;"
         )
+        phase = "snapshot-rpc-fixture"
         artifact_url = f"https://{DEV_REF}.supabase.co/storage/v1/s3/{bucket}/{run.prefix}/snapshot.h5"
         client.sql(
             f"insert into private.lca_network_snapshots(id,scope,process_filter,source_hash,status,created_by,created_at,updated_at) values('{fixture_id}','full_library','{{\"issue380\":true}}','issue380-source','ready','{uuid.uuid5(namespace, 'actor')}','2099-08-02T00:00:00Z','2099-08-02T00:00:00Z');"
@@ -574,6 +589,7 @@ def qualify(config: Config) -> None:
             if status not in (401, 403) or not isinstance(payload, dict) or payload.get("code") != "42501":
                 raise QualificationError(f"anonymous RPC boundary mismatch: {name}")
 
+        phase = "auth-boundary"
         created = require_response(client.auth("admin/users", method="POST", key=secret_key, body={"email": email, "password": password, "email_confirm": True, "user_metadata": {"issue380_marker": marker}}), 200)
         user = created.get("user", created) if isinstance(created, dict) else None
         if not isinstance(user, dict) or not user.get("id"):
@@ -588,6 +604,7 @@ def qualify(config: Config) -> None:
             if status not in (401, 403) or not isinstance(payload, dict) or payload.get("code") != "42501":
                 raise QualificationError(f"authenticated RPC boundary mismatch: {name}")
 
+        phase = "worker-artifact-fixture"
         process = _single_row(client.sql("select id::text, btrim(version)::text version from public.processes where state_code between 100 and 199 and btrim(version) <> '' order by id,version limit 1"))
         process_id, process_version = process["id"], process["version"]
         snapshot_index = {"version": 1, "snapshot_id": str(fixture_id), "process_count": 1, "impact_count": 1, "process_map": [{"process_id": process_id, "process_version": process_version, "process_index": 0}], "impact_map": [{"impact_id": str(impact_id), "impact_index": 0, "impact_key": "issue380", "impact_name": "Issue 380", "unit": "kg"}]}
@@ -614,6 +631,7 @@ def qualify(config: Config) -> None:
             f"insert into public.lca_latest_all_unit_results(snapshot_id,job_id,worker_job_id,result_id,query_artifact_url,query_artifact_sha256,query_artifact_byte_size,query_artifact_format,status,computed_at) values('{fixture_id}','{all_unit_job}','{all_unit_job}','{result_id}','https://{DEV_REF}.supabase.co/storage/v1/s3/{bucket}/{run.prefix}/query.json','{'b' * 64}',{len(json.dumps(query_envelope, separators=(',', ':')).encode())},'all-unit-query:v1','ready','2099-08-02T00:00:03Z');"
         )
 
+        phase = "edge-endpoint-contract"
         bodies = {
             "lca_solve": {"snapshot_id": str(fixture_id), "demand_mode": "all_unit"},
             "lca_query_results": {"snapshot_id": str(fixture_id), "data_scope": "open_data", "mode": "process_all_impacts", "process_id": process_id, "process_version": process_version},
@@ -638,8 +656,10 @@ def qualify(config: Config) -> None:
                 raise QualificationError(f"Edge query DTO mismatch on attempt {attempt + 1}")
         bad = dict(bodies["lca_solve"]); bad.update({"demand_mode": "single", "demand": {"process_index": 1, "amount": 1}})
         require_response(client.edge("lca_solve", method="POST", body=bad, bearer=access_token), 400, {"error": "process_index_out_of_range", "process_index": 1, "process_count": 1})
-    except BaseException as error:
+    except QualificationError as error:
         primary_error = error
+    except BaseException as error:
+        primary_error = unexpected_phase_error(phase, error)
     finally:
         finish_with_reconcile(primary_error, client, run)
 
@@ -648,13 +668,7 @@ def main() -> int:
     try:
         qualify(Config.from_env())
     except BaseException as error:
-        if isinstance(error, QualificationError):
-            detail = str(error)
-        elif isinstance(error, ExceptionGroup):
-            details = [str(item) for item in error.exceptions if isinstance(item, QualificationError)]
-            detail = "; ".join(details) if details else "aggregate failure"
-        else:
-            detail = type(error).__name__
+        detail = "; ".join(safe_diagnostic_details(error))
         print(f"hosted qualification failed: {detail}", file=sys.stderr)
         return 1
     print("persistent Dev hosted qualification passed; residue=0")

--- a/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
@@ -12,7 +12,9 @@ from supabase.tests.hosted.lca_snapshot_hosted_qualification import (
     reconcile_namespace,
     require_response,
     resolve_keys,
+    safe_diagnostic_details,
     select_current_keys,
+    unexpected_phase_error,
 )
 
 
@@ -185,6 +187,43 @@ class CleanupTests(unittest.TestCase):
         messages = [str(error) for error in raised.exception.exceptions]
         self.assertTrue(any("primary" in message for message in messages))
         self.assertTrue(any("discover-auth-actors" in message for message in messages))
+
+    def test_unexpected_phase_error_names_phase_and_type_without_value(self):
+        secret = "do-not-print-this-value"
+        error = unexpected_phase_error("auth-boundary", RuntimeError(secret))
+        self.assertEqual(str(error), "hosted phase failed: auth-boundary: RuntimeError")
+        self.assertNotIn(secret, str(error))
+
+    def test_nested_primary_and_cleanup_diagnostics_are_recursive_and_secret_safe(self):
+        primary_secret = "primary-secret-value"
+        cleanup_secret = "cleanup-secret-value"
+        error = ExceptionGroup(
+            "outer group contains no reportable detail",
+            [
+                unexpected_phase_error("worker-artifact-fixture", ValueError(primary_secret)),
+                ExceptionGroup(
+                    "nested group contains no reportable detail",
+                    [
+                        QualificationError("namespace reconcile failed: discover-auth-actors: RuntimeError"),
+                        RuntimeError(cleanup_secret),
+                    ],
+                ),
+            ],
+        )
+        details = safe_diagnostic_details(error)
+        self.assertEqual(
+            details,
+            [
+                "hosted phase failed: worker-artifact-fixture: ValueError",
+                "namespace reconcile failed: discover-auth-actors: RuntimeError",
+                "RuntimeError",
+            ],
+        )
+        rendered = "; ".join(details)
+        self.assertNotIn(primary_secret, rendered)
+        self.assertNotIn(cleanup_secret, rendered)
+        self.assertNotIn("outer group", rendered)
+        self.assertNotIn("nested group", rendered)
 
 
 class WorkflowSecurityTests(unittest.TestCase):


### PR DESCRIPTION
Closes #380

## 摘要

上一轮 hosted run 30750197004 仅输出 aggregate failure，嵌套主错误被诊断汇总丢失。本 PR 增加固定 phase + exception type 的 secret-safe 诊断，并递归展开 nested BaseExceptionGroup。

## 安全边界

- 不输出异常 value、ExceptionGroup message、HTTP payload 或凭据。
- 不改变 canonical dev / persistent Dev 固定目标。
- 不改变 production 拒绝、凭据 mask、cleanup/readback 或 fail-closed。
- 不改变业务 SQL、fixture 或 endpoint 请求。

## 验证

- focused unittest：16/16
- py_compile / diff check：通过
- Docpact strict 与 enforce：通过
- 独立复审：GO，P0=0，P1=0，P2=1（极早期 resolve_keys unexpected error 仍只有 type，无泄密且不阻断）

## 执行

合并到 dev 后自动重跑 persistent Dev hosted qualification，以定位 30750197004 的真实失败 phase；production 不触碰。