### PR TITLE
fix: 恢复 Schema cutover 运行时 ACL

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-07"
-lastReviewedCommit: "0a97cc761f8127ca379ab7d4df4395dab255707a"
+lastReviewedCommit: "c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8"
 lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: existing migration/test ownership and exact capability-grant governance cover the authenticated RLS helpers and Edge release facades without new rules."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-07"
-lastReviewedCommit: "096c44d36e35579de5d59f6a0d983fbff86bcef9"
-lastReviewedNote: "Reviewed for Issue #422 Edge consumer closure: Data Product/TIDAS facades, the lifecycle review-admin predicate, exact ACLs, upgrade proof, and generated types remain governed together."
+lastReviewedCommit: "0a97cc761f8127ca379ab7d4df4395dab255707a"
+lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: existing migration/test ownership and exact capability-grant governance cover the authenticated RLS helpers and Edge release facades without new rules."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
 lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: the existing repo ownership, dev-first delivery, least-privilege API manifest, and local-to-hosted proof boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 8b956d03165792b1b0890318bea021a18f7284b7
-lastReviewedNote: "Reviewed for Issue #422 Edge consumer closure: Data Product/TIDAS facades, the lifecycle review-admin predicate, exact API privileges, upgrade proof, and generated types remain one governed contract."
+lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: the existing repo ownership, dev-first delivery, least-privilege API manifest, and local-to-hosted proof boundaries remain unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
 lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: manifest-first grants preserve the existing public/api/private boundary and require no architecture change."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,8 +28,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 8b956d03165792b1b0890318bea021a18f7284b7
-lastReviewedNote: "Reviewed for Issue #422 Edge consumer closure: Data Product/TIDAS facades and the lifecycle review-admin predicate preserve the public/private boundary."
+lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: manifest-first grants preserve the existing public/api/private boundary and require no architecture change."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
 lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: the existing schema-cutover, exact-ACL, release-control-plane, and targeted pgTAP proof layers remain sufficient."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 8b956d03165792b1b0890318bea021a18f7284b7
-lastReviewedNote: "Reviewed for Issue #422 Edge consumer closure: add Data Product/TIDAS and lifecycle authorization facade behavior, ACL, upgrade, and generated-type proof."
+lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: the existing schema-cutover, exact-ACL, release-control-plane, and targeted pgTAP proof layers remain sufficient."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
 lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: populated upgrade validation now covers exact authenticated RLS-helper and Edge release facade grants."
 related:
   - ../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 8b956d03165792b1b0890318bea021a18f7284b7
-lastReviewedNote: "Reviewed for Issue #422 Edge consumer closure: include Data Product facade installation in populated upgrade validation and generated public/api types."
+lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: populated upgrade validation now covers exact authenticated RLS-helper and Edge release facade grants."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -55,7 +55,9 @@ routine identities plus trigger, RLS-policy, constraint, and exact row-count
 state, applies the cutover and contract-closure migrations, and verifies
 complete preservation, capability-manifest installation, idempotency-index
 creation, Data Product consumer-facade installation, and removal of PostgreSQL
-`PUBLIC` execution from the API surface.
+`PUBLIC` execution from the API surface. It also applies the Issue #422 runtime
+ACL repair and verifies the exact authenticated RLS-helper and Edge release
+façade grants after a populated upgrade.
 
 Usage:
 

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 8b956d03165792b1b0890318bea021a18f7284b7
-lastReviewedNote: "已为 Issue #422 Edge 消费者收口复核：升级验证纳入 Data Product façade，并同步生成 public/api 类型。"
+lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedNote: "已为 Issue #422 运行时 ACL 修复复核：有数据升级验证现覆盖 authenticated RLS helper 与 Edge release façade 的精确授权。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -52,7 +52,9 @@ related:
 把本地数据库重建到全量 Schema 切换前的最后一个 migration，写入一条代表性业务数据，
 快照关系与函数身份、触发器、RLS 策略、约束及精确行数，再应用切换与契约收口
 migration，验证对象和数据完整保留、能力清单、幂等索引及 Data Product 消费者 façade
-已安装，并确认 API 函数不再向 PostgreSQL `PUBLIC` 角色开放执行权限。
+已安装，并确认 API 函数不再向 PostgreSQL `PUBLIC` 角色开放执行权限。脚本还会应用
+Issue #422 运行时 ACL 修复，并在有数据升级后校验 authenticated RLS helper 与 Edge
+release façade 的精确授权。
 
 用法：
 

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
 lastReviewedNote: "已为 Issue #422 运行时 ACL 修复复核：有数据升级验证现覆盖 authenticated RLS helper 与 Edge release façade 的精确授权。"
 related:
   - ../AGENTS.md

