### PR TITLE
fix: 收敛 cancelled LCA result cache

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -135,6 +135,8 @@ routing:
         - scripts/test_export_database_contract.py
         - supabase/migrations/*issue_390_result_api_facade*.sql
         - supabase/tests/*issue_390_result_api_facade*.sql
+        - supabase/migrations/*issue_395_reconcile_cancelled*.sql
+        - supabase/tests/*issue_395_reconcile_cancelled*.sql
         - .github/workflows/database-validation.yml
         - .github/workflows/supabase-dev.yml
         - scripts/test_database_contract_manifest.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-03
-lastReviewedCommit: 2cb88b079a8e50f7630378b9f565739c4144df60
-lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous status contract: exact anonymous 401 denial ignores the platform-owned verify_jwt body while authenticated checks, zero-residue cascade cleanup, trusted targeting, and production ownership remain enforced."
+lastReviewedCommit: 4dbea4a0ee7102a07b68613628e56022a37a5cf0
+lastReviewedNote: "Reviewed for Issue #395: a forward-only service facade replacement and its exact reviewed-blob gate preserve repository ownership, migration immutability, local-first validation, and production-mutation boundaries."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-03
-lastReviewedCommit: 2cb88b079a8e50f7630378b9f565739c4144df60
-lastReviewedNote: "Reviewed for the Issue #380 hosted anonymous status contract: qualification-only status handling of the platform-owned gateway body does not change schema sources, generated workspaces, cascade ownership, or repository boundaries."
+lastReviewedCommit: 4dbea4a0ee7102a07b68613628e56022a37a5cf0
+lastReviewedNote: "Reviewed for Issue #395: replacing one existing api facade through a forward migration does not change schema source ownership, generated workspace boundaries, or the eight-routine result facade shape."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-03
-lastReviewedCommit: 2cb88b079a8e50f7630378b9f565739c4144df60
-lastReviewedNote: "Reviewed for Issue #390: canonical-local now binds the exact service-only result facade pgTAP contract to its loopback Data API, concurrency, and zero-residue runtime qualification."
+lastReviewedCommit: 4dbea4a0ee7102a07b68613628e56022a37a5cf0
+lastReviewedNote: "Reviewed for Issue #395: result-cache qualification now covers cancelled-to-failed reconciliation, exact ACL convergence, concurrent touch accounting, and two-stage retry admission."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-03
-lastReviewedCommit: 2cb88b079a8e50f7630378b9f565739c4144df60
-lastReviewedNote: "Reviewed for Issue #390: canonical-local automatically runs the exact result API facade Data API, concurrency, and cleanup qualification when its pgTAP contract is selected."
+lastReviewedCommit: 4dbea4a0ee7102a07b68613628e56022a37a5cf0
+lastReviewedNote: "Reviewed for Issue #395: the result API runtime also proves concurrent cancelled-to-failed reconciliation and retry admission without adding a ninth facade."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -629,14 +629,17 @@ python scripts/test_identity_collaboration_data_api.py
 python scripts/test_identity_collaboration_concurrency.py
 ```
 
-### Issue #390 result API facade runtime
+### Issue #390/#395 result API facade runtime
 
 `test_issue_390_result_api_facade_runtime.py` is a loopback-only qualification
 for the eight service-only `api` routines. It freezes the positive DTO values,
 exact anonymous/authenticated/private-profile denials, one eight-request HTTP
 admission race, one eight-backend PostgreSQL race, same-binding replay, and
-post-cleanup zero residue. `canonical-local` runs it automatically whenever the
-Issue #390 pgTAP contract is selected.
+post-cleanup zero residue. The Issue #395 extension also runs eight concurrent
+reconciliations of one cancelled Worker job, proves every call contributes
+exactly one hit while preserving all identities, then admits a retry that
+atomically clears the old result/error binding. `canonical-local` runs it
+automatically whenever the Issue #390 facade pgTAP contract is selected.
 
 ```bash
 python scripts/test_issue_390_result_api_facade_runtime.py

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-03
-lastReviewedCommit: 2cb88b079a8e50f7630378b9f565739c4144df60
-lastReviewedNote: "已为 Issue #390 复核：canonical-local 在选中 result API facade pgTAP 合同时自动执行精确 Data API、并发与零残留验证。"
+lastReviewedCommit: 4dbea4a0ee7102a07b68613628e56022a37a5cf0
+lastReviewedNote: "已为 Issue #395 复核：result API runtime 同时验证 cancelled 到 failed 的并发收敛与两阶段重试，且不增加第九个 facade。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -506,12 +506,15 @@ python scripts/test_identity_collaboration_data_api.py
 python scripts/test_identity_collaboration_concurrency.py
 ```
 
-### Issue #390 result API facade runtime
+### Issue #390/#395 result API facade runtime
 
 `test_issue_390_result_api_facade_runtime.py` 是仅允许 loopback 的八个 service-only
 `api` routine 验证器。它冻结服务成功 DTO、anon/authenticated/private profile 精确拒绝、
 8 请求 HTTP admission race、8 个独立 PostgreSQL backend race、same-binding replay 与
-清理后的零残留。canonical-local 选中 Issue #390 pgTAP 合同时会自动执行该脚本。
+清理后的零残留。Issue #395 进一步用 8 个并发请求验证同一 cancelled Worker job
+收敛为 failed：每次调用仅增加一次 hit 且不改变任何身份字段，随后第二阶段 retry
+原子清除旧 result/error 并重新绑定。canonical-local 选中 Issue #390 facade pgTAP
+合同时会自动执行该脚本。
 
 ```bash
 python scripts/test_issue_390_result_api_facade_runtime.py

--- a/scripts/issue_390_pre_ddl_gate.py
+++ b/scripts/issue_390_pre_ddl_gate.py
@@ -1193,12 +1193,25 @@ def pre_ddl_sql_signals(sql: str) -> list[str]:
     return sorted(set(signals))
 
 
-def _facade_review_violations(sql: str) -> list[str]:
+RECONCILE_REPLACEMENT_IDENTITY = (
+    "api",
+    "cmd_lca_reconcile_result_cache_v1",
+    (
+        (("pg_catalog", "uuid"), 0),
+        (("pg_catalog", "uuid"), 0),
+    ),
+)
+
+
+def _facade_review_violations(
+    sql: str, *, replacement_identity: tuple | None = None
+) -> list[str]:
     statements, errors = _parse_sql(sql)
     if errors:
         return errors
     created: set[tuple] = set()
     acl_state: dict[tuple, dict[str, bool]] = {}
+    explicitly_revoked: dict[tuple, set[str]] = {}
     violations = []
     for statement in statements:
         root_type, root = next(iter(statement.items()))
@@ -1221,14 +1234,26 @@ def _facade_review_violations(sql: str) -> list[str]:
                 violations.append("facade:duplicate-function-identity")
             created.add(identity)
             acl_state[identity] = {
-                "PUBLIC": True,
-                "anon": False,
-                "authenticated": False,
-                "service_role": False,
-                "api_internal_executor": False,
+                # CREATE grants EXECUTE to PUBLIC by default. A replacement,
+                # however, preserves the existing ACL, so model every governed
+                # runtime grantee as privileged until this exact migration
+                # explicitly revokes it.
+                role: replacement_identity is not None or role == "PUBLIC"
+                for role in (
+                    "PUBLIC",
+                    "anon",
+                    "authenticated",
+                    "service_role",
+                    "api_internal_executor",
+                )
             }
-            if root.get("replace"):
+            explicitly_revoked[identity] = set()
+            if root.get("replace") and replacement_identity is None:
                 violations.append("facade:create-or-replace-forbidden")
+            if replacement_identity is not None and (
+                not root.get("replace") or identity != replacement_identity
+            ):
+                violations.append("facade:replacement-identity-forbidden")
             if not _function_is_invoker_with_empty_search_path(root):
                 violations.append("facade:function-must-be-invoker-empty-search-path")
             options = _function_options(root)
@@ -1317,17 +1342,32 @@ def _facade_review_violations(sql: str) -> list[str]:
             for identity in identities:
                 for role in roles:
                     acl_state[identity][role] = bool(root.get("is_grant"))
+                    if not root.get("is_grant"):
+                        explicitly_revoked[identity].add(role)
         elif root_type != "CommentStmt":
             violations.append(f"facade:statement-forbidden:{root_type}")
     for identity in created:
         identity_text = _identity_text(identity)
         if any(
             acl_state[identity][role]
-            for role in ("PUBLIC", "anon", "authenticated")
+            for role in (
+                "PUBLIC",
+                "anon",
+                "authenticated",
+                "api_internal_executor",
+            )
         ):
             violations.append(f"facade:missing-browser-revoke:{identity_text}")
         if not acl_state[identity]["service_role"]:
             violations.append(f"facade:missing-service-grant:{identity_text}")
+        if replacement_identity is not None and not {
+            "PUBLIC",
+            "anon",
+            "authenticated",
+            "service_role",
+            "api_internal_executor",
+        } <= explicitly_revoked[identity]:
+            violations.append(f"facade:missing-exact-acl-reset:{identity_text}")
     if not created:
         violations.append("facade:no-api-function-created")
     return sorted(set(violations))
@@ -1347,11 +1387,16 @@ def pre_ddl_migration_violations(
         for row in allowlist
         if row.get("path") == path and row.get("gitBlob") == git_blob
     ]
-    if len(matching) != 1 or matching[0].get("classification") != (
-        "additive-api-service-only-reviewed"
-    ):
+    if len(matching) != 1:
         return signals
-    return _facade_review_violations(sql)
+    classification = matching[0].get("classification")
+    if classification == "additive-api-service-only-reviewed":
+        return _facade_review_violations(sql)
+    if classification == "reconcile-v1-service-only-replacement-reviewed":
+        return _facade_review_violations(
+            sql, replacement_identity=RECONCILE_REPLACEMENT_IDENTITY
+        )
+    return signals
 
 
 __all__ = [

--- a/scripts/test_database_contract_manifest.py
+++ b/scripts/test_database_contract_manifest.py
@@ -25,16 +25,16 @@ class DatabaseContractManifestTest(unittest.TestCase):
         cls.manifest = json.loads(runner.MANIFEST.read_text(encoding="utf-8"))
         cls.tracked = runner.tracked_test_files()
 
-    def test_checked_manifest_has_unique_classification_and_68_canonical_files(self) -> None:
+    def test_checked_manifest_has_unique_classification_and_69_canonical_files(self) -> None:
         classified = runner.validate_manifest(self.manifest, self.tracked)
         suite = self.manifest["suites"]["canonical-local"]
         selected = [
             path for path in classified[suite["classification"]]
             if path not in suite["excludedFiles"]
         ]
-        self.assertEqual(len(classified["canonical-pgtap"]), 87)
+        self.assertEqual(len(classified["canonical-pgtap"]), 88)
         self.assertEqual(len(suite["excludedFiles"]), 19)
-        self.assertEqual(len(selected), 68)
+        self.assertEqual(len(selected), 69)
 
     def test_persistent_dev_validation_fetches_immutable_provenance_history(self) -> None:
         workflow = (runner.ROOT / ".github/workflows/supabase-dev.yml").read_text(
@@ -65,7 +65,7 @@ class DatabaseContractManifestTest(unittest.TestCase):
             evidence = runner.suite_evidence("canonical-local", files, 19)
         self.assertEqual(evidence["gitCommit"], "a" * 40)
         self.assertFalse(evidence["worktreeDirty"])
-        self.assertEqual(evidence["migrationHead"], "20260802172930")
+        self.assertEqual(evidence["migrationHead"], "20260802190427")
         self.assertEqual(evidence["supabaseCliVersion"], "2.98.0")
         self.assertEqual(evidence["filesSha256"], runner.stable_json_sha256(files))
         self.assertEqual(
@@ -73,13 +73,13 @@ class DatabaseContractManifestTest(unittest.TestCase):
             hashlib.sha256(runner.MANIFEST.read_bytes()).hexdigest(),
         )
 
-    def test_all_101_sql_assets_are_owned_once_but_only_87_are_canonical_pgtap(self) -> None:
+    def test_all_102_sql_assets_are_owned_once_but_only_88_are_canonical_pgtap(self) -> None:
         classified = runner.validate_manifest(self.manifest, self.tracked)
         sql_paths = [path for path in self.tracked if path.endswith(".sql")]
         owned = [path for paths in classified.values() for path in paths if path.endswith(".sql")]
-        self.assertEqual(len(sql_paths), 101)
+        self.assertEqual(len(sql_paths), 102)
         self.assertEqual(sorted(owned), sorted(sql_paths))
-        self.assertEqual(len(classified["canonical-pgtap"]), 87)
+        self.assertEqual(len(classified["canonical-pgtap"]), 88)
 
     def test_issue_390_runtime_is_mandatory_exact_canonical_local_wiring(self) -> None:
         contract = runner.RESULT_API_FACADE_CONTRACT

--- a/scripts/test_issue_390_pre_ddl_gate.py
+++ b/scripts/test_issue_390_pre_ddl_gate.py
@@ -169,7 +169,7 @@ class Issue390PreDdlGateTest(unittest.TestCase):
         self.assertTrue(migration_gate["committedMigrationHistoryAppendOnly"])
         self.assertEqual(
             migration_gate["newMigrationsAllowed"],
-            "target-neutral-static-or-reviewed-ast-facade",
+            "target-neutral-static-or-reviewed-ast-facade-operation",
         )
         self.assertFalse(migration_gate["relationMovingDdlAllowed"])
         self.assertFalse(migration_gate["browserPrivateCompatibilityGrantAllowed"])
@@ -188,8 +188,12 @@ class Issue390PreDdlGateTest(unittest.TestCase):
             self.assertTrue(row["path"].startswith("supabase/migrations/"))
             self.assertTrue(row["path"].endswith(".sql"))
             self.assertRegex(row["gitBlob"], r"^[0-9a-f]{40}$")
-            self.assertEqual(
-                row["classification"], "additive-api-service-only-reviewed"
+            self.assertIn(
+                row["classification"],
+                {
+                    "additive-api-service-only-reviewed",
+                    "reconcile-v1-service-only-replacement-reviewed",
+                },
             )
 
     def test_target_neutral_migrations_are_allowed_without_global_freeze(self) -> None:
@@ -733,6 +737,93 @@ class Issue390PreDdlGateTest(unittest.TestCase):
             signals,
         )
 
+    def test_reviewed_reconcile_replacement_requires_exact_identity_and_acl_reset(self) -> None:
+        path = "supabase/migrations/20990101000012_reconcile_replace.sql"
+        blob = "c" * 40
+        reviewed = [
+            {
+                "path": path,
+                "gitBlob": blob,
+                "classification": (
+                    "reconcile-v1-service-only-replacement-reviewed"
+                ),
+            }
+        ]
+
+        def migration(
+            *,
+            name: str = "cmd_lca_reconcile_result_cache_v1",
+            replace: str = "OR REPLACE ",
+            revoke_roles: str = (
+                "PUBLIC, anon, authenticated, service_role, "
+                "api_internal_executor"
+            ),
+            grant_role: str = "service_role",
+        ) -> str:
+            return f"""
+            CREATE {replace}FUNCTION api.{name}(
+              p_requested_by pg_catalog.uuid,
+              p_cache_id pg_catalog.uuid
+            ) RETURNS pg_catalog.jsonb LANGUAGE sql SECURITY INVOKER
+            SET search_path = '' AS $$
+              SELECT pg_catalog.to_jsonb(cache_row)
+              FROM public.lca_result_cache AS cache_row
+              WHERE cache_row.id = p_cache_id
+            $$;
+            REVOKE ALL ON FUNCTION api.{name}(
+              pg_catalog.uuid, pg_catalog.uuid
+            ) FROM {revoke_roles};
+            GRANT EXECUTE ON FUNCTION api.{name}(
+              pg_catalog.uuid, pg_catalog.uuid
+            ) TO {grant_role};
+            """
+
+        self.assertEqual(
+            pre_ddl_migration_violations(
+                path=path,
+                git_blob=blob,
+                sql=migration(),
+                allowlist=reviewed,
+            ),
+            [],
+        )
+
+        rejected = [
+            migration(name="cmd_lca_reconcile_result_cache_v2"),
+            migration(replace=""),
+            migration(
+                revoke_roles=(
+                    "PUBLIC, anon, authenticated, api_internal_executor"
+                )
+            ),
+            migration(
+                revoke_roles=(
+                    "PUBLIC, anon, authenticated, service_role"
+                )
+            ),
+            migration(grant_role="api_internal_executor"),
+        ]
+        for sql in rejected:
+            self.assertNotEqual(
+                pre_ddl_migration_violations(
+                    path=path,
+                    git_blob=blob,
+                    sql=sql,
+                    allowlist=reviewed,
+                ),
+                [],
+                sql,
+            )
+
+        self.assertNotEqual(
+            pre_ddl_migration_violations(
+                path=path,
+                git_blob="d" * 40,
+                sql=migration(),
+                allowlist=reviewed,
+            ),
+            [],
+        )
     def test_checkout_descends_from_base_and_preserves_base_migrations(self) -> None:
         base = FREEZE_BASE_COMMIT
         ancestry = subprocess.run(

--- a/scripts/test_issue_390_result_api_facade_runtime.py
+++ b/scripts/test_issue_390_result_api_facade_runtime.py
@@ -199,6 +199,12 @@ def main() -> None:
     reconcile_worker_job = str(uuid.uuid4())
     reconcile_legacy_job = str(uuid.uuid4())
     reconcile_result_id = str(uuid.uuid4())
+    cancelled_worker_job = str(uuid.uuid4())
+    cancelled_legacy_job = str(uuid.uuid4())
+    cancelled_result_id = str(uuid.uuid4())
+    cancelled_cache = str(uuid.uuid4())
+    retry_worker_job = str(uuid.uuid4())
+    retry_legacy_job = str(uuid.uuid4())
     ready_cache = str(uuid.uuid4())
     reconcile_cache = str(uuid.uuid4())
     latest_id = str(uuid.uuid4())
@@ -219,6 +225,24 @@ def main() -> None:
          '{snapshot}', 'user', '{actor}', 'completed', 'lca.solve_one.request.v1',
          jsonb_build_object('job_id', '{legacy_job}', 'snapshot_id', '{snapshot}'),
          'lca.solve.result.v1', '{{"ok":true}}'::jsonb, now());
+      insert into private.worker_jobs
+        (id, job_kind, worker_queue, subject_type, subject_id, subject_version,
+         requester_type, requested_by, status, payload_schema_version, payload_json,
+         error_code, error_message, finished_at, cancelled_at)
+      values
+        ('{cancelled_worker_job}', 'lca.solve_one', 'solver', 'lca_job',
+         '{cancelled_legacy_job}', '{snapshot}', 'user', '{actor}', 'cancelled',
+         'lca.solve_one.request.v1',
+         jsonb_build_object('job_id', '{cancelled_legacy_job}', 'snapshot_id', '{snapshot}'),
+         'cancelled_by_test', 'cancelled by Issue #395 runtime', now(), now());
+      insert into private.worker_jobs
+        (id, job_kind, worker_queue, subject_type, subject_id, subject_version,
+         requester_type, requested_by, status, payload_schema_version, payload_json)
+      values
+        ('{retry_worker_job}', 'lca.solve_one', 'solver', 'lca_job',
+         '{retry_legacy_job}', '{snapshot}', 'user', '{actor}', 'queued',
+         'lca.solve_one.request.v1',
+         jsonb_build_object('job_id', '{retry_legacy_job}', 'snapshot_id', '{snapshot}'));
       insert into private.worker_jobs
         (id, job_kind, worker_queue, subject_type, subject_id, subject_version,
          requester_type, requested_by, status, payload_schema_version, payload_json,
@@ -244,6 +268,14 @@ def main() -> None:
          '{snapshot}', '{{}}'::jsonb, '{{}}'::jsonb,
          'storage://lca_results/{namespace}/reconcile-result.h5',
          repeat('c', 64), 768, 'hdf5:v1');
+      insert into public.lca_results
+        (id, job_id, worker_job_id, snapshot_id, payload, diagnostics,
+         artifact_url, artifact_sha256, artifact_byte_size, artifact_format)
+      values
+        ('{cancelled_result_id}', '{cancelled_legacy_job}', '{cancelled_worker_job}',
+         '{snapshot}', '{{}}'::jsonb, '{{}}'::jsonb,
+         'storage://lca_results/{namespace}/cancelled-preserved.h5',
+         repeat('d', 64), 395, 'hdf5:v1');
       insert into public.lca_result_cache
         (id, scope, snapshot_id, request_key, request_payload, status,
          job_id, worker_job_id, result_id, hit_count)
@@ -253,7 +285,10 @@ def main() -> None:
          'ready', '{legacy_job}', '{worker_job}', '{result_id}', 0),
         ('{reconcile_cache}', 'prod', '{snapshot}', '{namespace}-reconcile',
          '{{}}'::jsonb, 'pending', '{reconcile_legacy_job}',
-         '{reconcile_worker_job}', null, 0);
+         '{reconcile_worker_job}', null, 0),
+        ('{cancelled_cache}', 'prod', '{snapshot}', '{namespace}-cancelled',
+         '{{}}'::jsonb, 'pending', '{cancelled_legacy_job}',
+         '{cancelled_worker_job}', '{cancelled_result_id}', 0);
       insert into public.lca_latest_all_unit_results
         (id, snapshot_id, job_id, worker_job_id, result_id, query_artifact_url,
          query_artifact_sha256, query_artifact_byte_size, query_artifact_format, status)
@@ -266,7 +301,10 @@ def main() -> None:
       delete from public.lca_result_cache where snapshot_id = '{snapshot}';
       delete from public.lca_latest_all_unit_results where snapshot_id = '{snapshot}';
       delete from public.lca_results where snapshot_id = '{snapshot}';
-      delete from private.worker_jobs where id in ('{worker_job}', '{reconcile_worker_job}');
+      delete from private.worker_jobs where id in (
+        '{worker_job}', '{reconcile_worker_job}', '{cancelled_worker_job}',
+        '{retry_worker_job}'
+      );
       delete from public.lca_network_snapshots where id = '{snapshot}';
     """
 
@@ -371,6 +409,86 @@ def main() -> None:
         reconciled_cache = require_object(reconcile_data["cache"], "reconciled cache")
         if reconcile["ok"] is not True or reconcile["code"] != "reconciled" or reconciled_cache.get("resultId") != reconcile_result_id or reconciled_cache.get("hitCount") != 1:
             raise AssertionError("service reconcile did not bind and touch exactly once")
+
+        def reconcile_cancelled(_: int) -> object:
+            return expect_ok(
+                rpc(
+                    rest_url,
+                    "cmd_lca_reconcile_result_cache_v1",
+                    {"p_requested_by": actor, "p_cache_id": cancelled_cache},
+                    api_header=service_key,
+                    bearer=service_key,
+                ),
+                "concurrent cancelled reconcile",
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            cancelled_responses = list(executor.map(reconcile_cancelled, range(8)))
+        for response in cancelled_responses:
+            item = expect_keys(
+                response, {"ok", "code", "data"}, "cancelled reconcile"
+            )
+            data = require_object(item["data"], "cancelled reconcile data")
+            cache_state = require_object(data["cache"], "cancelled cache state")
+            if (
+                item["ok"] is not True
+                or item["code"] != "reconciled"
+                or data.get("workerStatus") != "cancelled"
+                or cache_state.get("status") != "failed"
+                or cache_state.get("legacyJobId") != cancelled_legacy_job
+                or cache_state.get("workerJobId") != cancelled_worker_job
+                or cache_state.get("resultId") != cancelled_result_id
+            ):
+                raise AssertionError(
+                    f"cancelled reconcile changed contract or identity: {item}"
+                )
+
+        cancelled_row = psql(
+            db_url,
+            f"select concat_ws(':', status, job_id::text, worker_job_id::text, "
+            f"result_id::text, hit_count::text) from public.lca_result_cache "
+            f"where id='{cancelled_cache}';",
+        )
+        expected_cancelled_row = (
+            f"failed:{cancelled_legacy_job}:{cancelled_worker_job}:"
+            f"{cancelled_result_id}:8"
+        )
+        if cancelled_row != expected_cancelled_row:
+            raise AssertionError(
+                "concurrent cancelled reconcile lost an increment or identity: "
+                f"{cancelled_row}"
+            )
+
+        retry = expect_ok(
+            rpc(
+                rest_url,
+                "cmd_lca_admit_result_cache_v1",
+                {
+                    "p_scope": "prod",
+                    "p_snapshot_id": snapshot,
+                    "p_request_key": f"{namespace}-cancelled",
+                    "p_request_payload": {"retry": True},
+                    "p_legacy_job_id": retry_legacy_job,
+                    "p_worker_job_id": retry_worker_job,
+                    "p_replace_ready": False,
+                },
+                api_header=service_key,
+                bearer=service_key,
+            ),
+            "cancelled retry admission",
+        )
+        retry_item = expect_keys(retry, {"ok", "outcome", "data"}, "retry")
+        retry_cache = require_object(retry_item["data"], "retry cache")
+        if (
+            retry_item["ok"] is not True
+            or retry_item["outcome"] != "accepted"
+            or retry_cache.get("status") != "pending"
+            or retry_cache.get("legacyJobId") != retry_legacy_job
+            or retry_cache.get("workerJobId") != retry_worker_job
+            or retry_cache.get("resultId") is not None
+            or retry_cache.get("hitCount") != 9
+        ):
+            raise AssertionError(f"cancelled retry was not atomically rebound: {retry}")
 
         latest_all = expect_keys(service_results["lca_read_latest_all_unit_result_v1"], {"ok", "data"}, "latest all-unit")
         latest_all_data = expect_keys(
@@ -503,6 +621,9 @@ def main() -> None:
                     "differentBindingOutcomes": {"accepted": 1, "reused": 7},
                     "sameBindingAccepted": 8,
                     "finalHitCount": 16,
+                    "cancelledConcurrentReconciles": 8,
+                    "cancelledFinalHitCountBeforeRetry": 8,
+                    "cancelledRetryHitCount": 9,
                 },
                 sort_keys=True,
             )
@@ -514,7 +635,10 @@ def main() -> None:
             f"""
               select
                 (select count(*) from public.lca_network_snapshots where id = '{snapshot}'),
-                (select count(*) from private.worker_jobs where id in ('{worker_job}', '{reconcile_worker_job}')),
+                (select count(*) from private.worker_jobs where id in (
+                  '{worker_job}', '{reconcile_worker_job}', '{cancelled_worker_job}',
+                  '{retry_worker_job}'
+                )),
                 (select count(*) from public.lca_results where snapshot_id = '{snapshot}'),
                 (select count(*) from public.lca_result_cache where snapshot_id = '{snapshot}'),
                 (select count(*) from public.lca_latest_all_unit_results where snapshot_id = '{snapshot}'),

--- a/supabase/migrations/20260802190427_issue_395_reconcile_cancelled_worker_cache.sql
+++ b/supabase/migrations/20260802190427_issue_395_reconcile_cancelled_worker_cache.sql
@@ -1,0 +1,189 @@
+-- Issue #395: a cancelled Worker job is terminal. Reconcile it to a failed
+-- cache row atomically so a later request can enqueue and admit a retry.
+-- This is a forward-only replacement of the existing service-only v1 facade;
+-- it does not add a routine or query surface.
+
+create or replace function api.cmd_lca_reconcile_result_cache_v1(
+  p_requested_by pg_catalog.uuid,
+  p_cache_id pg_catalog.uuid
+) returns pg_catalog.jsonb
+language sql
+security invoker
+set search_path = ''
+as $function$
+  with cache_state as (
+    select cache_row.id,
+           cache_row.status,
+           cache_row.job_id,
+           cache_row.worker_job_id,
+           cache_row.result_id
+    from public.lca_result_cache as cache_row
+    where cache_row.id = p_cache_id
+    for update
+  ), projection as (
+    select cache_state.id,
+           cache_state.status as prior_status,
+           cache_state.result_id as prior_result_id,
+           public.lca_read_job_projection(
+             p_requested_by,
+             cache_state.worker_job_id,
+             null,
+             false
+           ) as value
+    from cache_state
+  ), decision as (
+    select projection.id,
+           projection.prior_status,
+           projection.prior_result_id,
+           projection.value,
+           projection.value #>> '{data,job,status}' as worker_status,
+           case
+             when pg_catalog.jsonb_typeof(
+               projection.value #> '{data,result,resultId}'
+             ) = 'string'
+             and projection.value #>> '{data,result,resultId}' ~
+               '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+               then (projection.value #>> '{data,result,resultId}')::pg_catalog.uuid
+             else null
+           end as projected_result_id,
+           (
+             pg_catalog.jsonb_typeof(projection.value->'data') = 'object'
+             and pg_catalog.jsonb_typeof(projection.value #> '{data,job}') = 'object'
+             and pg_catalog.jsonb_typeof(projection.value #> '{data,job,status}') = 'string'
+             and (
+               pg_catalog.jsonb_typeof(projection.value #> '{data,result}') is null
+               or (
+                 pg_catalog.jsonb_typeof(projection.value #> '{data,result}') = 'object'
+                 and
+                 pg_catalog.jsonb_typeof(projection.value #> '{data,result,resultId}') = 'string'
+                 and projection.value #>> '{data,result,resultId}' ~
+                   '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+               )
+             )
+           ) as projection_shape_valid
+    from projection
+  ), reconciled as (
+    update public.lca_result_cache as cache_row
+    set status = case
+          when decision.worker_status = 'completed'
+            and decision.projected_result_id is not null
+            then 'ready'
+          when decision.worker_status in ('failed', 'stale', 'cancelled') then 'failed'
+          else cache_row.status
+        end,
+        result_id = case
+          when decision.worker_status = 'completed'
+            and decision.projected_result_id is not null
+            then decision.projected_result_id
+          else cache_row.result_id
+        end,
+        hit_count = cache_row.hit_count + 1,
+        last_accessed_at = pg_catalog.now(),
+        updated_at = pg_catalog.now()
+    from decision
+    where cache_row.id = decision.id
+      and decision.value->'ok' = 'true'::pg_catalog.jsonb
+      and decision.projection_shape_valid
+      and decision.worker_status in (
+        'queued', 'running', 'waiting', 'completed', 'blocked',
+        'stale', 'failed', 'cancelled'
+      )
+    returning cache_row.id,
+              cache_row.status,
+              cache_row.job_id,
+              cache_row.worker_job_id,
+              cache_row.result_id,
+              cache_row.hit_count,
+              cache_row.last_accessed_at,
+              cache_row.updated_at,
+              decision.worker_status,
+              decision.projected_result_id,
+              decision.value
+  )
+  select coalesce(
+    (
+      select case
+        when decision.value->'ok' = 'false'::pg_catalog.jsonb
+          and pg_catalog.jsonb_typeof(decision.value->'code') = 'string'
+          and pg_catalog.length(decision.value->>'code') > 0
+          and pg_catalog.jsonb_typeof(decision.value->'message') = 'string'
+          and pg_catalog.length(decision.value->>'message') > 0
+          and pg_catalog.jsonb_typeof(decision.value->'status') = 'number'
+          and decision.value #>> '{status}' ~ '^[1-5][0-9][0-9]$' then
+          pg_catalog.jsonb_strip_nulls(pg_catalog.jsonb_build_object(
+            'ok', false,
+            'code', decision.value->>'code',
+            'status', decision.value->'status',
+            'message', decision.value->>'message',
+            'details', decision.value->'details',
+            'data', null
+          ))
+        when decision.value->'ok' = 'true'::pg_catalog.jsonb
+          and decision.value ? 'data'
+          and decision.value->'data' = 'null'::pg_catalog.jsonb then
+          pg_catalog.jsonb_build_object(
+            'ok', true,
+            'code', 'job_not_found',
+            'data', null
+          )
+        when decision.value->'ok' = 'true'::pg_catalog.jsonb
+          and decision.projection_shape_valid
+          and decision.worker_status in (
+            'queued', 'running', 'waiting', 'completed', 'blocked',
+            'stale', 'failed', 'cancelled'
+          ) then
+          pg_catalog.jsonb_build_object(
+        'ok', true,
+        'code', case
+          when reconciled.worker_status = 'completed'
+            and reconciled.projected_result_id is null
+            then 'result_pending'
+          else 'reconciled'
+        end,
+        'data', pg_catalog.jsonb_build_object(
+            'cache', pg_catalog.jsonb_build_object(
+              'cacheId', reconciled.id,
+              'status', reconciled.status,
+              'legacyJobId', reconciled.job_id,
+              'workerJobId', reconciled.worker_job_id,
+              'resultId', reconciled.result_id,
+              'hitCount', reconciled.hit_count,
+              'lastAccessedAt', reconciled.last_accessed_at,
+              'updatedAt', reconciled.updated_at
+            ),
+            'workerStatus', reconciled.worker_status,
+            'jobProjection', reconciled.value
+          )
+      )
+        else pg_catalog.jsonb_build_object(
+          'ok', false,
+          'code', 'INVALID_LCA_JOB_PROJECTION',
+          'status', 500,
+          'data', null
+        )
+      end
+      from decision
+      left join reconciled on reconciled.id = decision.id
+    ),
+    pg_catalog.jsonb_build_object(
+      'ok', true,
+      'code', 'cache_not_found',
+      'data', null
+    )
+  )
+$function$;
+
+revoke all on function api.cmd_lca_reconcile_result_cache_v1(
+  pg_catalog.uuid,
+  pg_catalog.uuid
+) from public, anon, authenticated, service_role, api_internal_executor;
+
+grant execute on function api.cmd_lca_reconcile_result_cache_v1(
+  pg_catalog.uuid,
+  pg_catalog.uuid
+) to service_role;
+
+comment on function api.cmd_lca_reconcile_result_cache_v1(
+  pg_catalog.uuid,
+  pg_catalog.uuid
+) is 'Issue #395 service-only cache reconciliation command. cancelled, failed, and stale Worker states atomically converge cache status to failed while preserving job/result identity and touching exactly once. cache_not_found, job_not_found, and projection failures preserve the complete cache row. Completed jobs without a visible result return result_pending. Edge must not call touch or admit in the same request branch.';

--- a/supabase/tests/20260802_issue_395_reconcile_cancelled_worker_cache.sql
+++ b/supabase/tests/20260802_issue_395_reconcile_cancelled_worker_cache.sql
@@ -1,0 +1,324 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(16);
+
+select has_function(
+  'api', 'cmd_lca_reconcile_result_cache_v1', array['uuid', 'uuid']
+);
+
+select ok(
+  (
+    select proc.prolang = (select oid from pg_language where lanname = 'sql')
+      and not proc.prosecdef
+      and proc.proowner = 'postgres'::regrole
+      and proc.proconfig = array['search_path=""']::text[]
+    from pg_proc as proc
+    join pg_namespace as proc_schema on proc_schema.oid = proc.pronamespace
+    where proc_schema.nspname = 'api'
+      and proc.proname = 'cmd_lca_reconcile_result_cache_v1'
+      and pg_get_function_identity_arguments(proc.oid) =
+        'p_requested_by uuid, p_cache_id uuid'
+  ),
+  'reconcile keeps the exact SQL SECURITY INVOKER empty-search-path signature'
+);
+
+select ok(
+  (
+    select count(*) = 1
+      and bool_and(role_name.rolname = 'service_role')
+      and bool_and(not acl.is_grantable)
+    from pg_proc as proc
+    join pg_namespace as proc_schema on proc_schema.oid = proc.pronamespace
+    cross join lateral aclexplode(proc.proacl) as acl
+    join pg_roles as role_name on role_name.oid = acl.grantee
+    where proc_schema.nspname = 'api'
+      and proc.proname = 'cmd_lca_reconcile_result_cache_v1'
+      and acl.privilege_type = 'EXECUTE'
+      and acl.grantee <> proc.proowner
+  ),
+  'reconcile direct non-owner ACL is exactly service_role without grant option'
+);
+
+select ok(
+  has_function_privilege(
+    'service_role',
+    'api.cmd_lca_reconcile_result_cache_v1(uuid,uuid)',
+    'EXECUTE'
+  ),
+  'service_role can execute reconcile'
+);
+select ok(
+  not exists (
+    select 1
+    from pg_proc as proc
+    join pg_namespace as proc_schema on proc_schema.oid = proc.pronamespace
+    cross join lateral aclexplode(proc.proacl) as acl
+    where proc_schema.nspname = 'api'
+      and proc.proname = 'cmd_lca_reconcile_result_cache_v1'
+      and acl.grantee = 0
+      and acl.privilege_type = 'EXECUTE'
+  ),
+  'PUBLIC cannot execute reconcile'
+);
+select ok(
+  not has_function_privilege(
+    'anon', 'api.cmd_lca_reconcile_result_cache_v1(uuid,uuid)', 'EXECUTE'
+  ),
+  'anon cannot execute reconcile'
+);
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    'api.cmd_lca_reconcile_result_cache_v1(uuid,uuid)',
+    'EXECUTE'
+  ),
+  'authenticated cannot execute reconcile'
+);
+select ok(
+  not has_function_privilege(
+    'api_internal_executor',
+    'api.cmd_lca_reconcile_result_cache_v1(uuid,uuid)',
+    'EXECUTE'
+  ),
+  'api_internal_executor cannot execute reconcile'
+);
+
+insert into public.lca_network_snapshots (
+  id, scope, process_filter, provider_matching_rule, source_hash, status
+) values (
+  '98395000-0000-4000-8000-000000000010',
+  'full_library',
+  '{}'::jsonb,
+  'split_by_evidence_hybrid',
+  'issue-395-reconcile-cancelled',
+  'ready'
+);
+
+create temporary table issue_395_statuses (
+  worker_status text primary key,
+  ordinal integer not null,
+  worker_job_id uuid not null,
+  legacy_job_id uuid not null,
+  cache_id uuid not null,
+  expected_cache_status text not null,
+  expected_code text not null
+) on commit drop;
+grant all on issue_395_statuses to public;
+
+insert into issue_395_statuses values
+  ('queued',    1, '98395000-0000-4000-8000-000000000101', '98395000-0000-4000-8000-000000000201', '98395000-0000-4000-8000-000000000301', 'pending', 'reconciled'),
+  ('running',   2, '98395000-0000-4000-8000-000000000102', '98395000-0000-4000-8000-000000000202', '98395000-0000-4000-8000-000000000302', 'pending', 'reconciled'),
+  ('waiting',   3, '98395000-0000-4000-8000-000000000103', '98395000-0000-4000-8000-000000000203', '98395000-0000-4000-8000-000000000303', 'pending', 'reconciled'),
+  ('completed', 4, '98395000-0000-4000-8000-000000000104', '98395000-0000-4000-8000-000000000204', '98395000-0000-4000-8000-000000000304', 'pending', 'result_pending'),
+  ('blocked',   5, '98395000-0000-4000-8000-000000000105', '98395000-0000-4000-8000-000000000205', '98395000-0000-4000-8000-000000000305', 'pending', 'reconciled'),
+  ('stale',     6, '98395000-0000-4000-8000-000000000106', '98395000-0000-4000-8000-000000000206', '98395000-0000-4000-8000-000000000306', 'failed',  'reconciled'),
+  ('failed',    7, '98395000-0000-4000-8000-000000000107', '98395000-0000-4000-8000-000000000207', '98395000-0000-4000-8000-000000000307', 'failed',  'reconciled'),
+  ('cancelled', 8, '98395000-0000-4000-8000-000000000108', '98395000-0000-4000-8000-000000000208', '98395000-0000-4000-8000-000000000308', 'failed',  'reconciled');
+
+insert into private.worker_jobs (
+  id, job_kind, worker_queue, subject_type, subject_id, subject_version,
+  requester_type, requested_by, status, payload_schema_version, payload_json,
+  result_schema_version, result_json, finished_at, cancelled_at,
+  blocker_codes, resolution_scope
+)
+select worker_job_id, 'lca.solve_one', 'solver', 'lca_job', legacy_job_id,
+       '98395000-0000-4000-8000-000000000010', 'user',
+       '98395000-0000-4000-8000-000000000001', worker_status,
+       'lca.solve_one.request.v1',
+       jsonb_build_object(
+         'type', 'solve_one',
+         'job_id', legacy_job_id,
+         'snapshot_id', '98395000-0000-4000-8000-000000000010'
+       ),
+       case when worker_status = 'completed' then 'lca.solve.result.v1' end,
+       case when worker_status = 'completed' then '{"ok":true}'::jsonb end,
+       case when worker_status in ('completed', 'failed', 'cancelled') then now() end,
+       case when worker_status = 'cancelled' then now() end,
+       case when worker_status = 'blocked' then array['fixture_blocked']::text[]
+         else '{}'::text[] end,
+       case when worker_status = 'blocked' then 'user' end
+from issue_395_statuses;
+
+insert into public.lca_results (
+  id, job_id, worker_job_id, snapshot_id, payload, diagnostics,
+  artifact_url, artifact_sha256, artifact_byte_size, artifact_format
+) values (
+  '98395000-0000-4000-8000-000000000408',
+  '98395000-0000-4000-8000-000000000208',
+  '98395000-0000-4000-8000-000000000108',
+  '98395000-0000-4000-8000-000000000010',
+  '{}'::jsonb,
+  '{}'::jsonb,
+  'storage://lca_results/issue-395/cancelled-preserved.h5',
+  repeat('8', 64),
+  395,
+  'hdf5:v1'
+);
+
+insert into public.lca_result_cache (
+  id, scope, snapshot_id, request_key, request_payload, status,
+  job_id, worker_job_id, result_id, error_code, error_message, hit_count
+)
+select cache_id, 'prod', '98395000-0000-4000-8000-000000000010',
+       'issue-395-' || worker_status, '{}'::jsonb, 'pending',
+       legacy_job_id, worker_job_id,
+       case when worker_status = 'cancelled'
+         then '98395000-0000-4000-8000-000000000408'::uuid end,
+       case when worker_status = 'cancelled' then 'old-code' end,
+       case when worker_status = 'cancelled' then 'old-message' end,
+       0
+from issue_395_statuses;
+
+create temporary table issue_395_cancelled_before as
+select to_jsonb(cache_row) as row_state
+from public.lca_result_cache as cache_row
+where id = '98395000-0000-4000-8000-000000000308';
+grant all on issue_395_cancelled_before to public;
+
+set local role service_role;
+select set_config('request.jwt.claim.role', 'service_role', true);
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+select is(
+  api.cmd_lca_reconcile_result_cache_v1(
+    '98395000-0000-4000-8000-000000000099',
+    '98395000-0000-4000-8000-000000000308'
+  ),
+  '{"ok":true,"code":"job_not_found","data":null}'::jsonb,
+  'foreign cancelled reconcile returns the exact non-disclosing contract'
+);
+
+select is(
+  (
+    select to_jsonb(cache_row)
+    from public.lca_result_cache as cache_row
+    where id = '98395000-0000-4000-8000-000000000308'
+  ),
+  (select row_state from issue_395_cancelled_before),
+  'foreign cancelled reconcile has no status, identity, count, error, or timestamp side effect'
+);
+
+create temporary table issue_395_responses (
+  worker_status text primary key,
+  response jsonb not null
+) on commit drop;
+grant all on issue_395_responses to public;
+
+insert into issue_395_responses
+select fixture.worker_status,
+       api.cmd_lca_reconcile_result_cache_v1(
+         '98395000-0000-4000-8000-000000000001', fixture.cache_id
+       )
+from issue_395_statuses as fixture
+order by fixture.ordinal;
+
+select is(
+  (
+    select string_agg(
+      worker_status || ':' || (responses.response->>'code') || ':' ||
+      (responses.response #>> '{data,workerStatus}') || ':' ||
+      (responses.response #>> '{data,cache,status}'),
+      ',' order by fixture.ordinal
+    )
+    from issue_395_responses as responses
+    join issue_395_statuses as fixture using (worker_status)
+  ),
+  'queued:reconciled:queued:pending,running:reconciled:running:pending,waiting:reconciled:waiting:pending,completed:result_pending:completed:pending,blocked:reconciled:blocked:pending,stale:reconciled:stale:failed,failed:reconciled:failed:failed,cancelled:reconciled:cancelled:failed',
+  'all eight frozen Worker states retain their prior mapping and cancelled maps to failed'
+);
+
+select ok(
+  (
+    select bool_and(
+      cache_row.job_id = fixture.legacy_job_id
+      and cache_row.worker_job_id = fixture.worker_job_id
+      and cache_row.result_id is not distinct from
+        case when fixture.worker_status = 'cancelled'
+          then '98395000-0000-4000-8000-000000000408'::uuid end
+    )
+    from issue_395_statuses as fixture
+    join public.lca_result_cache as cache_row on cache_row.id = fixture.cache_id
+  ),
+  'reconcile preserves legacy job, Worker job, and result identity for every status'
+);
+
+select ok(
+  (
+    select bool_and(
+      cache_row.status = fixture.expected_cache_status
+      and cache_row.hit_count = 1
+    )
+    from issue_395_statuses as fixture
+    join public.lca_result_cache as cache_row on cache_row.id = fixture.cache_id
+  ),
+  'each successful reconcile persists its expected status and exactly one hit'
+);
+
+reset role;
+insert into private.worker_jobs (
+  id, job_kind, worker_queue, subject_type, subject_id, subject_version,
+  requester_type, requested_by, status, payload_schema_version, payload_json
+) values (
+  '98395000-0000-4000-8000-000000000109', 'lca.solve_one', 'solver',
+  'lca_job', '98395000-0000-4000-8000-000000000209',
+  '98395000-0000-4000-8000-000000000010', 'user',
+  '98395000-0000-4000-8000-000000000001', 'queued',
+  'lca.solve_one.request.v1',
+  '{"type":"solve_one","job_id":"98395000-0000-4000-8000-000000000209","snapshot_id":"98395000-0000-4000-8000-000000000010"}'::jsonb
+);
+set local role service_role;
+
+select is(
+  api.cmd_lca_admit_result_cache_v1(
+    'prod',
+    '98395000-0000-4000-8000-000000000010',
+    'issue-395-cancelled',
+    '{"retry":true}'::jsonb,
+    '98395000-0000-4000-8000-000000000209',
+    '98395000-0000-4000-8000-000000000109',
+    false
+  )->>'outcome',
+  'accepted',
+  'a cancelled job first reconciles to failed and then admits a retry'
+);
+
+select is(
+  (
+    select concat_ws(
+      ':', status, job_id::text, worker_job_id::text,
+      coalesce(result_id::text, 'null'), coalesce(error_code, 'null'),
+      coalesce(error_message, 'null'), hit_count::text
+    )
+    from public.lca_result_cache
+    where id = '98395000-0000-4000-8000-000000000308'
+  ),
+  'pending:98395000-0000-4000-8000-000000000209:98395000-0000-4000-8000-000000000109:null:null:null:2',
+  'retry admission atomically rebinds, clears result/error state, and adds exactly one hit'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from pg_proc as proc
+    join pg_namespace as proc_schema on proc_schema.oid = proc.pronamespace
+    where proc_schema.nspname = 'api'
+      and proc.proname in (
+        'lca_read_job_projection_v1',
+        'lca_read_result_projection_v1',
+        'lca_read_latest_single_solve_result_v1',
+        'lca_read_result_cache_v1',
+        'cmd_lca_touch_result_cache_v1',
+        'cmd_lca_admit_result_cache_v1',
+        'cmd_lca_reconcile_result_cache_v1',
+        'lca_read_latest_all_unit_result_v1'
+      )
+  ),
+  8,
+  'the forward replacement adds no ninth query or overload'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/contracts/lca_result_family_pre_ddl.v1.json
+++ b/supabase/tests/contracts/lca_result_family_pre_ddl.v1.json
@@ -6,7 +6,7 @@
   "predecessorMigrationHead": "20260802091342",
   "phase": "pre-ddl-consumer-cut",
   "ddlAuthorized": false,
-  "authorizationRule": "No migration may move or replace the protected family, remove its historical authenticated contract, weaken a protected api LCA facade, or grant non-service access to internal/target objects until static, runtime, and owner evidence satisfy the gate. Target-neutral non-executing static migrations remain allowed; an additive service-only api facade requires an exact reviewed blob plus AST semantic proof, while top-level data execution, opaque or dynamic execution remains hard denied.",
+  "authorizationRule": "No migration may move or replace the protected physical family, remove its historical authenticated contract, weaken a protected api LCA facade, or grant non-service access to internal/target objects until static, runtime, and owner evidence satisfy the gate. Target-neutral non-executing static migrations remain allowed. An additive service-only api facade or the exact cmd_lca_reconcile_result_cache_v1(uuid,uuid) service-only replacement requires its own exact reviewed blob plus AST semantic proof; top-level data execution and opaque or dynamic execution remain hard denied.",
   "sqlParser": {
     "name": "pglast",
     "version": "8.4",
@@ -20,12 +20,17 @@
   "migrationGate": {
     "baseMigrationBlobsImmutable": true,
     "committedMigrationHistoryAppendOnly": true,
-    "newMigrationsAllowed": "target-neutral-static-or-reviewed-ast-facade",
+    "newMigrationsAllowed": "target-neutral-static-or-reviewed-ast-facade-operation",
     "allowedTargetTouchingMigrations": [
       {
         "path": "supabase/migrations/20260802172930_issue_390_result_api_facade_v1.sql",
         "gitBlob": "6b183aa2b92d6d5457207f712d70e4855a7a394d",
         "classification": "additive-api-service-only-reviewed"
+      },
+      {
+        "path": "supabase/migrations/20260802190427_issue_395_reconcile_cancelled_worker_cache.sql",
+        "gitBlob": "435fd3c8e541b85aea497f79e61c2cd0c99010ae",
+        "classification": "reconcile-v1-service-only-replacement-reviewed"
       }
     ],
     "relationMovingDdlAllowed": false,

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-03
-lastReviewedCommit: 2cb88b079a8e50f7630378b9f565739c4144df60
-lastReviewedNote: "Reviewed for Issue #376 CI repair: qualification-runner manifest evidence and credential-free command examples do not change generated workspace ownership, refresh semantics, or deployment boundaries."
+lastReviewedCommit: 4dbea4a0ee7102a07b68613628e56022a37a5cf0
+lastReviewedNote: "Reviewed for Issue #395: the forward-only result facade replacement does not change generated workspace ownership, refresh semantics, or deployment boundaries."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-03
-lastReviewedCommit: 2cb88b079a8e50f7630378b9f565739c4144df60
-lastReviewedNote: "已为 Issue #376 CI 修复复核：qualification runner 的 manifest evidence 与无凭证命令示例不改变生成 workspace 的所有权、刷新语义或部署边界。"
+lastReviewedCommit: 4dbea4a0ee7102a07b68613628e56022a37a5cf0
+lastReviewedNote: "已为 Issue #395 复核：result facade 的前向替换不改变生成 workspace 的所有权、刷新语义或部署边界。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## 摘要

- 新增 forward-only migration `20260802190427_issue_395_reconcile_cancelled_worker_cache.sql`，仅将 Worker `cancelled` 纳入 `api.cmd_lca_reconcile_result_cache_v1` 的 terminal→cache `failed` 映射。
- 保持 8 个 facade、exact signature、service-only ACL、SECURITY INVOKER、空 search_path、job/result identity 和 JSON envelope 不变。
- 扩展 pre-DDL replacement gate、pgTAP、真实 Data API/并发 runtime、合同清单和当前验证文档。

## 关键语义

- active cache 每个请求仍只执行一次 reconcile；不在 Edge 同请求叠加 touch/admit。
- cancelled 首次 poll 原子收敛为 failed、hit_count +1；下一次 poll enqueue 后 admit，清理旧 result/error binding 并再 +1。
- foreign owner、cache/job not found 和 projection failure 无 cache 副作用。

## 验证

- 两次 fresh reset；migration ledger head `20260802190427`。
- canonical-local：69 个 SQL 文件、2232 个 pgTAP，全部通过。
- #395 pgTAP：16/16。
- loopback Data API：8 路并发 cancelled reconcile→failed，identity 保持、hit=8；retry accepted/pending/rebound、hit=9。
- runtime unit 6/6；pre-DDL + manifest unit 51/51。
- Worker/Data API/identity concurrency、lint、catalog、schema-phase、inventory、SECURITY DEFINER、Docpact gates 全部通过。
- migration git blob：`435fd3c8e541b85aea497f79e61c2cd0c99010ae`。

## 风险与发布

- 不新增 facade/查询，不移动 relation，不触碰 production。
- 合并后由 Supabase Dev workflow 应用到 persistent Dev；Edge #258 再绑定 exact merge SHA/head 执行真实合同测试。

Closes #395
Refs tiangong-lca/workspace#484
Refs linancn/tiangong-lca-edge-functions#258