### PR TITLE
fix: 对齐静态 SQL SECURITY DEFINER canonical 门禁

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,9 +20,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-03
-lastReviewedCommit: c5356d2b0d340f9c5c31a645479be5f3d19a52db
-lastReviewedNote: "Reviewed for Issue #405: exact-head inventory refresh and comparison require explicit loopback URLs, emit no DDL, and cannot authorize Contract."
+lastReviewedAt: 2026-08-04
+lastReviewedCommit: 269ef181e103bf57a7e15c6e82f5291005f33ded
+lastReviewedNote: "Reviewed for Issue #412: target-neutral internal static SQL SECURITY DEFINER admission is structural and does not use business-specific allowlists."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -363,6 +363,15 @@ remain protected from later replacement, privilege, and security-mode changes.
 HEAD, index, and worktree each use their own contract revision. The gate
 never treats one zero-match query as burn-in. The canonical manifest-contract
 module imports this test case, so existing CI runs it without a second workflow.
+
+The target-neutral rule for an internal `SECURITY DEFINER` is structural, not
+an allowlist. It accepts only an explicitly internal-schema `LANGUAGE SQL`
+function whose body parses completely, whose relation dependencies are
+schema-qualified, and whose only function-level path is exactly
+`pg_catalog, pg_temp`. Exposed-schema functions, procedural or dynamic bodies,
+unqualified relations, duplicate or reordered path settings, and paths that
+contain another schema remain hard denied. The rule never inspects an Issue
+number, migration path, function name, Git blob, or classification.
 
 ### `issue_390_physical_qualification.py`
 

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-03
-lastReviewedCommit: c5356d2b0d340f9c5c31a645479be5f3d19a52db
-lastReviewedNote: "已为 Issue #405 复核：exact-head inventory 刷新与对比只接受显式 loopback URL，不生成 DDL，也不授权 Contract。"
+lastReviewedAt: 2026-08-04
+lastReviewedCommit: 269ef181e103bf57a7e15c6e82f5291005f33ded
+lastReviewedNote: "已为 Issue #412 复核：target-neutral 内部静态 SQL SECURITY DEFINER 准入采用结构规则，不使用业务专属 allowlist。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -344,6 +344,13 @@ custom type/access method、trigger/rule 状态变更，以及 migration identit
 mode 弱化。HEAD、index 与 worktree
 分别读取各自版本的合同。单次日志零命中也不构成 burn-in。canonical
 manifest contract 会导入该 test case，因此沿用既有 CI 而不新增第二条 workflow。
+
+内部 `SECURITY DEFINER` 的 target-neutral 准入是结构规则，不是 allowlist。
+它只接受显式位于内部 schema 的 `LANGUAGE SQL` 函数，且函数体必须完整解析、
+relation 依赖必须 schema-qualified、唯一的函数级路径必须精确等于
+`pg_catalog, pg_temp`。exposed-schema 函数、过程式或动态 body、未限定 relation、
+重复或反序的路径设置，以及包含其他 schema 的路径继续 hard deny。规则不读取
+Issue 编号、migration 路径、函数名、Git blob 或 classification。
 
 ### `issue_390_physical_qualification.py`
 

--- a/scripts/issue_390_pre_ddl_gate.py
+++ b/scripts/issue_390_pre_ddl_gate.py
@@ -536,6 +536,134 @@ def _scalar_strings(value: object) -> Iterator[str]:
             yield from _scalar_strings(child)
 
 
