### PR TITLE
chore: 重新绑定持久 Supabase Dev 分支

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-02"
-lastReviewedCommit: "1ff6d2775bed146379d50dc91eaf43c7915dca0f"
-lastReviewedNote: "Reviewed for Issue #323: the existing migration and SQL-test routing covers the additive Root/Reference Review v2 grouped-queue RPCs and focused regression proof without changing governance rules."
+lastReviewedAt: "2026-08-05"
+lastReviewedCommit: "f7e0e6fbe3b83cf57bbdae8d3d07ebb683d68a8e"
+lastReviewedNote: "Reviewed for Issue #418: recreating the persistent Supabase dev branch changes only its concrete project binding; existing ownership, routing, deployment, and validation rules remain unchanged."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 1ff6d2775bed146379d50dc91eaf43c7915dca0f
-lastReviewedNote: "Reviewed for Issue #323: repository ownership, additive migration discipline, local database proof, dev-branch delivery, and later workspace integration already govern the root-grouped review queue change; no contract rule changes are required."
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: f7e0e6fbe3b83cf57bbdae8d3d07ebb683d68a8e
+lastReviewedNote: "Reviewed for Issue #418: the persistent Supabase dev branch was recreated after the rollback; repository ownership, dev-first delivery, migration source-of-truth, and workspace integration rules remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 1ff6d2775bed146379d50dc91eaf43c7915dca0f
-lastReviewedNote: "Reviewed for Issue #323: the additive root-grouped queue RPCs stay within the existing Root/Reference Review v2 database boundary and do not change the repository shape or cross-repo ownership."
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: f7e0e6fbe3b83cf57bbdae8d3d07ebb683d68a8e
+lastReviewedNote: "Reviewed for Issue #418: replacing the concrete persistent-dev project binding does not change stable path ownership, generated workspace boundaries, or repository shape."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-02
-lastReviewedCommit: 1ff6d2775bed146379d50dc91eaf43c7915dca0f
-lastReviewedNote: "Reviewed for Issue #323: local fresh-stack reset plus the Root/Reference Review v2 and root-grouped queue pgTAP suites remain the minimum proof; hosted Preview and persistent-dev proof stay deferred to deployment."
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: f7e0e6fbe3b83cf57bbdae8d3d07ebb683d68a8e
+lastReviewedNote: "Reviewed for Issue #418: the persistent-dev rebind still requires exact branch identity, migration deployment, and hosted readback proof; the validation matrix itself is unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,9 +20,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-07-29
-lastReviewedCommit: 6577b7a48f90ae449cbdd2ef419d92d13c273a0c
-lastReviewedNote: "Reviewed Issue #308 rollout follow-up: the additive publication/GC migration reapplies final guards and RPCs so an existing Preview can advance even when earlier PR migrations were already recorded."
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: f7e0e6fbe3b83cf57bbdae8d3d07ebb683d68a8e
+lastReviewedNote: "Reviewed for Issue #418: recreating persistent dev requires updating its project ref and database credential before redeployment; the Git dev to persistent-dev workflow and promotion rules remain unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -20,8 +20,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-05-18
-lastReviewedCommit: 9b0c7f2d41057d9eecf2fa0adad2a9055ca8ee32
+lastReviewedAt: 2026-08-05
+lastReviewedCommit: f7e0e6fbe3b83cf57bbdae8d3d07ebb683d68a8e
+lastReviewedNote: "已为 Issue #418 复核：重建持久 dev 后必须更新 project ref 与数据库凭据再部署；Git dev 到持久 dev 的工作流及 promote 规则不变。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -422,7 +422,7 @@ s3_secret_key = "env(S3_SECRET_KEY)"
 # Keep this project ref synchronized with the actual persistent `dev` branch returned by
 # `npx supabase --experimental branches list --project-ref qgzvkongdjqiiamzbbts`.
 [remotes.dev]
-project_id = "fotofiyqnuyvgtotswie"
+project_id = "submidrhbtknjxfympna"
 
 [remotes.dev.auth]
 site_url = "http://localhost:8000"


### PR DESCRIPTION
Refs #418

## 概要
- 将 `supabase/config.toml` 的 `[remotes.dev]` 绑定更新为回滚后新建的持久 Dev project ref。
- 同步复核 Docpact、仓库契约、验证指南、架构说明及中英文 Supabase branching 文档；分支模型与部署规则不变。

## 背景
PR #419 合并后，旧持久 Dev 因 migration ledger 仍包含已回滚 migration 而无法通过 `db push`。已按 Issue #418 的既定计划删除旧实例并创建无生产数据的新持久 Dev。该 ref 只有在实例创建后才能确定，因此需要此最小绑定 PR。

## 验证
- 新 branch identity：名称 `dev`、persistent=true、with_data=false、实例 `ACTIVE_HEALTHY`。
- `supabase/config.toml` TOML 解析及 project ref 精确断言通过。
- GitHub `SUPABASE_DEV_PROJECT_ID` variable 与数据库密码 secret 已同步至新实例。
- `./scripts/docpact-gate.sh --base origin/dev` 通过。
- `git diff --check origin/dev...HEAD` 通过。

## 部署与验证
本 PR 合并到 `dev` 后，由唯一的 `Supabase Dev` workflow 对新实例运行 `supabase db push --include-all`。随后在 Issue #418 下记录 migration head、数据库 catalog 与目标 pgTAP 验证，再关闭 Issue。

## 风险与回滚
- Dev 在部署完成前短时不可用，已在父任务 workspace#550 中批准。
- 如部署失败，不修补 migration ledger；修复 Git/source binding 后继续重建或重新部署新 Dev。