--- a/scripts/test_full_schema_cutover_upgrade.sh
+++ b/scripts/test_full_schema_cutover_upgrade.sh
@@ -9,6 +9,7 @@ contract_migrations=(
 )
 drift_cleanup_migration="$repo_root/supabase/migrations/20260806230500_remove_recreated_public_routines.sql"
 consumer_facade_migration="$repo_root/supabase/migrations/20260807103000_data_product_consumer_facades.sql"
+acl_runtime_repair_migration="$repo_root/supabase/migrations/20260807233000_issue_422_acl_runtime_repair.sql"
 database_url="$(
   supabase status --output env \
     | sed -n 's/^DB_URL="\([^"]*\)"$/\1/p'
@@ -332,6 +333,7 @@ SQL
 
 psql "$database_url" -v ON_ERROR_STOP=1 -f "$drift_cleanup_migration"
 psql "$database_url" -v ON_ERROR_STOP=1 -f "$consumer_facade_migration"
+psql "$database_url" -v ON_ERROR_STOP=1 -f "$acl_runtime_repair_migration"
 
 psql "$database_url" -v ON_ERROR_STOP=1 <<'SQL'
 do $verify_contract_closure_upgrade$
@@ -375,6 +377,42 @@ begin
      or pg_catalog.to_regprocedure('api.policy_roles_update(uuid,uuid,text)') is null
      or pg_catalog.to_regprocedure('private.update_modified_at()') is null then
     raise exception 'a canonical routine was lost during public drift cleanup';
