### PR TITLE
test: accept exact hosted unauthorized boundaries

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "070958386e7cc3609105105c4dfd37a76e9080f1"
-lastReviewedNote: "Reviewed for the Issue #380 hosted DTO labels: existing hosted-proof routing covers fixed secret-safe phase labels without changing DTO validation, ownership, targeting, or schema routing."
+lastReviewedCommit: "8adf0c825c143ded099b325f01d089e316119bef"
+lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous authorization contract: existing hosted-proof routing covers the exact handler/gateway 401 DTO union without changing authenticated validation, ownership, targeting, or schema routing."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 070958386e7cc3609105105c4dfd37a76e9080f1
-lastReviewedNote: "Reviewed for the Issue #380 hosted DTO labels: fixed phase/type diagnostics preserve trusted targeting, fail-closed DTO checks, cleanup, and production ownership without exposing response or exception values."
+lastReviewedCommit: 8adf0c825c143ded099b325f01d089e316119bef
+lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous authorization contract: the exact handler/gateway 401 DTO union preserves trusted targeting, fail-closed authenticated DTO checks, cleanup, and production ownership without logging payloads."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 070958386e7cc3609105105c4dfd37a76e9080f1
-lastReviewedNote: "Reviewed for the Issue #380 hosted DTO labels: diagnostic-only phase labels do not change schema sources, generated workspaces, or repository ownership boundaries."
+lastReviewedCommit: 8adf0c825c143ded099b325f01d089e316119bef
+lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous authorization contract: qualification-only 401 DTO handling does not change schema sources, generated workspaces, or repository ownership boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 070958386e7cc3609105105c4dfd37a76e9080f1
-lastReviewedNote: "Reviewed for Issue #380 hosted DTO labels: granular static phase/type reporting remains content-silent while preserving the fail-closed hosted validation contract."
+lastReviewedCommit: 8adf0c825c143ded099b325f01d089e316119bef
+lastReviewedNote: "Reviewed for Issue #380 hosted anonymous authorization contract: exact handler/gateway 401 DTO acceptance remains content-silent while authenticated success, retry, and negative checks stay fail-closed."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: 070958386e7cc3609105105c4dfd37a76e9080f1
-lastReviewedNote: "Reviewed for the Issue #380 hosted DTO labels: diagnostic-only static labels preserve canonical dev targeting, serialized persistent-dev execution, and the unchanged production boundary."
+lastReviewedCommit: 8adf0c825c143ded099b325f01d089e316119bef
+lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous authorization contract: qualification-only handler/gateway 401 acceptance preserves canonical dev targeting, serialized persistent-dev execution, and the unchanged production boundary."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
@@ -281,6 +281,19 @@ def require_response(actual: tuple[int, Any], status: int, payload: Any | None =
     return actual_payload
 
 
+def require_anonymous_unauthorized(actual: tuple[int, Any]) -> dict[str, Any]:
+    status, payload = actual
+    accepted = (
+        {"error": "unauthorized"},
+        {"code": 401, "message": "Missing authorization header"},
+    )
+    if status != 401:
+        raise QualificationError("anonymous Edge response status mismatch")
+    if not isinstance(payload, dict) or payload not in accepted:
+        raise QualificationError("anonymous Edge response DTO mismatch")
+    return payload
+
+
 def _single_row(payload: Any) -> dict[str, Any]:
     if isinstance(payload, list) and len(payload) == 1 and isinstance(payload[0], dict):
         return payload[0]
@@ -663,7 +676,7 @@ def qualify(config: Config) -> None:
             if client.edge(name, method="OPTIONS", body=None, bearer=None)[0] not in (200, 204):
                 raise QualificationError(f"Edge CORS mismatch: {name}")
             phase = f"edge-{name}-anonymous"
-            require_response(client.edge(name, method="POST", body=body, bearer=None), 401, {"error": "unauthorized"})
+            require_anonymous_unauthorized(client.edge(name, method="POST", body=body, bearer=None))
         expected_endpoint_results = {
             "lca_solve": str(solve_result_id),
             "lca_contribution_path": str(contribution_result_id),

--- a/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
@@ -18,6 +18,7 @@ from supabase.tests.hosted.lca_snapshot_hosted_qualification import (
     qualify,
     qualification_phase_error,
     reconcile_namespace,
+    require_anonymous_unauthorized,
     require_response,
     resolve_keys,
     safe_diagnostic_details,
@@ -100,6 +101,36 @@ class KeyTests(unittest.TestCase):
     def test_invalid_current_key_semantics_fail_closed(self):
         with self.assertRaises(QualificationError):
             require_response((401, {"message": "Invalid API key"}), 200)
+
+    def test_anonymous_edge_contract_accepts_only_handler_or_gateway_401(self):
+        accepted = (
+            {"error": "unauthorized"},
+            {"code": 401, "message": "Missing authorization header"},
+        )
+        for payload in accepted:
+            with self.subTest(payload=payload):
+                self.assertEqual(require_anonymous_unauthorized((401, payload)), payload)
+
+    def test_anonymous_edge_contract_rejects_other_status_or_dto(self):
+        secret = "anonymous-response-secret"
+        rejected = (
+            (403, {"error": "unauthorized"}),
+            (401, None),
+            (401, "Missing authorization header"),
+            (401, {"error": "other"}),
+            (401, {"code": "401", "message": "Missing authorization header"}),
+            (401, {"code": 401, "message": ""}),
+            (401, {"code": 401, "message": "Invalid JWT"}),
+            (401, {"code": 401, "message": "Missing authorization header", "extra": True}),
+            (401, {"error": secret}),
+        )
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            for response in rejected:
+                with self.subTest(response=response), self.assertRaises(QualificationError):
+                    require_anonymous_unauthorized(response)
+        self.assertNotIn(secret, stdout.getvalue())
+        self.assertNotIn(secret, stderr.getvalue())
 
     def test_management_first_and_fallback(self):
         calls = []


### PR DESCRIPTION
Closes #380

## 摘要

Hosted run 30751511788 精确失败于 edge-lca_solve-anonymous：HTTP 401 正确，但 verify_jwt gateway 在 handler 前返回 Supabase 平台 DTO，而 runner 只接受 handler DTO。

本 PR 要求 anonymous status 精确为 401，并仅接受两个完整字典：handler 的 error=unauthorized，或 Supabase gateway 的 code=401/message=Missing authorization header。其他状态、非字典、替代 message/code 类型/额外字段全部 fail-closed。三个 Edge endpoint 共用该契约。

## 验证

- authenticated success/retry/query/negative 契约未修改。
- response payload 不写日志。
- focused 21/21；Docpact strict/enforce；diff-check 通过。
- 独立复审 GO：P0/P1/P2=0。
- 官方依据：https://supabase.com/docs/guides/troubleshooting/edge-function-401-error-response
- 合并仅触发 persistent Dev；production 不触碰。