+def _search_path_tokens(value: object) -> list[str] | None:
+    setting = value.get("VariableSetStmt", {}) if isinstance(value, dict) else {}
+    if setting.get("name") != "search_path":
+        return None
+    return [
+        token.strip()
+        for scalar in _scalar_strings(setting.get("args", []))
+        for token in scalar.split(",")
+        if token.strip()
+    ]
+
+
+def _is_trusted_internal_static_sql_definer(statement: dict) -> bool:
+    if len(_function_name(statement)) != 2:
+        return False
+    if _function_name(statement)[0] not in INTERNAL_SCHEMAS:
+        return False
+    languages = [
+        value.get("String", {}).get("sval")
+        for value in _function_option_values(statement, "language")
+    ]
+    securities = [
+        value.get("Boolean", {}).get("boolval")
+        for value in _function_option_values(statement, "security")
+    ]
+    set_values = _function_option_values(statement, "set")
+    search_paths = [_search_path_tokens(value) for value in set_values]
+    return (
+        languages == ["sql"]
+        and securities == [True]
+        and search_paths == [["pg_catalog", "pg_temp"]]
+        and len(_function_body_strings(statement)) == 1
+    )
+
+
+def _static_sql_relation_qualification_violations(
+    value: object,
+    inherited_ctes: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Reject unqualified relations while preserving lexical CTE visibility."""
+
+    violations = []
+    if isinstance(value, list):
+        for child in value:
+            violations.extend(
+                _static_sql_relation_qualification_violations(
+                    child, inherited_ctes
+                )
+            )
+        return violations
+    if not isinstance(value, dict):
+        return violations
+
+    statement_wrapper = next(
+        (
+            node
+            for node_type, node in value.items()
+            if node_type.endswith("Stmt") and isinstance(node, dict)
+        ),
+        None,
+    )
+    if statement_wrapper is not None:
+        with_clause = _direct_with_clause(statement_wrapper)
+        if with_clause.get("recursive"):
+            violations.append(
+                "hard-deny:static-sql-definer-recursive-cte"
+            )
+        visible_ctes = inherited_ctes
+        for item in with_clause.get("ctes", []):
+            cte = item.get("CommonTableExpr", {}) if isinstance(item, dict) else {}
+            violations.extend(
+                _static_sql_relation_qualification_violations(
+                    cte.get("ctequery", {}), visible_ctes
+                )
+            )
+            if isinstance(cte.get("ctename"), str):
+                visible_ctes = visible_ctes | {cte["ctename"]}
+        for key, child in statement_wrapper.items():
+            if key != "withClause":
+                violations.extend(
+                    _static_sql_relation_qualification_violations(
+                        child, visible_ctes
+                    )
+                )
+        return violations
+
+    relation = value.get("RangeVar") if isinstance(value.get("RangeVar"), dict) else None
+    if relation is not None:
+        parts = [
+            part
+            for part in (relation.get("schemaname"), relation.get("relname"))
+            if isinstance(part, str)
+        ]
+        if not (
+            len(parts) == 2
+            or (len(parts) == 1 and parts[0] in inherited_ctes)
+        ):
+            violations.append(
+                "hard-deny:static-sql-definer-unqualified-relation:"
+                + ".".join(parts)
+            )
+        return violations
+
+    if isinstance(value.get("relname"), str):
+        parts = [
+            part
+            for part in (value.get("schemaname"), value.get("relname"))
+            if isinstance(part, str)
+        ]
+        if not (
+            len(parts) == 2
+            or (len(parts) == 1 and parts[0] in inherited_ctes)
+        ):
+            violations.append(
+                "hard-deny:static-sql-definer-unqualified-relation:"
+                + ".".join(parts)
+            )
+        return violations
+
+    for child in value.values():
+        violations.extend(
+            _static_sql_relation_qualification_violations(
+                child, inherited_ctes
+            )
+        )
+    return violations
+
+
 def _contains_scalar(value: object, expected: object) -> bool:
     if value == expected:
         return True
@@ -873,13 +1001,16 @@ def _statement_signals(statement: dict, *, top_level: bool = True) -> list[str]:
         if setting_name == "default_table_access_method":
             signals.append("hard-deny:default-table-access-method-change")
         if setting.get("name") == "search_path":
-            search_path = {
-                token.strip()
-                for value in _scalar_strings(setting.get("args", []))
-                for token in value.split(",")
-                if token.strip()
-            }
-            if not search_path <= {"pg_catalog"}:
+            search_path = _search_path_tokens(
+                {"VariableSetStmt": setting}
+            ) or []
+            if (
+                search_path not in ([], ["pg_catalog"])
+                and not (
+                    root_type == "CreateFunctionStmt"
+                    and _is_trusted_internal_static_sql_definer(root)
+                )
+            ):
                 signals.append("hard-deny:untrusted-search-path")
         if setting_name == "pgrst.db_schemas":
             exposed = [
@@ -1039,6 +1170,12 @@ def _statement_signals(statement: dict, *, top_level: bool = True) -> list[str]:
             signals.extend(errors)
             for nested_statement in nested:
                 signals.extend(_statement_signals(nested_statement, top_level=False))
+                if _is_trusted_internal_static_sql_definer(root):
+                    signals.extend(
+                        _static_sql_relation_qualification_violations(
+                            nested_statement
+                        )
+                    )
                 if len(name) == 2 and name[0] in EXPOSED_SCHEMAS:
                     signals.extend(
                         _api_internal_reference_violations(nested_statement)

--- a/scripts/test_issue_390_pre_ddl_gate.py
+++ b/scripts/test_issue_390_pre_ddl_gate.py
@@ -209,6 +209,7 @@ class Issue390PreDdlGateTest(unittest.TestCase):
             "CREATE VIEW api.unrelated_receipts WITH (security_invoker=true) AS SELECT id FROM public.processes;",
             "CREATE SCHEMA unrelated_owned AUTHORIZATION postgres;",
             "CREATE FUNCTION api.unrelated_constant() RETURNS pg_catalog.int4 LANGUAGE sql SECURITY INVOKER SET search_path='' AS $$ SELECT 1 $$;",
+            "CREATE FUNCTION private.record_internal_event(p_id pg_catalog.uuid) RETURNS pg_catalog.uuid LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,pg_temp AS $$ WITH payload AS (SELECT p_id AS id) INSERT INTO public.internal_event_log(id) SELECT id FROM payload RETURNING id $$;",
         ]
         for sql in allowed:
             self.assertEqual(pre_ddl_sql_signals(sql), [], sql)
@@ -236,6 +237,11 @@ class Issue390PreDdlGateTest(unittest.TestCase):
             'ALTER TABLE public.U&"lca\\005fresults" SET SCHEMA private;',
             "DO $$ BEGIN EXECUTE 'ALTER ' || 'TABLE ' || 'public.' || 'lca_' || 'results SET SCHEMA private'; END $$;",
             "SELECT format('ALTER TABLE %I.%I SET SCHEMA private', 'public', 'lca_results') \\gexec;",
+            "CREATE FUNCTION private.bad_path_order() RETURNS pg_catalog.int4 LANGUAGE sql SECURITY DEFINER SET search_path=pg_temp,pg_catalog AS $$ SELECT 1 $$;",
+            "CREATE FUNCTION private.bad_path_schema() RETURNS pg_catalog.int4 LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,public,pg_temp AS $$ SELECT 1 $$;",
+            "CREATE FUNCTION public.exposed_definer() RETURNS pg_catalog.int4 LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,pg_temp AS $$ SELECT 1 $$;",
+            "CREATE FUNCTION private.opaque_definer() RETURNS pg_catalog.int4 LANGUAGE plpgsql SECURITY DEFINER SET search_path=pg_catalog,pg_temp AS $$ BEGIN RETURN 1; END $$;",
+            "CREATE FUNCTION private.unqualified_definer() RETURNS SETOF pg_catalog.uuid LANGUAGE sql SECURITY DEFINER SET search_path=pg_catalog,pg_temp AS $$ SELECT id FROM internal_event_log $$;",
         ]
         for sql in guarded:
             self.assertNotEqual(pre_ddl_sql_signals(sql), [], sql)


### PR DESCRIPTION
Closes tiangong-lca/database-engine#412

## Summary
- 为内部 schema 的静态 SQL SECURITY DEFINER 建立与业务无关的 canonical 准入规则。
- 保持公开 schema、过程语言、动态 SQL、错误 search_path 和非限定依赖继续 fail closed。

## Key Decisions
- 仅接受精确 search_path = pg_catalog, pg_temp、函数体可完整解析且关系引用均已 schema-qualified 的内部 LANGUAGE SQL 函数。
- 不使用 Issue、migration 路径、函数名、blob 哈希或 classification 专属绿色通道。

## Validation
- python -m unittest scripts.test_issue_390_pre_ddl_gate scripts.test_database_contract_manifest scripts.test_public_inventory_exact_head：116 项通过。
- Fresh reset 与 70 个 SQL 文件、2292 项 pgTAP 通过；并发校验 8 sessions / 800 calls 通过。
- SECURITY DEFINER v1/v2、schema boundary、public inventory、catalog export、Docpact 严格校验通过。

## Risks / Rollback
- 规则仅扩展到可静态证明安全的内部 SQL 函数；回滚可撤销本提交，恢复此前 fail-closed 行为。

## Follow-ups
- Issue #323 的通知修复以本 PR 分支为临时基线；本 PR 合并后将其 base 切回 dev。

## Workspace Integration
- routine PR 合入 database-engine/dev；后续经 dev -> main promote 后才可进入 workspace 根集成。