+  end if;
+
+  if not pg_catalog.has_function_privilege(
+       'authenticated', 'api.policy_roles_select(uuid,text)', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'authenticated', 'api.policy_review_can_read(uuid,uuid)', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'anon', 'api.policy_roles_select(uuid,text)', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'service_role', 'api.policy_review_can_read(uuid,uuid)', 'EXECUTE'
+     ) then
+    raise exception 'authenticated RLS helper ACLs drifted after populated upgrade';
+  end if;
+
+  if not pg_catalog.has_function_privilege(
+       'authenticated', 'api.assert_lca_release_manager()', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'service_role', 'api.assert_lca_release_manager()', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'service_role', 'api.get_current_lca_release()', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'service_role', 'api.get_current_lca_release_process(uuid,text)', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'service_role', 'api.get_lca_release_artifact_download(uuid)', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'service_role', 'api.get_lca_release_run(uuid)', 'EXECUTE'
+     ) then
+    raise exception 'Edge release ACLs drifted after populated upgrade';
   end if;
 
   if exists (

--- a/supabase/migrations/20260807233000_issue_422_acl_runtime_repair.sql
+++ b/supabase/migrations/20260807233000_issue_422_acl_runtime_repair.sql
@@ -1,0 +1,212 @@
+begin;
+
+set local lock_timeout = '10s';
+set local statement_timeout = '2min';
+
+-- Issue #422 runtime repair. The contract-closure migration revoked every
+-- external api EXECUTE grant before rebuilding ACLs from this manifest. Keep
+-- the repair manifest-first so later exact-ACL checks cannot silently drift
+-- from the privileges required by Next RLS evaluation and Edge release reads.
+do $preflight$
+declare
+  missing_routines text[];
+begin
+  if session_user <> 'postgres' or current_user <> 'postgres' then
+    raise exception using
+      errcode = '42501',
+      message = 'Issue #422 ACL repair requires the postgres owner session';
+  end if;
+
+  if pg_catalog.to_regclass('private.api_capability_grants') is null then
+    raise exception using
+      errcode = '42P01',
+      message = 'Issue #422 capability grant manifest is missing';
+  end if;
+
+  select pg_catalog.array_agg(identity order by identity)
+  into missing_routines
+  from pg_catalog.unnest(array[
+    'api.policy_roles_select(uuid,text)',
+    'api.policy_review_can_read(uuid,uuid)',
+    'api.assert_lca_release_manager()',
+    'api.get_current_lca_release()',
+    'api.get_current_lca_release_process(uuid,text)',
+    'api.get_lca_release_artifact_download(uuid)',
+    'api.get_lca_release_run(uuid)'
+  ]::text[]) as required(identity)
+  where pg_catalog.to_regprocedure(identity) is null;
+
+  if missing_routines is not null then
+    raise exception using
+      errcode = '42883',
+      message = 'Issue #422 ACL repair routines are missing',
+      detail = pg_catalog.array_to_string(missing_routines, ', ');
+  end if;
+end
+$preflight$;
+
+insert into private.api_capability_grants (
+  routine_identity,
+  capability_id,
+  allow_anon,
+  allow_authenticated,
+  allow_service_role
+)
+select
+  pg_catalog.format(
+    '%I.%I(%s)',
+    namespace.nspname,
+    routine.proname,
+    pg_catalog.oidvectortypes(routine.proargtypes)
+  ),
+  required.capability_id,
+  required.allow_anon,
+  required.allow_authenticated,
+  required.allow_service_role
+from (
+  values
+    ('api.policy_roles_select(uuid,text)', 'NX-CORE-01', false, true, false),
+    ('api.policy_review_can_read(uuid,uuid)', 'NX-REV-01', false, true, false),
+    ('api.assert_lca_release_manager()', 'EDGE-REL-01', false, true, false),
+    ('api.get_current_lca_release()', 'EDGE-REL-01', true, true, true),
+    ('api.get_current_lca_release_process(uuid,text)', 'EDGE-REL-01', true, true, true),
+    ('api.get_lca_release_artifact_download(uuid)', 'EDGE-REL-01', false, true, true),
+    ('api.get_lca_release_run(uuid)', 'EDGE-REL-01', false, true, true)
+) as required(identity, capability_id, allow_anon, allow_authenticated, allow_service_role)
+join pg_catalog.pg_proc as routine
+  on routine.oid = pg_catalog.to_regprocedure(required.identity)
+join pg_catalog.pg_namespace as namespace
+  on namespace.oid = routine.pronamespace
+on conflict (routine_identity) do update set
+  capability_id = excluded.capability_id,
+  allow_anon = excluded.allow_anon,
+  allow_authenticated = excluded.allow_authenticated,
+  allow_service_role = excluded.allow_service_role;
+
+-- Rebuild these seven ACLs exactly instead of only layering grants over an
+-- unknown state. PUBLIC remains closed and every role gets only its declared
+-- capability.
+revoke execute on function api.policy_roles_select(uuid, text)
+  from public, anon, authenticated, service_role;
+grant execute on function api.policy_roles_select(uuid, text)
+  to authenticated;
+
+revoke execute on function api.policy_review_can_read(uuid, uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function api.policy_review_can_read(uuid, uuid)
+  to authenticated;
+
+revoke execute on function api.assert_lca_release_manager()
+  from public, anon, authenticated, service_role;
+grant execute on function api.assert_lca_release_manager()
+  to authenticated;
+
+revoke execute on function api.get_current_lca_release()
+  from public, anon, authenticated, service_role;
+grant execute on function api.get_current_lca_release()
+  to anon, authenticated, service_role;
+
+revoke execute on function api.get_current_lca_release_process(uuid, text)
+  from public, anon, authenticated, service_role;
+grant execute on function api.get_current_lca_release_process(uuid, text)
+  to anon, authenticated, service_role;
+
+revoke execute on function api.get_lca_release_artifact_download(uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function api.get_lca_release_artifact_download(uuid)
+  to authenticated, service_role;
+
+revoke execute on function api.get_lca_release_run(uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function api.get_lca_release_run(uuid)
+  to authenticated, service_role;
+
+do $postcondition$
+declare
+  mismatch_count integer;
+begin
+  select pg_catalog.count(*)
+  into mismatch_count
+  from (
+    values
+      ('api.policy_roles_select(uuid,text)', 'NX-CORE-01', false, true, false),
+      ('api.policy_review_can_read(uuid,uuid)', 'NX-REV-01', false, true, false),
+      ('api.assert_lca_release_manager()', 'EDGE-REL-01', false, true, false),
+      ('api.get_current_lca_release()', 'EDGE-REL-01', true, true, true),
+      ('api.get_current_lca_release_process(uuid,text)', 'EDGE-REL-01', true, true, true),
+      ('api.get_lca_release_artifact_download(uuid)', 'EDGE-REL-01', false, true, true),
+      ('api.get_lca_release_run(uuid)', 'EDGE-REL-01', false, true, true)
+  ) as expected(identity, capability_id, allow_anon, allow_authenticated, allow_service_role)
+  join pg_catalog.pg_proc as routine
+    on routine.oid = pg_catalog.to_regprocedure(expected.identity)
+  join pg_catalog.pg_namespace as namespace
+    on namespace.oid = routine.pronamespace
+  left join private.api_capability_grants as manifest
+    on manifest.routine_identity = pg_catalog.format(
+      '%I.%I(%s)',
+      namespace.nspname,
+      routine.proname,
+      pg_catalog.oidvectortypes(routine.proargtypes)
+    )
+  where manifest.capability_id is distinct from expected.capability_id
+     or manifest.allow_anon is distinct from expected.allow_anon
+     or manifest.allow_authenticated is distinct from expected.allow_authenticated
+     or manifest.allow_service_role is distinct from expected.allow_service_role;
+
+  if mismatch_count <> 0 then
+    raise exception 'Issue #422 capability manifest postcondition failed: % rows', mismatch_count;
+  end if;
+
+  if not pg_catalog.has_function_privilege(
+       'authenticated', 'api.policy_roles_select(uuid,text)', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'anon', 'api.policy_roles_select(uuid,text)', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'service_role', 'api.policy_roles_select(uuid,text)', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'authenticated', 'api.policy_review_can_read(uuid,uuid)', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'anon', 'api.policy_review_can_read(uuid,uuid)', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'service_role', 'api.policy_review_can_read(uuid,uuid)', 'EXECUTE'
+     ) then
+    raise exception 'Issue #422 RLS helper ACL postcondition failed';
+  end if;
+
+  if not pg_catalog.has_function_privilege(
+       'authenticated', 'api.assert_lca_release_manager()', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'anon', 'api.assert_lca_release_manager()', 'EXECUTE'
+     )
+     or pg_catalog.has_function_privilege(
+       'service_role', 'api.assert_lca_release_manager()', 'EXECUTE'
+     ) then
+    raise exception 'Issue #422 release manager assertion ACL postcondition failed';
+  end if;
+
+  if not pg_catalog.has_function_privilege(
+       'service_role', 'api.get_current_lca_release()', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'service_role', 'api.get_current_lca_release_process(uuid,text)', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'service_role', 'api.get_lca_release_artifact_download(uuid)', 'EXECUTE'
+     )
+     or not pg_catalog.has_function_privilege(
+       'service_role', 'api.get_lca_release_run(uuid)', 'EXECUTE'
+     ) then
+    raise exception 'Issue #422 Edge release ACL postcondition failed';
+  end if;
+end
+$postcondition$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/tests/20260716_lci_lcia_release_control_plane.sql
+++ b/supabase/tests/20260716_lci_lcia_release_control_plane.sql
@@ -291,6 +291,14 @@ as $$
   )
 $$;
 
+-- The schema cutover closes postgres-owned function EXECUTE by default. These
+-- helpers are transaction-local test fixtures, so grant only the two roles
+-- that evaluate their payloads below.
+grant execute on function pg_temp.release_publish_plan() to authenticated;
+grant execute on function pg_temp.report_ref(text) to service_role;
+grant execute on function pg_temp.release_manifest() to service_role;
+grant execute on function pg_temp.uploaded_artifacts() to service_role;
+
 set local role authenticated;
 select set_config('request.jwt.claim.role', 'authenticated', true);
 select set_config('request.jwt.claims', '{"role":"authenticated"}', true);
@@ -640,11 +648,17 @@ select is(
   'release_process_not_found',
   'process projection has an explicit legacy or out-of-scope empty state'
 );
+
+set local role service_role;
+select set_config('request.jwt.claim.role', 'service_role', true);
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+select set_config('request.jwt.claim.sub', '', true);
+
 select ok(
   (api.get_lca_release_artifact_download(
     (select id from release_test_receipts where label = 'download_artifact')
   )->'data'->>'public')::boolean,
-  'published artifact is eligible for Edge signed download'
+  'published artifact is eligible for Edge service-mediated signed download'
 );
 
 set local role authenticated;

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260807103000'::text,
+  '20260807233000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260807_issue_422_acl_runtime_repair.sql
+++ b/supabase/tests/20260807_issue_422_acl_runtime_repair.sql
@@ -1,0 +1,177 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, api, private, auth;
+
+select plan(15);
+
+select is(
+  (
+    select jsonb_object_agg(
+      manifest.routine_identity,
+      jsonb_build_object(
+        'capabilityId', manifest.capability_id,
+        'anon', manifest.allow_anon,
+        'authenticated', manifest.allow_authenticated,
+        'serviceRole', manifest.allow_service_role
+      )
+      order by manifest.routine_identity
+    )
+    from private.api_capability_grants as manifest
+    where manifest.routine_identity in (
+      select pg_catalog.format(
+        '%I.%I(%s)',
+        namespace.nspname,
+        routine.proname,
+        pg_catalog.oidvectortypes(routine.proargtypes)
+      )
+      from pg_catalog.pg_proc as routine
+      join pg_catalog.pg_namespace as namespace on namespace.oid = routine.pronamespace
+      where routine.oid = any(array[
+        'api.policy_roles_select(uuid,text)'::regprocedure,
+        'api.policy_review_can_read(uuid,uuid)'::regprocedure,
+        'api.assert_lca_release_manager()'::regprocedure,
+        'api.get_current_lca_release()'::regprocedure,
+        'api.get_current_lca_release_process(uuid,text)'::regprocedure,
+        'api.get_lca_release_artifact_download(uuid)'::regprocedure,
+        'api.get_lca_release_run(uuid)'::regprocedure
+      ]::oid[])
+    )
+  ),
+  jsonb_build_object(
+    'api.assert_lca_release_manager()',
+      jsonb_build_object('capabilityId', 'EDGE-REL-01', 'anon', false, 'authenticated', true, 'serviceRole', false),
+    'api.get_current_lca_release()',
+      jsonb_build_object('capabilityId', 'EDGE-REL-01', 'anon', true, 'authenticated', true, 'serviceRole', true),
+    'api.get_current_lca_release_process(uuid, text)',
+      jsonb_build_object('capabilityId', 'EDGE-REL-01', 'anon', true, 'authenticated', true, 'serviceRole', true),
+    'api.get_lca_release_artifact_download(uuid)',
+      jsonb_build_object('capabilityId', 'EDGE-REL-01', 'anon', false, 'authenticated', true, 'serviceRole', true),
+    'api.get_lca_release_run(uuid)',
+      jsonb_build_object('capabilityId', 'EDGE-REL-01', 'anon', false, 'authenticated', true, 'serviceRole', true),
+    'api.policy_roles_select(uuid, text)',
+      jsonb_build_object('capabilityId', 'NX-CORE-01', 'anon', false, 'authenticated', true, 'serviceRole', false),
+    'api.policy_review_can_read(uuid, uuid)',
+      jsonb_build_object('capabilityId', 'NX-REV-01', 'anon', false, 'authenticated', true, 'serviceRole', false)
+  ),
+  'the exact capability manifest records the seven runtime ACL repairs'
+);
+
+select ok(
+  has_function_privilege('authenticated', 'api.policy_roles_select(uuid,text)', 'EXECUTE')
+    and not has_function_privilege('anon', 'api.policy_roles_select(uuid,text)', 'EXECUTE')
+    and not has_function_privilege('service_role', 'api.policy_roles_select(uuid,text)', 'EXECUTE')
+    and has_function_privilege('authenticated', 'api.policy_review_can_read(uuid,uuid)', 'EXECUTE')
+    and not has_function_privilege('anon', 'api.policy_review_can_read(uuid,uuid)', 'EXECUTE')
+    and not has_function_privilege('service_role', 'api.policy_review_can_read(uuid,uuid)', 'EXECUTE'),
+  'the roles and review RLS helpers are executable only by authenticated'
+);
+
+select ok(
+  has_function_privilege('service_role', 'api.get_current_lca_release()', 'EXECUTE')
+    and has_function_privilege('service_role', 'api.get_current_lca_release_process(uuid,text)', 'EXECUTE')
+    and has_function_privilege('service_role', 'api.get_lca_release_artifact_download(uuid)', 'EXECUTE')
+    and has_function_privilege('service_role', 'api.get_lca_release_run(uuid)', 'EXECUTE'),
+  'service role can execute all four Edge release read facades'
+);
+
+select ok(
+  has_function_privilege('anon', 'api.get_current_lca_release()', 'EXECUTE')
+    and has_function_privilege('anon', 'api.get_current_lca_release_process(uuid,text)', 'EXECUTE')
+    and not has_function_privilege('anon', 'api.get_lca_release_artifact_download(uuid)', 'EXECUTE')
+    and not has_function_privilege('anon', 'api.get_lca_release_run(uuid)', 'EXECUTE'),
+  'anonymous direct access remains limited to the two public projections'
+);
+
+select ok(
+  has_function_privilege('authenticated', 'api.assert_lca_release_manager()', 'EXECUTE')
+    and not has_function_privilege('anon', 'api.assert_lca_release_manager()', 'EXECUTE')
+    and not has_function_privilege('service_role', 'api.assert_lca_release_manager()', 'EXECUTE')
+    and has_function_privilege('authenticated', 'api.get_current_lca_release()', 'EXECUTE')
+    and has_function_privilege('authenticated', 'api.get_current_lca_release_process(uuid,text)', 'EXECUTE')
+    and has_function_privilege('authenticated', 'api.get_lca_release_artifact_download(uuid)', 'EXECUTE')
+    and has_function_privilege('authenticated', 'api.get_lca_release_run(uuid)', 'EXECUTE'),
+  'authenticated retains the manager assertion and all four release read facades'
+);
+
+set local role authenticated;
+select pg_catalog.set_config('request.jwt.claim.role', 'authenticated', true);
+select pg_catalog.set_config('request.jwt.claims', '{"role":"authenticated"}', true);
+select pg_catalog.set_config('request.jwt.claim.sub', '42270000-0000-4000-8000-000000000001', true);
+
+select lives_ok(
+  $$select api.policy_roles_select('42270000-0000-4000-8000-000000000010'::uuid, 'member')$$,
+  'authenticated can execute the roles policy helper under JWT context'
+);
+
+select lives_ok(
+  $$
+    select
+      (select count(*) from public.processes)
+      + (select count(*) from public.flows)
+      + (select count(*) from public.contacts)
+      + (select count(*) from public.sources)
+      + (select count(*) from public.unitgroups)
+      + (select count(*) from public.flowproperties)
+      + (select count(*) from public.lifecyclemodels)
+  $$,
+  'all seven roles-dependent core relations evaluate RLS without 42501'
+);
+
+select lives_ok(
+  $$select (select count(*) from public.lciamethods) + (select count(*) from public.ilcd)$$,
+  'the two roles-independent core relations remain readable'
+);
+
+select lives_ok(
+  $$select (select count(*) from private.roles) + (select count(*) from private.reviews)$$,
+  'authenticated can evaluate both private RLS dependencies without 42501'
+);
+
+select lives_ok(
+  $$select count(*) from api.qry_team_list('public', null, 1, 10)$$,
+  'the authenticated team read facade remains executable'
+);
+
+select lives_ok(
+  $$
+    select
+      (select count(*) from api.qry_review_get_items(null, null, null, null))
+      + (select count(*) from api.qry_review_get_comment_items(
+          '42270000-0000-4000-8000-000000000050'::uuid,
+          'all'
+        ))
+  $$,
+  'the authenticated review and comment read facades remain executable'
+);
+
+reset role;
+set local role service_role;
+select pg_catalog.set_config('request.jwt.claim.role', 'service_role', true);
+select pg_catalog.set_config('request.jwt.claims', '{"role":"service_role"}', true);
+select pg_catalog.set_config('request.jwt.claim.sub', '', true);
+
+select lives_ok(
+  $$select api.get_current_lca_release()$$,
+  'service role can call the current release projection'
+);
+
+select lives_ok(
+  $$select api.get_current_lca_release_process('42270000-0000-4000-8000-000000000020'::uuid, '1.0.0')$$,
+  'service role can call the current release process projection'
+);
+
+select lives_ok(
+  $$select api.get_lca_release_artifact_download('42270000-0000-4000-8000-000000000030'::uuid)$$,
+  'service role can call the release artifact download projection'
+);
+
+select lives_ok(
+  $$select api.get_lca_release_run('42270000-0000-4000-8000-000000000040'::uuid)$$,
+  'service role can call the release run projection'
+);
+
+reset role;
+
+select * from finish();
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
 lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: no generated-workspace workflow or stable-overlay contract change is required."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 096c44d36e35579de5d59f6a0d983fbff86bcef9
-lastReviewedNote: "Reviewed for Issue #422 Edge consumer closure: generated types include the Data Product and enriched TIDAS API facade contracts."
+lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: no generated-workspace workflow or stable-overlay contract change is required."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 096c44d36e35579de5d59f6a0d983fbff86bcef9
-lastReviewedNote: "已为 Issue #422 Edge 消费者收口复核：生成类型包含 Data Product 与增强后的 TIDAS API façade 合同。"
+lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedNote: "已为 Issue #422 运行时 ACL 修复复核：无需调整生成 workspace 流程或稳定 overlay 合同。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-07
-lastReviewedCommit: 0a97cc761f8127ca379ab7d4df4395dab255707a
+lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
 lastReviewedNote: "已为 Issue #422 运行时 ACL 修复复核：无需调整生成 workspace 流程或稳定 overlay 合同。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -60498,6 +60498,7 @@ GRANT ALL ON FUNCTION "api"."_search_simple_dataset_latest"("p_table" "regclass"
 
 REVOKE ALL ON FUNCTION "api"."assert_lca_release_manager"() FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."assert_lca_release_manager"() TO "api_internal_executor";
+GRANT ALL ON FUNCTION "api"."assert_lca_release_manager"() TO "authenticated";
 
 
 
@@ -61070,6 +61071,7 @@ REVOKE ALL ON FUNCTION "api"."get_current_lca_release"() FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."get_current_lca_release"() TO "api_internal_executor";
 GRANT ALL ON FUNCTION "api"."get_current_lca_release"() TO "anon";
 GRANT ALL ON FUNCTION "api"."get_current_lca_release"() TO "authenticated";
+GRANT ALL ON FUNCTION "api"."get_current_lca_release"() TO "service_role";
 
 
 
@@ -61077,6 +61079,7 @@ REVOKE ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" 
 GRANT ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" "uuid", "p_process_version" "text") TO "api_internal_executor";
 GRANT ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" "uuid", "p_process_version" "text") TO "anon";
 GRANT ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" "uuid", "p_process_version" "text") TO "authenticated";
+GRANT ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" "uuid", "p_process_version" "text") TO "service_role";
 
 
 
@@ -61132,12 +61135,14 @@ GRANT ALL ON FUNCTION "api"."get_latest_unitgroup_versions"("page_size" bigint, 
 REVOKE ALL ON FUNCTION "api"."get_lca_release_artifact_download"("p_artifact_id" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."get_lca_release_artifact_download"("p_artifact_id" "uuid") TO "api_internal_executor";
 GRANT ALL ON FUNCTION "api"."get_lca_release_artifact_download"("p_artifact_id" "uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "api"."get_lca_release_artifact_download"("p_artifact_id" "uuid") TO "service_role";
 
 
 
 REVOKE ALL ON FUNCTION "api"."get_lca_release_run"("p_release_run_id" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."get_lca_release_run"("p_release_run_id" "uuid") TO "api_internal_executor";
 GRANT ALL ON FUNCTION "api"."get_lca_release_run"("p_release_run_id" "uuid") TO "authenticated";
+GRANT ALL ON FUNCTION "api"."get_lca_release_run"("p_release_run_id" "uuid") TO "service_role";
 
 
 
@@ -61376,6 +61381,7 @@ GRANT ALL ON FUNCTION "api"."policy_is_team_public"("_team_id" "uuid") TO "api_i
 
 REVOKE ALL ON FUNCTION "api"."policy_review_can_read"("p_review_id" "uuid", "p_actor" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."policy_review_can_read"("p_review_id" "uuid", "p_actor" "uuid") TO "api_internal_executor";
+GRANT ALL ON FUNCTION "api"."policy_review_can_read"("p_review_id" "uuid", "p_actor" "uuid") TO "authenticated";
 
 
 
@@ -61391,6 +61397,7 @@ GRANT ALL ON FUNCTION "api"."policy_roles_insert"("_user_id" "uuid", "_team_id" 
 
 REVOKE ALL ON FUNCTION "api"."policy_roles_select"("_team_id" "uuid", "_role" "text") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."policy_roles_select"("_team_id" "uuid", "_role" "text") TO "api_internal_executor";
+GRANT ALL ON FUNCTION "api"."policy_roles_select"("_team_id" "uuid", "_role" "text") TO "authenticated";
 
 
 

--- a/supabase/workspace/schemas/api/functions/assert_lca_release_manager/definition.sql
+++ b/supabase/workspace/schemas/api/functions/assert_lca_release_manager/definition.sql
@@ -31,3 +31,5 @@ ALTER FUNCTION "api"."assert_lca_release_manager"() OWNER TO "postgres";
 REVOKE ALL ON FUNCTION "api"."assert_lca_release_manager"() FROM PUBLIC;
 
 GRANT ALL ON FUNCTION "api"."assert_lca_release_manager"() TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."assert_lca_release_manager"() TO "authenticated";

--- a/supabase/workspace/schemas/api/functions/get_current_lca_release/definition.sql
+++ b/supabase/workspace/schemas/api/functions/get_current_lca_release/definition.sql
@@ -28,3 +28,5 @@ GRANT ALL ON FUNCTION "api"."get_current_lca_release"() TO "api_internal_executo
 GRANT ALL ON FUNCTION "api"."get_current_lca_release"() TO "anon";
 
 GRANT ALL ON FUNCTION "api"."get_current_lca_release"() TO "authenticated";
+
+GRANT ALL ON FUNCTION "api"."get_current_lca_release"() TO "service_role";

--- a/supabase/workspace/schemas/api/functions/get_current_lca_release_process/definition.sql
+++ b/supabase/workspace/schemas/api/functions/get_current_lca_release_process/definition.sql
@@ -66,3 +66,5 @@ GRANT ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" "
 GRANT ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" "uuid", "p_process_version" "text") TO "anon";
 
 GRANT ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" "uuid", "p_process_version" "text") TO "authenticated";
+
+GRANT ALL ON FUNCTION "api"."get_current_lca_release_process"("p_process_uuid" "uuid", "p_process_version" "text") TO "service_role";

--- a/supabase/workspace/schemas/api/functions/get_lca_release_artifact_download/definition.sql
+++ b/supabase/workspace/schemas/api/functions/get_lca_release_artifact_download/definition.sql
@@ -48,3 +48,5 @@ REVOKE ALL ON FUNCTION "api"."get_lca_release_artifact_download"("p_artifact_id"
 GRANT ALL ON FUNCTION "api"."get_lca_release_artifact_download"("p_artifact_id" "uuid") TO "api_internal_executor";
 
 GRANT ALL ON FUNCTION "api"."get_lca_release_artifact_download"("p_artifact_id" "uuid") TO "authenticated";
+
+GRANT ALL ON FUNCTION "api"."get_lca_release_artifact_download"("p_artifact_id" "uuid") TO "service_role";

--- a/supabase/workspace/schemas/api/functions/get_lca_release_run/definition.sql
+++ b/supabase/workspace/schemas/api/functions/get_lca_release_run/definition.sql
@@ -102,3 +102,5 @@ REVOKE ALL ON FUNCTION "api"."get_lca_release_run"("p_release_run_id" "uuid") FR
 GRANT ALL ON FUNCTION "api"."get_lca_release_run"("p_release_run_id" "uuid") TO "api_internal_executor";
 
 GRANT ALL ON FUNCTION "api"."get_lca_release_run"("p_release_run_id" "uuid") TO "authenticated";
+
+GRANT ALL ON FUNCTION "api"."get_lca_release_run"("p_release_run_id" "uuid") TO "service_role";

--- a/supabase/workspace/schemas/api/functions/policy_review_can_read/definition.sql
+++ b/supabase/workspace/schemas/api/functions/policy_review_can_read/definition.sql
@@ -31,3 +31,5 @@ ALTER FUNCTION "api"."policy_review_can_read"("p_review_id" "uuid", "p_actor" "u
 REVOKE ALL ON FUNCTION "api"."policy_review_can_read"("p_review_id" "uuid", "p_actor" "uuid") FROM PUBLIC;
 
 GRANT ALL ON FUNCTION "api"."policy_review_can_read"("p_review_id" "uuid", "p_actor" "uuid") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."policy_review_can_read"("p_review_id" "uuid", "p_actor" "uuid") TO "authenticated";

--- a/supabase/workspace/schemas/api/functions/policy_roles_select/definition.sql
+++ b/supabase/workspace/schemas/api/functions/policy_roles_select/definition.sql
@@ -29,3 +29,5 @@ ALTER FUNCTION "api"."policy_roles_select"("_team_id" "uuid", "_role" "text") OW
 REVOKE ALL ON FUNCTION "api"."policy_roles_select"("_team_id" "uuid", "_role" "text") FROM PUBLIC;
 
 GRANT ALL ON FUNCTION "api"."policy_roles_select"("_team_id" "uuid", "_role" "text") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."policy_roles_select"("_team_id" "uuid", "_role" "text") TO "authenticated";


### PR DESCRIPTION
## 关联

Refs #422

本 PR 只完成 Issue #422 中 Schema cutover 后的运行时 ACL 修复，不自动关闭整体迁移 Issue。

## 变更摘要

- 新增 manifest-first ACL migration，恢复两个 authenticated RLS helper、一个 Edge actor 断言和四个 Edge release 读取 façade 的精确 `EXECUTE` 权限。
- 将七个函数 identity 写入 `private.api_capability_grants`，并在 migration 内执行前置对象校验和后置 ACL/manifest 断言。
- 新增 15 条 pgTAP ACL/运行时回归，并补强 release control-plane 与有数据升级测试。
- 不扩大 schema 暴露范围，不增加表级直连权限，也不改变现有 service-role 消费方式。

## 精确授权

- `authenticated`: `api.policy_roles_select(uuid,text)`、`api.policy_review_can_read(uuid,uuid)`、`api.assert_lca_release_manager()`
- `anon` / `authenticated` / `service_role`: `api.get_current_lca_release()`、`api.get_current_lca_release_process(uuid,text)`
- `authenticated` / `service_role`: `api.get_lca_release_artifact_download(uuid)`、`api.get_lca_release_run(uuid)`

所有函数都先撤销外部角色的既有 `EXECUTE`，再按上述矩阵精确授权；`PUBLIC` 保持无执行权限。

## 验证

- 空库 `supabase db reset` 到最新 migration head：通过。
- 当前 schema-cutover / API contract / identity / package / data-product / release / ACL 七组 pgTAP：253 条断言全部通过。
- `scripts/test_full_schema_cutover_upgrade.sh`：从切换前基线保留 61 张关系、333 个函数、106 个触发器、61 条策略和 444 个约束；有数据升级、对象保持及精确 ACL 断言通过。
- `supabase db lint --level warning`：命令通过；输出仅包含既有函数的动态 SQL、临时表及历史列引用分析项，本 PR 未新增或重定义函数。
- Docpact strict config、staged lint、pre-push gate：通过，0 findings。

## 发布与回滚

- PR 合并前由 Supabase Preview 验证 migration；合并到 `dev` 后由 Supabase 原生同步部署，不手工 `db push`。
- 持久 Dev 到达精确 head 后，再执行 hosted catalog 检查以及 Next/Edge authenticated E2E。
- 如需回滚，提交新的补偿 migration 恢复上一版 manifest/ACL；不修改已执行 migration。
