### PR TITLE
fix: 恢复 database-only Supabase Dev 部署

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-07"
-lastReviewedCommit: "c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8"
-lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: existing migration/test ownership and exact capability-grant governance cover the authenticated RLS helpers and Edge release facades without new rules."
+lastReviewedAt: "2026-08-08"
+lastReviewedCommit: "78134bdf89ee4a727e8b49cd0af47fb06cac10a9"
+lastReviewedNote: "Updated for Issue #422: persistent Dev uses the database-only db-push workflow again, with native Git dev deployment excluded from ownership."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.
@@ -299,7 +299,7 @@ rules:
         mode: review_or_update
       - path: docs/agents/supabase-branching_CN.md
         mode: review_or_update
-    reason: Branch bindings, native-integration deployment, and read-only persistent Dev verification change repo routing, proof, and branch-operation guidance together.
+    reason: Branch bindings, database-only persistent Dev deployment, and hosted verification change repo routing, proof, and branch-operation guidance together.
   - id: database-engine-migration-and-seed-contract
     scope: repo
     repo: database-engine

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -1,4 +1,4 @@
-name: Verify Supabase Dev
+name: Deploy and Verify Supabase Dev
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: supabase-dev-verification-${{ github.ref }}
+  group: supabase-dev-deployment-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
         with:
           version: 2.98.0
 
-      - name: Verify workflow remains read-only
+      - name: Verify deployment workflow contract
         run: |
           python scripts/test_resolve_migration_head.py
           python scripts/test_supabase_dev_workflow_contract.py
@@ -59,13 +59,15 @@ jobs:
         if: always()
         run: supabase stop --no-backup
 
-  hosted-read-only:
-    name: Verify native Dev deployment
+  deploy-and-verify:
+    name: Deploy and verify persistent Dev
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    needs: local-contract
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
       SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_DEV_PROJECT_ID }}
 
     steps:
@@ -78,6 +80,12 @@ jobs:
         uses: supabase/setup-cli@v2
         with:
           version: 2.98.0
+
+      - name: Link Supabase Dev branch
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Push migrations to Supabase Dev branch
+        run: supabase db push --include-all
 
       - name: Resolve expected migration head
         id: migration_head
@@ -97,7 +105,7 @@ jobs:
           echo "ANON_KEY=$anon_key" >> "$GITHUB_ENV"
           echo "SERVICE_ROLE_KEY=$service_role_key" >> "$GITHUB_ENV"
 
-      - name: Wait for exact native migration head
+      - name: Verify exact deployed migration head
         shell: bash
         env:
           EXPECTED_MIGRATION_HEAD: ${{ steps.migration_head.outputs.head }}
@@ -122,7 +130,7 @@ jobs:
             fi
             sleep 10
           done
-          echo "native Supabase deployment did not reach the expected schema contract" >&2
+          echo "database migration deployment did not reach the expected schema contract" >&2
           exit 1
 
       - name: Verify hosted PostgREST boundary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
-lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: the existing repo ownership, dev-first delivery, least-privilege API manifest, and local-to-hosted proof boundaries remain unchanged."
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "Updated for Issue #422: persistent Dev migrations are again deployed by the database-only GitHub Actions db-push path; Supabase native deployment must not compete for Git dev."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -117,7 +117,7 @@ Keep these entry-level facts in `AGENTS.md`. Use `docs/agents/repo-validation.md
 - disposable Hosted actors must use an outer-frozen request/namespace and deterministic role email, be registered before creation, carry exact fixture/request/namespace/role metadata, recover only one exact filtered metadata match, use global logout, and treat hard admin DELETE as incomplete until both GET-by-ID returns 404 and a fresh exact filtered census is empty; the outer wrapper must create the exact empty owner-only non-symlink private temp directory and durably fsync each secret-free inner recovery checkpoint before returning its exact IPC ACK, so an actor ID is durable before sign-in or fixture mutation; cleanup must hold the derivative coordinator lock and remain before external dispatch, any missing or ambiguous global logout must retain the actor and forbid hard DELETE, and temporary credential files must be proven removed independently by the inner and outer processes; offline lifecycle and 39-surface residue contracts prove the local control/readback shape without replacing the later exact-head Hosted run and independent Auth/SQL readback execution
 - migration authoring starts from Git `dev`, not GitHub default-branch UI
 - preview-branch proof belongs to the repo PR
-- persistent `dev` deployment belongs to the Supabase GitHub integration bound to Git `dev`; the checked-in workflow derives the expected head from the current checkout's migration directory, then acts as a read-only verifier that waits for that exact migration head, reads back the ordered hosted PostgREST schema/search-path lists, and probes the default `public`, explicit `api`, rejected `private`, and retired `public` RPC routes without a database password or a second `db push`
+- persistent `dev` migration deployment belongs to `.github/workflows/supabase-dev.yml`; after the local contract passes, it links the configured Dev project, runs exactly one `supabase db push --include-all`, derives the expected head from the checkout, reads back the ordered hosted PostgREST schema/search-path lists, and probes the default `public`, explicit `api`, rejected `private`, and retired `public` RPC routes; it must never deploy or delete Edge Functions or push project configuration
 - production `main` proof belongs after `dev -> main` promote and should confirm Supabase GitHub integration applied migrations automatically; when `supabase/config.toml` changes, the operator must also push and verify that configuration against the production project
 - production-volume administrative backfills must fit the platform statement timeout or use a bounded session override that is restored immediately after the statement; Preview row counts alone are not sufficient volume proof
 - root workspace proof belongs later in `lca-workspace`
@@ -185,7 +185,7 @@ Use the role table in this file as the update map.
 ## Hard Boundaries
 
 - do not treat `supabase/workspace/remote_schema.sql`, `global/**`, or `schemas/**` as stable edit locations
-- do not create any checked-in workflow that competes with the Supabase GitHub integration for persistent-`dev` deployment
+- do not leave Supabase native deployment bound to Git `dev` while the checked-in persistent-Dev migration workflow is active; one target must have one deployer
 - do not move frontend `.env` or app-side client logic into this repo
 - do not treat a merged PR here as delivery-complete when the workspace still needs a submodule bump
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
-lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: manifest-first grants preserve the existing public/api/private boundary and require no architecture change."
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "Updated for Issue #422: persistent Dev migration ownership returns to the database-only GitHub Actions db-push path without changing schema ownership."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -99,7 +99,7 @@ that needs private RLS helpers runs through the constrained
 | `supabase/tests/preview/**` | exact-ref-bound disposable Hosted Preview mutation fixtures, cleanup, rollback-only fault assertions, and offline transport/lifecycle contracts; test-only and excluded from migrations, seeds, Dev data rehearsal, and production execution |
 | `.env.supabase.dev.local.example`, `.env.supabase.main.local.example` | operator branch-binding templates |
 | `scripts/**` | export, refresh, change-copy, migration-generation, and workflow-contract helpers; `resolve_migration_head.py` is the single parser used to derive the current checkout's exact migration head for persistent-Dev verification |
-| `.github/workflows/supabase-dev.yml` | read-only local-contract and persistent-Dev verification after the Supabase GitHub integration deploys Git `dev` |
+| `.github/workflows/supabase-dev.yml` | local-contract rebuild, database-only persistent-Dev migration deployment with `db push --include-all`, and exact hosted verification |
 | `supabase/workspace/changes/**` | manual overlay area used when generating migrations from workspace files |
 | `supabase/workspace/remote_schema.sql` | generated full raw dump from the remote database |
 | `supabase/workspace/global/**` | generated split-out global objects rebuilt on workspace refresh |
@@ -113,7 +113,7 @@ that needs private RLS helpers runs through the constrained
 - Git `dev` is the daily integration trunk
 - Git `main` is the promoted release line
 - PR branches map to Supabase preview branches
-- the Supabase GitHub integration is the sole migration deployer for Git `dev`; `.github/workflows/supabase-dev.yml` rebuilds the local contract and waits for/readbacks the exact native deployment without issuing `db push`, `config push`, or Management API mutations
+- `.github/workflows/supabase-dev.yml` is the sole migration deployer for Git `dev`; it gates the remote job on the local contract, issues exactly one `db push --include-all`, and verifies the exact hosted result without Functions deployment, config push, or Management API mutations
 - the production Supabase project is migrated automatically by the Supabase GitHub integration when Git `main` advances
 
 This means branch behavior is part of the repo architecture, not just delivery process.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
-lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: the existing schema-cutover, exact-ACL, release-control-plane, and targeted pgTAP proof layers remain sufficient."
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "Updated for Issue #422: workflow proof now requires one database-only db push followed by exact-head and hosted-boundary verification, with no Functions or config deployment."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -89,7 +89,7 @@ need Git provenance still check out full history (`fetch-depth: 0`).
 | `supabase/tests/**` only | run the relevant SQL assertion files against a reset local DB | add a nearby migration or policy smoke check if the new assertions expose a gap | This repo stores PGTAP-style SQL assertions, not a single canonical runner wrapper. |
 | `supabase/seed.sql` or `supabase/seeds/dev.sql` | `supabase db reset` succeeds with expected seed behavior | rerun targeted SQL assertions that depend on the seeded rows; for shared-seed changes, confirm the hosted Preview seed stage completes | Keep shared seed and dev-only seed expectations separate. A shared seed with no data must still contain an executable no-op statement; a comments-only batch is not deployment-safe. |
 | `supabase/config.toml` | `supabase start` and `supabase db reset` still work locally | verify the changed branch-binding or auth assumption against `docs/agents/supabase-branching.md`; for exposed-schema changes, prove the Supabase GitHub integration applies the configuration or record the explicit operator gate, then read back exact ordered hosted PostgREST schema/search-path lists | Config changes affect preview, persistent dev, and local behavior together; local CLI order is not hosted default-profile proof. |
-| `.github/workflows/supabase-dev.yml` | inspect and parse YAML; run `python scripts/test_resolve_migration_head.py` and `python scripts/test_supabase_dev_workflow_contract.py`; regenerate `supabase/workspace/database.types.ts` from the full local migration state; assert the workflow contains no pinned migration head, `db push`, `config push`, Management API mutation, or database-password dependency | prove the workflow rejects generated type drift, derives the expected head from the checked-out migration directory, waits for that exact native migration head, and performs only Management API GET plus read-only Data API probes: profile-less `public`, explicit `api`, rejected `private`, and retired `public` RPC | Supabase GitHub integration is the sole persistent-Dev deployer; the workflow verifies rather than races it. |
+| `.github/workflows/supabase-dev.yml` | inspect and parse YAML; run `python scripts/test_resolve_migration_head.py` and `python scripts/test_supabase_dev_workflow_contract.py`; regenerate `supabase/workspace/database.types.ts` from the full local migration state; assert the hosted job links the configured Dev project, runs exactly one `supabase db push --include-all`, contains no pinned migration head, Functions deploy/delete, `config push`, or Management API mutation | prove local contract success gates the remote deploy, generated type drift is rejected, the expected head is derived from the checkout, and post-deploy verification performs only Management API GET plus read-only Data API probes: profile-less `public`, explicit `api`, rejected `private`, and retired `public` RPC | GitHub Actions is the sole persistent-Dev migration deployer. Disable the native Git `dev` deployment binding before merge so it cannot race this workflow or touch Edge Functions. |
 | `scripts/**` | run the touched script with `--help` when possible, or execute the narrowest safe non-destructive path | if a script changes generated workspace behavior, refresh the workspace in a safe environment and inspect git diff | Avoid remote-destructive script runs unless the task explicitly requires them. |
 | `supabase/workspace/**` | prove whether the touched file is generated or stable | if stable manual overlay files changed, explain how they feed migration generation | Generated files alone are not sufficient evidence of a durable schema change. |
 | repo docs only | `scripts/docpact lint --root . --files "<csv>" --mode enforce` | `scripts/docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | Refresh review metadata even when prose stays unchanged. |
@@ -201,7 +201,7 @@ The canonical refresh target remains remote `dev`. For an exact local migration-
 python scripts/build_schema_workspace.py --environment local
 ```
 
-For a schema-changing PR, an exact-local reconstruction may be committed as a review snapshot after a blank migration rebuild, targeted contract tests, and a second deterministic regeneration show no drift. Record those proofs in the PR. After merge, require exact-head native Dev deployment, hosted catalog checks, and a remote-Dev refresh comparison; commit any resulting drift as a follow-up.
+For a schema-changing PR, an exact-local reconstruction may be committed as a review snapshot after a blank migration rebuild, targeted contract tests, and a second deterministic regeneration show no drift. Record those proofs in the PR. After merge, require the database-only Dev deployment to reach the exact head, hosted catalog checks, and a remote-Dev refresh comparison; commit any resulting drift as a follow-up.
 
 ## Preview, Persistent Dev, and Root Integration
 

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,9 +20,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0b615b0fa753eb1ccbfaf5ce4a08938258d97ad7
-lastReviewedNote: "Reviewed for Issue #422 contract closure: Supabase GitHub Integration is the sole Dev deployer and repository CI performs only local plus hosted read-only verification."
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "Updated for Issue #422: persistent Dev migration deployment is owned by the database-only GitHub Actions db-push path; native Git dev deployment must be disabled."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -58,7 +58,7 @@ Those stay in consumer repositories such as `tiangong-lca-next` and `tiangong-lc
 ## Branch contract
 
 - Git `main` -> production baseline migrated automatically by the Supabase GitHub integration
-- Git `dev` -> persistent Supabase `dev` branch migrated by the Supabase GitHub integration and read-only verified by `.github/workflows/supabase-dev.yml`
+- Git `dev` -> persistent Supabase `dev` branch migrated and verified by `.github/workflows/supabase-dev.yml`
 - PR / feature branches -> preview branches created by the Supabase GitHub integration
 
 Rules:
@@ -77,14 +77,15 @@ When review changes an already-applied PR migration, add a later migration that 
 - Treat committed files in `supabase/migrations/` as the schema source of truth for production, `dev`, and preview branches.
 - Keep branch-specific overrides in `[remotes.<branch>]` inside `supabase/config.toml`.
 - Do not create a separate `supabase/` directory per Git branch.
-- Keep the Supabase GitHub integration as the sole persistent-`dev` migration deployer. `.github/workflows/supabase-dev.yml` must remain read-only with respect to hosted schema and configuration.
+- Keep `.github/workflows/supabase-dev.yml` as the sole persistent-`dev` migration deployer. It may run `supabase link` and exactly one `supabase db push --include-all`, but must not deploy/delete Edge Functions or push project configuration.
+- Disable the Supabase native deployment binding for Git `dev` before this workflow reaches `dev`; two deployers must never target the same persistent branch.
 - Do not add a checked-in GitHub Actions production deploy for Git `main`; the production project is migrated by the Supabase GitHub integration bound to this repository.
 - Do not author normal schema changes by editing the remote database first and reconstructing migrations later.
 
 ## Files to maintain
 
 - `supabase/config.toml`: shared baseline plus `[remotes.dev]`
-- `.github/workflows/supabase-dev.yml`: rebuilds local migrations and verifies the exact native persistent-`dev` deployment
+- `.github/workflows/supabase-dev.yml`: rebuilds the local contract, deploys committed migrations to persistent `dev`, and verifies the exact hosted result
 - `supabase/migrations/*.sql`: committed migration history
 - `supabase/seed.sql`: shared seed data
 - `supabase/seeds/dev.sql`: optional persistent-dev-only seed data
@@ -125,6 +126,7 @@ Repository configuration expected by `.github/workflows/supabase-dev.yml`:
 
 - variable `SUPABASE_DEV_PROJECT_ID`
 - secret `SUPABASE_ACCESS_TOKEN`
+- secret `SUPABASE_DEV_DB_PASSWORD`
 
 ## PR to Supabase migration path
 
@@ -139,15 +141,17 @@ Normal PR path:
    the checked-in `supabase/` directory.
 4. The preview branch is PR-scoped proof only; it is not the persistent
    Supabase `dev` branch.
-5. After the PR merges, the Supabase GitHub integration applies Git `dev` to
-   the persistent Supabase `dev` branch.
-6. The same push triggers `.github/workflows/supabase-dev.yml`, which performs
-   a blank local rebuild, derives the expected head from the checked-out
-   migration directory, and waits until a service-only readback reports that
-   exact migration head. The workflow never carries a manually pinned head.
-7. The workflow reads `public,api,graphql_public` and
+5. Before the PR merges, confirm that Supabase native deployment is no longer
+   bound to Git `dev`.
+6. After merge, `.github/workflows/supabase-dev.yml` performs a blank local
+   rebuild, links the configured persistent Dev project, and runs
+   `supabase db push --include-all` after the local contract passes.
+7. The workflow derives the expected head from the checked-out migration
+   directory and waits until a service-only readback reports that exact head;
+   it never carries a manually pinned head.
+8. The workflow reads `public,api,graphql_public` and
    `public,api,extensions` through the Management API and probes the hosted
-   Data API boundary. It performs no hosted mutation.
+   Data API boundary. After `db push`, these checks are read-only.
 
 An existing Preview branch applies newly added migration files on later PR
 pushes. Editing a migration already recorded in that Preview's migration
@@ -187,8 +191,8 @@ against persistent `dev` before the `dev -> main` promote.
 This repository currently has no checked-in `workflow_dispatch` production
 deploy for Supabase. That is intentional: Git `main` is handled by the Supabase
 GitHub integration. An operator can still run `supabase link` and
-`supabase db push` locally as an explicit fallback or recovery path, but that
-manual action must be recorded in validation or incident notes.
+`supabase db push --include-all` locally as an explicit fallback or recovery
+path, but that manual action must be recorded in validation or incident notes.
 
 ## Vault secret contract
 
@@ -226,13 +230,17 @@ Rules:
 
 ### Persistent `dev` branch deployment
 
-- Pushes to Git `dev` are deployed by the Supabase GitHub integration.
-- The same push triggers `.github/workflows/supabase-dev.yml`; it rebuilds the
-  migration history locally, waits for the exact native migration head, and
-  fails unless Management API readback and REST profile probes match the
-  checked-in contract.
-- The workflow has no database password and performs no hosted mutation. Do
-  not add a competing deployment path for the same target.
+- Pushes to Git `dev` are deployed by `.github/workflows/supabase-dev.yml`.
+- The workflow first rebuilds and verifies the complete migration history
+  locally. The hosted job depends on that success, links the configured Dev
+  project, and runs exactly one `supabase db push --include-all`.
+- It then derives the expected head from its checkout and fails unless the
+  exact-head readback, Management API readback, and REST profile probes match
+  the checked-in contract.
+- The workflow owns database migrations only. It must not run `supabase
+  functions deploy`, `supabase functions delete`, or `supabase config push`.
+- Supabase native deployment must not remain bound to Git `dev`, because it
+  would race this workflow and may synchronize Edge Functions.
 
 ### Production `main` deployment
 

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-08-06
-lastReviewedCommit: 0b615b0fa753eb1ccbfaf5ce4a08938258d97ad7
-lastReviewedNote: "已为 Issue #422 合同收口复核：Supabase GitHub Integration 是唯一 Dev 部署方，仓库 CI 仅执行本地与托管只读验证。"
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "已为 Issue #422 更新：持久化 Dev migration 恢复由数据库专用 GitHub Actions db-push 路径负责，必须关闭 Git dev 的原生部署绑定。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -58,7 +58,7 @@ related:
 ## 分支契约
 
 - Git `main` -> 生产基线，由 Supabase GitHub integration 自动迁移
-- Git `dev` -> 持久化 Supabase `dev` 分支，由 Supabase GitHub integration 迁移，并由 `.github/workflows/supabase-dev.yml` 只读验证
+- Git `dev` -> 持久化 Supabase `dev` 分支，由 `.github/workflows/supabase-dev.yml` 迁移并验证
 - PR / feature 分支 -> 由 Supabase GitHub integration 自动创建的 preview branch
 
 规则：
@@ -75,14 +75,15 @@ related:
 - 把 `supabase/migrations/` 中已提交的文件视为 production、`dev` 和 preview 分支共同遵循的 schema 真相源。
 - 分支差异放在 `supabase/config.toml` 的 `[remotes.<branch>]` 中。
 - 不要为不同 Git 分支复制多套 `supabase/` 目录。
-- 把 Supabase GitHub integration 作为持久化 `dev` 的唯一 migration 部署者；`.github/workflows/supabase-dev.yml` 不得修改托管 schema 或配置。
+- 把 `.github/workflows/supabase-dev.yml` 作为持久化 `dev` 的唯一 migration 部署者；它可以执行 `supabase link` 和准确一次 `supabase db push --include-all`，但不得部署/删除 Edge Functions 或推送项目配置。
+- 在该 workflow 进入 `dev` 前关闭 Git `dev` 的 Supabase 原生部署绑定；同一个持久化分支不能同时存在两个部署者。
 - 不要为 Git `main` 增加 checked-in 的 GitHub Actions 生产部署流程；生产项目由绑定到本仓的 Supabase GitHub integration 自动迁移。
 - 不要先手改远端数据库再回头补 migration。
 
 ## 需要维护的文件
 
 - `supabase/config.toml`：共享基线加 `[remotes.dev]`
-- `.github/workflows/supabase-dev.yml`：重建本地 migration，并只读验证持久化 `dev` 已到达准确的原生部署 head
+- `.github/workflows/supabase-dev.yml`：重建本地合同、把已提交 migration 部署到持久化 `dev`，并验证准确的托管结果
 - `supabase/migrations/*.sql`：已提交的 migration 历史
 - `supabase/seed.sql`：共享 seed 数据
 - `supabase/seeds/dev.sql`：可选的持久化 dev 专属 seed 数据
@@ -122,6 +123,7 @@ related:
 
 - variable `SUPABASE_DEV_PROJECT_ID`
 - secret `SUPABASE_ACCESS_TOKEN`
+- secret `SUPABASE_DEV_DB_PASSWORD`
 
 ## PR 到 Supabase migration 路径
 
@@ -133,10 +135,11 @@ related:
 2. PR 目标分支是 Git `dev`。
 3. Supabase GitHub integration 根据已提交的 `supabase/` 目录创建或更新该 PR 的 preview branch。
 4. preview branch 只用于 PR 级别验证；它不是持久化 Supabase `dev` 分支。
-5. PR 合并后，Supabase GitHub integration 会把 Git `dev` 应用到持久化 Supabase `dev` 分支。
-6. 同一次 Git push 会触发 `.github/workflows/supabase-dev.yml`，先完成本地空库重建，并从当前 checkout 的 migration 目录推导期望 head，再等待 service-only readback 报告该准确 head；workflow 中不再手工固定 migration head。
-7. workflow 通过 Management API 回读 `public,api,graphql_public` 与
-   `public,api,extensions`，并验证托管 Data API 边界；它不会修改托管数据库或配置。
+5. PR 合并前，确认 Git `dev` 已不再绑定 Supabase 原生部署。
+6. 合并后，`.github/workflows/supabase-dev.yml` 先完成本地空库重建；本地合同通过后，绑定配置的持久化 Dev 项目并执行 `supabase db push --include-all`。
+7. workflow 从当前 checkout 的 migration 目录推导期望 head，再等待 service-only readback 报告该准确 head；workflow 中不手工固定 migration head。
+8. workflow 通过 Management API 回读 `public,api,graphql_public` 与
+   `public,api,extensions`，并验证托管 Data API 边界；`db push` 后的这些检查均为只读。
 
 `--include-all` 表示所有尚未出现在远端 migration history 中的已提交 migration
 都可以被应用。受治理的 `main -> dev` 回合并可能带入时间戳早于 `dev` 已记录新
@@ -162,7 +165,7 @@ Promote 路径：
 
 本仓目前没有 checked-in 的 `workflow_dispatch` 生产 Supabase 部署流程。这是有意设计：
 Git `main` 由 Supabase GitHub integration 处理。运维人员仍可在本地执行
-`supabase link` 和 `supabase db push`，但这只能作为明确的兜底或恢复路径，
+`supabase link` 和 `supabase db push --include-all`，但这只能作为明确的兜底或恢复路径，
 并且必须在验证记录或事故记录中说明。
 
 ## Vault secret 契约
@@ -200,12 +203,14 @@ Git `main` 由 Supabase GitHub integration 处理。运维人员仍可在本地�
 
 ### 持久化 `dev` 分支部署
 
-- 对 Git `dev` 的 push 由 Supabase GitHub integration 部署。
-- 同一次 push 会触发 `.github/workflows/supabase-dev.yml`；它在本地重建完整
-  migration history，等待托管项目到达准确的原生 migration head，并在
-  Management API 回读或 REST profile 探测不符合合同时失败。
-- 该 workflow 不使用数据库密码，也不修改托管状态。不要再增加与 integration
-  竞争同一目标的部署链路。
+- 对 Git `dev` 的 push 由 `.github/workflows/supabase-dev.yml` 部署。
+- workflow 先在本地重建并验证完整 migration history；Hosted job 依赖该结果，
+  随后绑定配置的 Dev 项目，并准确执行一次 `supabase db push --include-all`。
+- 部署后从当前 checkout 推导期望 head，并在 exact-head readback、Management API
+  回读或 REST profile 探测不符合合同时失败。
+- workflow 只负责数据库 migration，不得执行 `supabase functions deploy`、
+  `supabase functions delete` 或 `supabase config push`。
+- Git `dev` 不得继续绑定 Supabase 原生部署，否则会与该 workflow 竞争，并可能同步 Edge Functions。
 
 ### 生产 `main` 部署
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,9 +20,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
-lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: populated upgrade validation now covers exact authenticated RLS-helper and Edge release facade grants."
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "Updated for Issue #422: the workflow contract helper now enforces one database-only persistent Dev db push and rejects Functions/config deployment."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -86,11 +86,11 @@ python scripts/test_resolve_migration_head.py
 
 ### `test_supabase_dev_workflow_contract.py`
 
-Fails closed if the persistent-Dev verification workflow regains database
-password usage, `db push`, `config push`, a Management API mutation, or a
-manually pinned migration head. It requires the hosted job to derive the
-expected head with `resolve_migration_head.py` from its own checkout and pass
-that step output to the exact-head readback.
+Fails closed unless the persistent-Dev workflow performs exactly one database
+deployment with `supabase db push --include-all` after linking the configured
+project. It rejects Functions deploy/delete, `config push`, Management API
+mutation, and a manually pinned migration head, then requires exact-head
+readback from the same checkout.
 
 ```bash
 python scripts/test_supabase_dev_workflow_contract.py
@@ -196,7 +196,7 @@ Warnings:
 - Manual edits inside `remote_schema.sql`, `global/`, and `schemas/` are not stable
 - Refresh can overwrite uncommitted Git changes in generated workspace files
 - If you want `--git-changes` to reflect only later hand edits, commit the refreshed `supabase/workspace/schemas` to Git after syncing the remote database and before editing files.
-- Remote `dev` remains the canonical generated-schema target. A schema-changing PR may commit an exact-local review snapshot after a blank migration rebuild, targeted contract tests, and a second deterministic regeneration show no drift. After merge, the native Dev deployment must reach the exact head, hosted catalog checks must pass, and a remote-Dev refresh must be compared with the review snapshot; commit any resulting drift as a follow-up.
+- Remote `dev` remains the canonical generated-schema target. A schema-changing PR may commit an exact-local review snapshot after a blank migration rebuild, targeted contract tests, and a second deterministic regeneration show no drift. After merge, the database-only Dev deployment must reach the exact head, hosted catalog checks must pass, and a remote-Dev refresh must be compared with the review snapshot; commit any resulting drift as a follow-up.
 
 ### `build_database_types.py`
 

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
-lastReviewedNote: "已为 Issue #422 运行时 ACL 修复复核：有数据升级验证现覆盖 authenticated RLS helper 与 Edge release façade 的精确授权。"
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "已为 Issue #422 更新：workflow 契约 helper 现强制唯一数据库专用 Dev db push，并拒绝 Functions/config 部署。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -82,10 +82,10 @@ python scripts/test_resolve_migration_head.py
 
 ### `test_supabase_dev_workflow_contract.py`
 
-当持久化 Dev 验证 workflow 重新引入数据库密码、`db push`、`config push` 或
-Management API 写操作，或者重新手工固定 migration head 时立即失败；同时要求
-Hosted job 从自己的 checkout 调用 `resolve_migration_head.py`，并把该 step output
-传给 exact-head readback。
+除非持久化 Dev workflow 在绑定目标项目后准确执行一次
+`supabase db push --include-all`，否则立即失败。该契约同时拒绝 Functions
+deploy/delete、`config push`、Management API 写操作和手工固定 migration head，
+并要求 Hosted job 使用同一 checkout 完成 exact-head readback。
 
 ```bash
 python scripts/test_supabase_dev_workflow_contract.py
@@ -187,7 +187,7 @@ python scripts/build_schema_workspace.py --environment local
 - `remote_schema.sql`、`global/` 和 `schemas/` 中的手工修改都不稳定
 - 刷新时可能覆盖这些生成文件里尚未提交到 Git 的改动
 - 如果你希望 `--git-changes` 只反映后续手工修改，应在同步远程数据库并刷新 workspace 之后，先把新的 `supabase/workspace/schemas` 提交到 Git，再开始编辑
-- 远程 `dev` 仍是生成 schema 的权威目标。Schema 变更 PR 可以提交 exact-local 审查快照，但必须先通过空库 migration 重建、定向合同测试，并再次生成证明无漂移。合并后，原生 Dev 部署必须到达准确 head、托管 catalog 检查必须通过，还要将 remote-Dev 刷新结果与审查快照比较；若有漂移，以后续提交收口。
+- 远程 `dev` 仍是生成 schema 的权威目标。Schema 变更 PR 可以提交 exact-local 审查快照，但必须先通过空库 migration 重建、定向合同测试，并再次生成证明无漂移。合并后，数据库专用 Dev 部署必须到达准确 head、托管 catalog 检查必须通过，还要将 remote-Dev 刷新结果与审查快照比较；若有漂移，以后续提交收口。
 
 ### `build_database_types.py`
 

--- a/scripts/test_supabase_dev_workflow_contract.py
+++ b/scripts/test_supabase_dev_workflow_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail closed if persistent-Dev verification becomes a second deployer."""
+"""Fail closed if persistent-Dev deployment exceeds the database boundary."""
 
 from __future__ import annotations
 
@@ -19,10 +19,8 @@ def main() -> int:
     lowered = text.lower()
 
     forbidden = {
-        "database password": "supabase_db_password",
-        "manual project link": "supabase link",
-        "second migration deployer": "supabase db push",
-        "second config deployer": "supabase config push",
+        "Edge Functions command": "supabase functions",
+        "project configuration deploy": "supabase config push",
         "Management API mutation": "--request patch",
     }
     failures = [label for label, token in forbidden.items() if token in lowered]
@@ -31,9 +29,13 @@ def main() -> int:
     if re.search(r'EXPECTED_MIGRATION_HEAD:\s*["\']?\d{14}', text):
         failures.append("migration head must not be pinned manually")
 
-    hosted_workflow = text.split("  hosted-read-only:", 1)[-1]
+    hosted_workflow = text.split("  deploy-and-verify:", 1)[-1]
     hosted_required = (
         "uses: actions/checkout@v6",
+        "needs: local-contract",
+        "SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}",
+        'supabase link --project-ref "$SUPABASE_PROJECT_ID"',
+        "supabase db push --include-all",
         "id: migration_head",
         "python scripts/resolve_migration_head.py",
         "EXPECTED_MIGRATION_HEAD: ${{ steps.migration_head.outputs.head }}",
@@ -44,9 +46,20 @@ def main() -> int:
         if token not in hosted_workflow
     )
 
+    if lowered.count("supabase db push --include-all") != 1:
+        failures.append("workflow must contain exactly one database-only db push")
+
+    deployment_order = (
+        hosted_workflow.find('supabase link --project-ref "$SUPABASE_PROJECT_ID"'),
+        hosted_workflow.find("supabase db push --include-all"),
+        hosted_workflow.find("id: migration_head"),
+    )
+    if -1 not in deployment_order and deployment_order != tuple(sorted(deployment_order)):
+        failures.append("link, migration push, and exact-head verification are out of order")
+
     required = (
         "pull_request:",
-        "supabase-dev-verification-${{ github.ref }}",
+        "supabase-dev-deployment-${{ github.ref }}",
         "cancel-in-progress: true",
         "github.event_name == 'push' && github.ref == 'refs/heads/dev'",
         "python scripts/test_resolve_migration_head.py",
@@ -72,7 +85,7 @@ def main() -> int:
         return 1
 
     print(
-        "PASS: Supabase Dev workflow is read-only and waits for exact head "
+        "PASS: Supabase Dev workflow deploys migrations only and verifies exact head "
         f"{expected_head}"
     )
     return 0

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -20,9 +20,9 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
-lastReviewedNote: "Reviewed for Issue #422 ACL runtime repair: no generated-workspace workflow or stable-overlay contract change is required."
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "Reviewed for Issue #422 database-only Dev deployment: generated-workspace behavior is unchanged; hosted provenance now follows the GitHub Actions db-push path."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -96,7 +96,7 @@ python scripts/build_schema_workspace.py --environment local \
   --schemas public api private util archive
 ```
 
-For a schema-changing PR, this exact-local output may be committed as a review snapshot after a blank migration rebuild, targeted contract tests, and a second deterministic regeneration show no drift. It is not yet hosted provenance. After merge, require the native Dev deployment to reach the exact migration head, pass the hosted catalog checks, and compare a remote-Dev refresh with this snapshot; commit any resulting drift as a follow-up.
+For a schema-changing PR, this exact-local output may be committed as a review snapshot after a blank migration rebuild, targeted contract tests, and a second deterministic regeneration show no drift. It is not yet hosted provenance. After merge, require the database-only Dev deployment to reach the exact migration head, pass the hosted catalog checks, and compare a remote-Dev refresh with this snapshot; commit any resulting drift as a follow-up.
 
 Regenerate the checked-in Data API type contract from that same exact local migration state:
 

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-07
-lastReviewedCommit: c6d3e24ba8fbe0eb99b56a9aff9180c964dd9ca8
-lastReviewedNote: "已为 Issue #422 运行时 ACL 修复复核：无需调整生成 workspace 流程或稳定 overlay 合同。"
+lastReviewedAt: 2026-08-08
+lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedNote: "已为 Issue #422 数据库专用 Dev 部署复核：生成 workspace 行为不变，托管来源改由 GitHub Actions db-push 路径确认。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -95,7 +95,7 @@ python scripts/build_schema_workspace.py --environment local \
   --schemas public api private util archive
 ```
 
-Schema 变更 PR 可以把该 exact-local 结果作为审查快照提交，但必须先通过空库 migration 重建、定向合同测试，并再次生成证明无漂移；此时它还不代表托管来源。合并后必须确认原生 Dev 部署到达准确 migration head、托管 catalog 检查通过，并把 remote-Dev 刷新结果与本快照比较；若有漂移，以后续提交收口。
+Schema 变更 PR 可以把该 exact-local 结果作为审查快照提交，但必须先通过空库 migration 重建、定向合同测试，并再次生成证明无漂移；此时它还不代表托管来源。合并后必须确认数据库专用 Dev 部署到达准确 migration head、托管 catalog 检查通过，并把 remote-Dev 刷新结果与本快照比较；若有漂移，以后续提交收口。
 
 随后应从同一个本地完整 migration 状态生成纳入版本控制的 Data API 类型合同：
 


### PR DESCRIPTION
## Summary
- Refs #422。将 persistent Dev migration 部署恢复为仓库 GitHub Actions 中的 supabase link + supabase db push --include-all；本 PR 不关闭整体 schema 重构 Issue。
- 保留现有 blank-to-head、本地 capability tests、generated workspace/types drift、exact hosted migration head 与 PostgREST boundary 验证。

## Key Decisions
- Hosted deploy job 仅在 Git dev push 且 local-contract 成功后运行；PR 事件不会连接 persistent Dev。
- workflow 契约禁止任何 supabase functions 命令、supabase config push 和 Management API mutation，并要求准确一次 db push --include-all。

## Validation
- python scripts/test_resolve_migration_head.py
- python scripts/test_supabase_dev_workflow_contract.py
- Ruby YAML parse；git diff --check；scripts/docpact-gate.sh --base origin/dev
- supabase db reset --no-seed；supabase migration list --local；本地重生成 schema workspace/types 无业务漂移
- 四个 20260805/20260806 schema/capability pgTAP 文件通过；scripts/test_full_schema_cutover_upgrade.sh 通过
- persistent Dev: supabase db push --include-all --dry-run --db-url ... 返回 Remote database is up to date（只读，未写数据库）

## Risks / Rollback
- 合并前必须在 Supabase Dashboard 关闭 Git dev 的原生 deployment 绑定；否则合并 push 会同时触发原生全量同步，仍可能覆盖 Edge Functions。
- 回滚方式：revert 本 PR，并在重新启用原生 Dev 部署前确认 Edge Functions owner 与恢复顺序。

## Follow-ups
- 合并后确认 GitHub Actions 使用 SUPABASE_DEV_DB_PASSWORD 成功完成 no-op/后续 migration push，并重验 exact head 与 Hosted boundary。

## Workspace Integration
- database-engine 为 M2 仓；本 PR 合并 dev 后不直接更新 workspace main pointer，待 dev -> main promote 后再做 root integration。