### PR TITLE
docs: 明确 Supabase Preview 的 Functions 验证方式

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "78134bdf89ee4a727e8b49cd0af47fb06cac10a9"
+lastReviewedCommit: "8be75648495ddc6a582ce63b5723bcbc75c03119"
 lastReviewedNote: "Updated for Issue #422: persistent Dev uses the database-only db-push workflow again, with native Git dev deployment excluded from ownership."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
 lastReviewedNote: "Updated for Issue #422: persistent Dev migrations are again deployed by the database-only GitHub Actions db-push path; Supabase native deployment must not compete for Git dev."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
 lastReviewedNote: "Updated for Issue #422: persistent Dev migration ownership returns to the database-only GitHub Actions db-push path without changing schema ownership."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
 lastReviewedNote: "Updated for Issue #422: workflow proof now requires one database-only db push followed by exact-head and hosted-boundary verification, with no Functions or config deployment."
 related:
   - ../../AGENTS.md

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -21,8 +21,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
-lastReviewedNote: "Updated for Issue #422: persistent Dev migration deployment is owned by the database-only GitHub Actions db-push path; native Git dev deployment must be disabled."
+lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
+lastReviewedNote: "Updated for Issue #422: added deterministic Edge Function verification for Supabase Preview and native branch runs."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -81,6 +81,13 @@ When review changes an already-applied PR migration, add a later migration that 
 - Disable the Supabase native deployment binding for Git `dev` before this workflow reaches `dev`; two deployers must never target the same persistent branch.
 - Do not add a checked-in GitHub Actions production deploy for Git `main`; the production project is migrated by the Supabase GitHub integration bound to this repository.
 - Do not author normal schema changes by editing the remote database first and reconstructing migrations later.
+
+### Edge Function ownership verification
+
+- A successful `Supabase Preview` check proves that the native branch workflow ran; it does not by itself prove that deployed Edge Function content changed.
+- `tiangong-lca-edge-functions` remains the source of truth and deployer for Edge Function runtime code. This repository must not add or deploy Edge Function sources.
+- To determine whether a database-native run changed the persistent Dev Functions, capture the same sorted inventory of Edge-repo-owned function slugs and their hosted content hashes immediately before and after the run, then compare the deterministic inventory digest.
+- An unchanged digest means the owned Function content was preserved. Treat a changed digest, owned-function inventory, `verify_jwt` setting, or active state as an ownership-boundary failure that requires investigation.
 
 ## Files to maintain
 

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
-lastReviewedNote: "已为 Issue #422 更新：持久化 Dev migration 恢复由数据库专用 GitHub Actions db-push 路径负责，必须关闭 Git dev 的原生部署绑定。"
+lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
+lastReviewedNote: "已为 Issue #422 更新：增加 Supabase Preview 与原生分支流程的确定性 Edge Function 验证规则。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -79,6 +79,13 @@ related:
 - 在该 workflow 进入 `dev` 前关闭 Git `dev` 的 Supabase 原生部署绑定；同一个持久化分支不能同时存在两个部署者。
 - 不要为 Git `main` 增加 checked-in 的 GitHub Actions 生产部署流程；生产项目由绑定到本仓的 Supabase GitHub integration 自动迁移。
 - 不要先手改远端数据库再回头补 migration。
+
+### Edge Function 所有权验证
+
+- `Supabase Preview` 检查成功只表示原生分支流程已经运行，不能单独证明已部署的 Edge Function 内容发生了变化。
+- `tiangong-lca-edge-functions` 仍是 Edge Function 运行时代码的真相源与部署者；本仓不得新增或部署 Edge Function 源码。
+- 要判断 database-native 流程是否修改了持久化 Dev Functions，应在流程运行前后，对同一组 Edge 仓所拥有的 function slug 与托管内容哈希进行排序并计算确定性清单摘要，然后比较两次结果。
+- 摘要不变表示受管 Function 内容得到保留；如果摘要、受管函数清单、`verify_jwt` 设置或 active 状态发生变化，则视为所有权边界失败并继续调查。
 
 ## 需要维护的文件
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -9,6 +9,8 @@ project_id = "database-engine"
 # - Pull requests / feature branches -> ephemeral preview branches inheriting the shared baseline
 # Keep branch-specific overrides under [remotes.<branch>] instead of duplicating the `supabase/`
 # directory per Git branch.
+# Edge Function source and deployment remain in `tiangong-lca-edge-functions`; this project
+# intentionally contains no `supabase/functions/` runtime source.
 
 [api]
 enabled = true


### PR DESCRIPTION
## 变更

- 明确 `Supabase Preview` 成功不等于 Edge Function 内容发生变化。
- 固化 database-native 流程前后按 Edge 仓受管函数清单与内容哈希比较的验证方式。
- 在 `supabase/config.toml` 增加两行无行为变化的所有权注释，使原生 Preview 能被实际触发。
- 保持 `tiangong-lca-edge-functions` 为 Function 运行时代码唯一 owner；database-engine 不新增 Function 源码或部署动作。

## 本次探针基线

- persistent Dev 项目：`submidrhbtknjxfympna`
- Edge 精确来源：`579dce72d25937ed78a694d42c6ad9bdb3a79976`
- 受管函数数：78
- 运行前内容摘要：`9fb221bbbe0e1f667fbdace7dded751d73458bad8639569d972f6af39d47da3c`
- 原生流程运行后，对同一排序清单重新计算摘要。

## 验证

- `supabase start`
- `supabase db reset`（blank-to-head 成功，migration head `20260807233000`）
- `scripts/docpact lint --root . --files ".docpact/config.yaml,AGENTS.md,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,docs/agents/supabase-branching.md,docs/agents/supabase-branching_CN.md,supabase/config.toml" --mode enforce --format json`
- `scripts/docpact validate-config --root . --strict`
- `git diff --check`
- pre-push Docpact gate

本 PR 不修改 migration、workflow 或运行时代码；`config.toml` 仅新增注释。

Part of #422