### PR TITLE
test: accept non-JSON hosted OPTIONS responses

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "0e4000b68abe97f11bf10f0ff972e8a453af643b"
-lastReviewedNote: "Reviewed for the Issue #380 hosted phase diagnostics: existing hosted-proof routing covers secret-safe phase/type reporting and nested cleanup failures without changing ownership, targeting, or schema routing."
+lastReviewedCommit: "0abc9f8b54a289292da641c13224b52c5ee5b402"
+lastReviewedNote: "Reviewed for the Issue #380 hosted non-JSON OPTIONS repair: existing hosted-proof routing covers tolerant transport decoding without changing DTO validation, ownership, targeting, or schema routing."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 0e4000b68abe97f11bf10f0ff972e8a453af643b
-lastReviewedNote: "Reviewed for the Issue #380 hosted phase diagnostics: secret-safe phase/type reporting preserves trusted targeting, cleanup, and production ownership without exposing response or exception values."
+lastReviewedCommit: 0abc9f8b54a289292da641c13224b52c5ee5b402
+lastReviewedNote: "Reviewed for the Issue #380 hosted non-JSON OPTIONS repair: tolerant response decoding preserves trusted targeting, fail-closed DTO checks, cleanup, and production ownership without logging response content."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 0e4000b68abe97f11bf10f0ff972e8a453af643b
-lastReviewedNote: "Reviewed for the Issue #380 hosted phase diagnostics: diagnostic-only error classification does not change schema sources, generated workspaces, or repository ownership boundaries."
+lastReviewedCommit: 0abc9f8b54a289292da641c13224b52c5ee5b402
+lastReviewedNote: "Reviewed for the Issue #380 hosted non-JSON OPTIONS repair: transport-only response decoding does not change schema sources, generated workspaces, or repository ownership boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 0e4000b68abe97f11bf10f0ff972e8a453af643b
-lastReviewedNote: "Reviewed for Issue #380 hosted phase diagnostics: fixed phase/type labels and recursive nested-error reporting remain secret-safe while preserving the canonical hosted cleanup and fail-closed validation contract."
+lastReviewedCommit: 0abc9f8b54a289292da641c13224b52c5ee5b402
+lastReviewedNote: "Reviewed for Issue #380 hosted non-JSON OPTIONS repair: tolerant transport decoding remains content-silent while existing DTO/type checks preserve the fail-closed hosted validation contract."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 0e4000b68abe97f11bf10f0ff972e8a453af643b
-lastReviewedNote: "Reviewed for the Issue #380 hosted phase diagnostics: diagnostic-only reporting preserves canonical dev targeting, serialized persistent-dev execution, and the unchanged production boundary."
+lastReviewedCommit: 0abc9f8b54a289292da641c13224b52c5ee5b402
+lastReviewedNote: "Reviewed for the Issue #380 hosted non-JSON OPTIONS repair: transport-only response decoding preserves canonical dev targeting, serialized persistent-dev execution, and the unchanged production boundary."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
@@ -128,7 +128,13 @@ def _json_request(
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             payload = response.read()
-            return response.status, json.loads(payload) if payload else None
+            if not payload:
+                return response.status, None
+            try:
+                parsed = json.loads(payload)
+            except json.JSONDecodeError:
+                parsed = payload.decode("utf-8", errors="replace")
+            return response.status, parsed
     except urllib.error.HTTPError as error:
         payload = error.read()
         try:

--- a/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
@@ -1,9 +1,13 @@
+import contextlib
+import io
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from supabase.tests.hosted.lca_snapshot_hosted_qualification import (
     DEV_REF,
     PRODUCTION_REF,
+    _json_request,
     Config,
     QualificationError,
     RunNamespace,
@@ -46,6 +50,37 @@ class TargetingTests(unittest.TestCase):
             config(git_ref="refs/heads/main").validate()
 
 class KeyTests(unittest.TestCase):
+    class FakeResponse:
+        def __init__(self, status, payload):
+            self.status = status
+            self.payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return self.payload
+
+    def test_success_transport_accepts_text_and_preserves_json_without_logging_content(self):
+        secret_text = "plain-text-response-must-not-be-logged"
+        responses = [
+            self.FakeResponse(204, secret_text.encode()),
+            self.FakeResponse(200, b'{"ok":true,"value":42}'),
+        ]
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with (
+            patch("urllib.request.urlopen", side_effect=responses),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            self.assertEqual(_json_request("https://example.invalid/options"), (204, secret_text))
+            self.assertEqual(_json_request("https://example.invalid/json"), (200, {"ok": True, "value": 42}))
+        self.assertNotIn(secret_text, stdout.getvalue())
+        self.assertNotIn(secret_text, stderr.getvalue())
+
     def test_selects_current_default_modern_keys(self):
         rows = [
             {"type": "secret", "name": "old", "api_key": "sb_secret_old", "disabled": True},


### PR DESCRIPTION
Closes #380

## 摘要

Persistent Dev hosted run 30750691089 已定位为 edge-endpoint-contract JSONDecodeError：成功的 Edge OPTIONS 响应可以是非 JSON 文本，而通用 transport 之前对所有非空 2xx body 强制 json.loads。

本 PR 对成功 transport 做最小对称修复：空 body 返回 None，合法 JSON 保持原 DTO，非 JSON 返回 UTF-8 replacement 文本。OPTIONS 调用只检查 status；所有业务 RPC/Auth/Edge DTO 仍保留原精确 JSON/type 校验并 fail-closed。

## 安全与验证

- HTTPError 分支、production guard、凭据 mask、cleanup/readback 均未修改。
- response content 不写 stdout/stderr。
- focused 17/17；Docpact strict/enforce；diff-check 通过。
- 独立复审 GO：P0=0，P1=0，P2=0。
- 合并仅触发 persistent Dev；production 不触碰。