### PR TITLE
test: validate anonymous hosted denial by status

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "a258c190e440f2cf388b5827086fe13b7da1a9bb"
-lastReviewedNote: "Reviewed for the Issue #380 hosted gateway/cascade contract: existing hosted-proof routing covers the strict known gateway 401 union and canonical parent-cascade cleanup without changing authenticated validation, ownership, targeting, or schema routing."
+lastReviewedCommit: "ca686b19f359eb90e78d12b789e08a8ccb89afe0"
+lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous status contract: existing hosted-proof routing treats the verify_jwt pre-handler body as platform-owned while exact 401 denial, authenticated DTO validation, and canonical parent-cascade cleanup remain enforced."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: a258c190e440f2cf388b5827086fe13b7da1a9bb
-lastReviewedNote: "Reviewed for the Issue #380 hosted gateway/cascade contract: strict known gateway 401 DTOs and parent-cascade artifact cleanup preserve trusted targeting, fail-closed authenticated checks, zero-residue readback, and production ownership."
+lastReviewedCommit: ca686b19f359eb90e78d12b789e08a8ccb89afe0
+lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous status contract: exact anonymous 401 denial ignores the platform-owned verify_jwt body while authenticated checks, zero-residue cascade cleanup, trusted targeting, and production ownership remain enforced."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: a258c190e440f2cf388b5827086fe13b7da1a9bb
-lastReviewedNote: "Reviewed for the Issue #380 hosted gateway/cascade contract: qualification-only 401 handling and existing snapshot-to-artifact cascade ownership do not change schema sources, generated workspaces, or repository boundaries."
+lastReviewedCommit: ca686b19f359eb90e78d12b789e08a8ccb89afe0
+lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous status contract: qualification-only status handling of the platform-owned gateway body does not change schema sources, generated workspaces, cascade ownership, or repository boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: a258c190e440f2cf388b5827086fe13b7da1a9bb
-lastReviewedNote: "Reviewed for Issue #380 hosted gateway/cascade contract: strict known gateway 401 acceptance remains content-silent while parent-cascade artifact cleanup retains mandatory zero-residue readback and authenticated checks stay fail-closed."
+lastReviewedCommit: ca686b19f359eb90e78d12b789e08a8ccb89afe0
+lastReviewedNote: "Reviewed for Issue #380 hosted anonymous status contract: exact anonymous 401 is the stable denial proof; the platform-owned verify_jwt body is ignored and content-silent while authenticated DTOs and cascade zero-residue remain exact."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -22,8 +22,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-02
-lastReviewedCommit: a258c190e440f2cf388b5827086fe13b7da1a9bb
-lastReviewedNote: "Reviewed for the Issue #380 hosted gateway/cascade contract: qualification-only known gateway 401 acceptance and canonical parent-cascade cleanup preserve dev targeting, serialized execution, and the unchanged production boundary."
+lastReviewedCommit: ca686b19f359eb90e78d12b789e08a8ccb89afe0
+lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous status contract: qualification-only exact 401 denial ignores the platform-owned gateway body while preserving dev targeting, serialized execution, cascade cleanup, and the production boundary."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/lca_snapshot_hosted_qualification.py
@@ -281,19 +281,10 @@ def require_response(actual: tuple[int, Any], status: int, payload: Any | None =
     return actual_payload
 
 
-def require_anonymous_unauthorized(actual: tuple[int, Any]) -> dict[str, Any]:
-    status, payload = actual
-    accepted = (
-        {"error": "unauthorized"},
-        {"code": 401, "message": "Missing authorization header"},
-        {"code": 401, "message": "Invalid Token or Protected Header formatting"},
-        {"code": 401, "message": "Invalid JWT"},
-    )
+def require_anonymous_401(actual: tuple[int, Any]) -> None:
+    status, _payload = actual
     if status != 401:
         raise QualificationError("anonymous Edge response status mismatch")
-    if not isinstance(payload, dict) or payload not in accepted:
-        raise QualificationError("anonymous Edge response DTO mismatch")
-    return payload
 
 
 def _single_row(payload: Any) -> dict[str, Any]:
@@ -677,7 +668,7 @@ def qualify(config: Config) -> None:
             if client.edge(name, method="OPTIONS", body=None, bearer=None)[0] not in (200, 204):
                 raise QualificationError(f"Edge CORS mismatch: {name}")
             phase = f"edge-{name}-anonymous"
-            require_anonymous_unauthorized(client.edge(name, method="POST", body=body, bearer=None))
+            require_anonymous_401(client.edge(name, method="POST", body=body, bearer=None))
         expected_endpoint_results = {
             "lca_solve": str(solve_result_id),
             "lca_contribution_path": str(contribution_result_id),

--- a/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
+++ b/supabase/tests/hosted/test_lca_snapshot_hosted_qualification.py
@@ -18,7 +18,7 @@ from supabase.tests.hosted.lca_snapshot_hosted_qualification import (
     qualify,
     qualification_phase_error,
     reconcile_namespace,
-    require_anonymous_unauthorized,
+    require_anonymous_401,
     require_response,
     resolve_keys,
     safe_diagnostic_details,
@@ -102,37 +102,21 @@ class KeyTests(unittest.TestCase):
         with self.assertRaises(QualificationError):
             require_response((401, {"message": "Invalid API key"}), 200)
 
-    def test_anonymous_edge_contract_accepts_only_handler_or_gateway_401(self):
-        accepted = (
-            {"error": "unauthorized"},
-            {"code": 401, "message": "Missing authorization header"},
-            {"code": 401, "message": "Invalid Token or Protected Header formatting"},
-            {"code": 401, "message": "Invalid JWT"},
-        )
-        for payload in accepted:
-            with self.subTest(payload=payload):
-                self.assertEqual(require_anonymous_unauthorized((401, payload)), payload)
-
-    def test_anonymous_edge_contract_rejects_other_status_or_dto(self):
+    def test_anonymous_edge_contract_accepts_any_body_only_with_401(self):
         secret = "anonymous-response-secret"
-        rejected = (
-            (403, {"error": "unauthorized"}),
-            (401, None),
-            (401, "Missing authorization header"),
-            (401, {"error": "other"}),
-            (401, {"code": "401", "message": "Missing authorization header"}),
-            (401, {"code": 401, "message": ""}),
-            (401, {"code": 401, "message": "invalid jwt"}),
-            (401, {"code": 401, "message": "Missing authorization header", "extra": True}),
-            (401, {"error": secret}),
-        )
-        stdout, stderr = io.StringIO(), io.StringIO()
-        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-            for response in rejected:
-                with self.subTest(response=response), self.assertRaises(QualificationError):
-                    require_anonymous_unauthorized(response)
-        self.assertNotIn(secret, stdout.getvalue())
-        self.assertNotIn(secret, stderr.getvalue())
+        for payload in ({"error": secret}, secret, None):
+            with self.subTest(payload=payload):
+                stdout, stderr = io.StringIO(), io.StringIO()
+                with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                    self.assertIsNone(require_anonymous_401((401, payload)))
+                self.assertNotIn(secret, stdout.getvalue())
+                self.assertNotIn(secret, stderr.getvalue())
+
+    def test_anonymous_edge_contract_rejects_every_other_http_status(self):
+        for status in range(100, 600):
+            if status != 401:
+                with self.subTest(status=status), self.assertRaises(QualificationError):
+                    require_anonymous_401((status, None))
 
     def test_management_first_and_fallback(self):
         calls = []
@@ -399,6 +383,13 @@ class QualifyPhaseFlowTests(unittest.TestCase):
 
 
 class WorkflowSecurityTests(unittest.TestCase):
+    def test_authenticated_edge_dto_checks_remain_exact(self):
+        runner = (ROOT / "supabase/tests/hosted/lca_snapshot_hosted_qualification.py").read_text()
+        self.assertEqual(runner.count("require_response(client.edge("), 4)
+        self.assertIn('first != second or first.get("mode") != "cache_hit"', runner)
+        self.assertIn('query.get("data", {}).get("values", [{}])[0].get("value") != 42.5', runner)
+        self.assertIn('{"error": "process_index_out_of_range", "process_index": 1, "process_count": 1}', runner)
+
     def test_workflow_is_dev_only_and_has_no_arbitrary_selector(self):
         text = (ROOT / ".github/workflows/lca-snapshot-hosted-qualification.yml").read_text()
         trigger = text.split("permissions:", 1)[0]


### PR DESCRIPTION
Closes #380

## 摘要

Hosted gateway 的 401 body 会随 verify_jwt 层和平台版本变化，不是应用稳定 DTO。前两轮已证明 exact HTTP status 始终为 401，但 body 不属于已枚举的文案集合。

本 PR 将 anonymous 安全合同定义为 exact HTTP 401；body 完全忽略、不返回、不格式化、不记录。三个 endpoint 共用同一 helper。authenticated success/retry/query/negative 的精确业务 DTO 不变。

## 验证

- 401 下覆盖 dict/string/None body；100..599 所有非401拒绝。
- 静态守卫确认 authenticated 两次 success/retry、query 和 negative exact DTO 均保留。
- parent cascade 与 artifact zero readback 保留。
- focused 23/23；Docpact strict/worktree/staged enforce；diff-check 通过。
- 独立复审 GO：P0/P1/P2=0。
- production 不触碰。