### PR TITLE
fix: restore team member identity fields

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "1d1d153edb92aa01dd5fb7717441b16bedc4a96b"
+lastReviewedCommit: "6ffdc9abd6bbf939fbb2fdae9a82aa839b0d9912"
 lastReviewedNote: "Reviewed for Issue #422: persistent Dev deploys and verifies database migrations here, then deploys and validates Functions through the Edge repository."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "8be75648495ddc6a582ce63b5723bcbc75c03119"
+lastReviewedCommit: "1d1d153edb92aa01dd5fb7717441b16bedc4a96b"
 lastReviewedNote: "Updated for Issue #422: persistent Dev uses the database-only db-push workflow again, with native Git dev deployment excluded from ownership."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "0ae372244bfffc680f12d1917718c10435a3b6d0"
+lastReviewedCommit: "8a821145d804b44d0958fb64f7f89a7812bdf825"
 lastReviewedNote: "Updated for Issue #422: persistent Dev uses the database-only db-push workflow again, with native Git dev deployment excluded from ownership."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "88cf87cabc902d694080cb84a07e582aa15de0d7"
+lastReviewedCommit: "0ae372244bfffc680f12d1917718c10435a3b6d0"
 lastReviewedNote: "Updated for Issue #422: persistent Dev uses the database-only db-push workflow again, with native Git dev deployment excluded from ownership."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "1d1d153edb92aa01dd5fb7717441b16bedc4a96b"
+lastReviewedCommit: "88cf87cabc902d694080cb84a07e582aa15de0d7"
 lastReviewedNote: "Updated for Issue #422: persistent Dev uses the database-only db-push workflow again, with native Git dev deployment excluded from ownership."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedCommit: 6ffdc9abd6bbf939fbb2fdae9a82aa839b0d9912
 lastReviewedNote: "Reviewed for Issue #422: persistent Dev delivery runs the database migration and verification here, then deploys and validates Functions through the Edge repository."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0ae372244bfffc680f12d1917718c10435a3b6d0
+lastReviewedCommit: 8a821145d804b44d0958fb64f7f89a7812bdf825
 lastReviewedNote: "Updated for Issue #422: persistent Dev migrations are again deployed by the database-only GitHub Actions db-push path; Supabase native deployment must not compete for Git dev."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
+lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
 lastReviewedNote: "Updated for Issue #422: persistent Dev migrations are again deployed by the database-only GitHub Actions db-push path; Supabase native deployment must not compete for Git dev."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
+lastReviewedCommit: 0ae372244bfffc680f12d1917718c10435a3b6d0
 lastReviewedNote: "Updated for Issue #422: persistent Dev migrations are again deployed by the database-only GitHub Actions db-push path; Supabase native deployment must not compete for Git dev."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
 lastReviewedNote: "Updated for Issue #422: persistent Dev migrations are again deployed by the database-only GitHub Actions db-push path; Supabase native deployment must not compete for Git dev."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0ae372244bfffc680f12d1917718c10435a3b6d0
+lastReviewedCommit: 8a821145d804b44d0958fb64f7f89a7812bdf825
 lastReviewedNote: "Updated for Issue #422: persistent Dev migration ownership returns to the database-only GitHub Actions db-push path without changing schema ownership."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedCommit: 6ffdc9abd6bbf939fbb2fdae9a82aa839b0d9912
 lastReviewedNote: "Reviewed for Issue #422: persistent Dev keeps database migration deployment here and Function deployment in the Edge repository."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
+lastReviewedCommit: 0ae372244bfffc680f12d1917718c10435a3b6d0
 lastReviewedNote: "Updated for Issue #422: persistent Dev migration ownership returns to the database-only GitHub Actions db-push path without changing schema ownership."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
+lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
 lastReviewedNote: "Updated for Issue #422: persistent Dev migration ownership returns to the database-only GitHub Actions db-push path without changing schema ownership."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
 lastReviewedNote: "Updated for Issue #422: persistent Dev migration ownership returns to the database-only GitHub Actions db-push path without changing schema ownership."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
 lastReviewedNote: "Updated for Issue #422: workflow proof now requires one database-only db push followed by exact-head and hosted-boundary verification, with no Functions or config deployment."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 0ae372244bfffc680f12d1917718c10435a3b6d0
+lastReviewedCommit: 8a821145d804b44d0958fb64f7f89a7812bdf825
 lastReviewedNote: "Updated for Issue #422: workflow proof now requires one database-only db push followed by exact-head and hosted-boundary verification, with no Functions or config deployment."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
+lastReviewedCommit: 0ae372244bfffc680f12d1917718c10435a3b6d0
 lastReviewedNote: "Updated for Issue #422: workflow proof now requires one database-only db push followed by exact-head and hosted-boundary verification, with no Functions or config deployment."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
+lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
 lastReviewedNote: "Updated for Issue #422: workflow proof now requires one database-only db push followed by exact-head and hosted-boundary verification, with no Functions or config deployment."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedCommit: 6ffdc9abd6bbf939fbb2fdae9a82aa839b0d9912
 lastReviewedNote: "Reviewed for Issue #422: persistent-Dev proof records the database deployment here and the subsequent Function deployment in the Edge repository."
 related:
   - ../../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
+lastReviewedCommit: 8a821145d804b44d0958fb64f7f89a7812bdf825
 lastReviewedNote: "Updated for Issue #422: the workflow contract helper now enforces one database-only persistent Dev db push and rejects Functions/config deployment."
 related:
   - ../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
 lastReviewedNote: "Updated for Issue #422: the workflow contract helper now enforces one database-only persistent Dev db push and rejects Functions/config deployment."
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
+lastReviewedCommit: 8a821145d804b44d0958fb64f7f89a7812bdf825
 lastReviewedNote: "已为 Issue #422 更新：workflow 契约 helper 现强制唯一数据库专用 Dev db push，并拒绝 Functions/config 部署。"
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
 lastReviewedNote: "已为 Issue #422 更新：workflow 契约 helper 现强制唯一数据库专用 Dev db push，并拒绝 Functions/config 部署。"
 related:
   - ../AGENTS.md

--- a/supabase/migrations/20260808090000_fix_team_member_identity_fields.sql
+++ b/supabase/migrations/20260808090000_fix_team_member_identity_fields.sql
@@ -1,0 +1,84 @@
+create or replace function api.qry_team_get_member_list(
+  p_team_id uuid,
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'created_at'::text,
+  p_sort_order text default 'desc'::text
+)
+returns table(
+  user_id uuid,
+  team_id uuid,
+  role text,
+  email text,
+  display_name text,
+  created_at timestamptz,
+  modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path to 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+as $function$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_page_size, 10), 100));
+  v_offset integer := (greatest(coalesce(p_page, 1), 1) - 1) * v_limit;
+  v_order_by text := api.cmd_membership_resolve_member_order_by(p_sort_by, false);
+  v_order_dir text := api.cmd_membership_resolve_sort_direction(p_sort_order);
+begin
+  if v_actor is null then
+    return;
+  end if;
+
+  if not api.cmd_membership_is_team_manager(v_actor, p_team_id) then
+    return;
+  end if;
+
+  return query execute format(
+    $sql$
+      with members as (
+        select
+          membership.user_id,
+          membership.team_id,
+          membership.role::text as role,
+          coalesce(
+            nullif(btrim(auth_user.email), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'email'), ''),
+            ''
+          ) as email,
+          coalesce(
+            nullif(btrim(profile.raw_user_meta_data ->> 'display_name'), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'name'), ''),
+            nullif(btrim(auth_user.email), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'email'), ''),
+            '-'
+          ) as display_name,
+          membership.created_at,
+          membership.modified_at
+        from private.roles as membership
+        left join private.users as profile
+          on profile.id = membership.user_id
+        left join auth.users as auth_user
+          on auth_user.id = membership.user_id
+        where membership.team_id = $1
+      )
+      select
+        m.user_id,
+        m.team_id,
+        m.role,
+        m.email,
+        m.display_name,
+        m.created_at,
+        m.modified_at,
+        count(*) over() as total_count
+      from members as m
+      order by %s %s nulls last, m.user_id asc
+      limit $2
+      offset $3
+    $sql$,
+    v_order_by,
+    v_order_dir
+  )
+  using p_team_id, v_limit, v_offset;
+end;
+$function$;

--- a/supabase/migrations/20260808120000_fix_system_member_identity_fields.sql
+++ b/supabase/migrations/20260808120000_fix_system_member_identity_fields.sql
@@ -1,7 +1,23 @@
-CREATE OR REPLACE FUNCTION "api"."qry_system_get_member_list"("p_page" integer DEFAULT 1, "p_page_size" integer DEFAULT 10, "p_sort_by" "text" DEFAULT 'created_at'::"text", "p_sort_order" "text" DEFAULT 'desc'::"text") RETURNS TABLE("user_id" "uuid", "team_id" "uuid", "role" "text", "email" "text", "display_name" "text", "created_at" timestamp with time zone, "modified_at" timestamp with time zone, "total_count" bigint)
-    LANGUAGE "plpgsql" SECURITY DEFINER
-    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
-    AS $_$
+create or replace function api.qry_system_get_member_list(
+  p_page integer default 1,
+  p_page_size integer default 10,
+  p_sort_by text default 'created_at'::text,
+  p_sort_order text default 'desc'::text
+)
+returns table(
+  user_id uuid,
+  team_id uuid,
+  role text,
+  email text,
+  display_name text,
+  created_at timestamptz,
+  modified_at timestamptz,
+  total_count bigint
+)
+language plpgsql
+security definer
+set search_path to 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+as $function$
 declare
   v_actor uuid := auth.uid();
   v_team_id uuid := '00000000-0000-0000-0000-000000000000'::uuid;
@@ -66,12 +82,4 @@ begin
   )
   using v_team_id, v_limit, v_offset;
 end;
-$_$;
-
-ALTER FUNCTION "api"."qry_system_get_member_list"("p_page" integer, "p_page_size" integer, "p_sort_by" "text", "p_sort_order" "text") OWNER TO "postgres";
-
-REVOKE ALL ON FUNCTION "api"."qry_system_get_member_list"("p_page" integer, "p_page_size" integer, "p_sort_by" "text", "p_sort_order" "text") FROM PUBLIC;
-
-GRANT ALL ON FUNCTION "api"."qry_system_get_member_list"("p_page" integer, "p_page_size" integer, "p_sort_by" "text", "p_sort_order" "text") TO "api_internal_executor";
-
-GRANT ALL ON FUNCTION "api"."qry_system_get_member_list"("p_page" integer, "p_page_size" integer, "p_sort_by" "text", "p_sort_order" "text") TO "authenticated";
+$function$;

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260807233000'::text,
+  '20260808090000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260808090000'::text,
+  '20260808120000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260808_system_member_identity_fields.sql
+++ b/supabase/tests/20260808_system_member_identity_fields.sql
@@ -1,0 +1,287 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(13);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43200000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'system-owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43200000-0000-0000-0000-000000000001","display_name":"System Owner"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43200000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'system-admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43200000-0000-0000-0000-000000000002","name":"System Admin"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43200000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'system-member@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43200000-0000-0000-0000-000000000003"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43200000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    null,
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43200000-0000-0000-0000-000000000004","email":"legacy-system-member@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43200000-0000-0000-0000-000000000005',
+    'authenticated',
+    'authenticated',
+    'system-outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43200000-0000-0000-0000-000000000005","display_name":"System Outsider"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into private.users (id, raw_user_meta_data, contact)
+values
+  (
+    '43200000-0000-0000-0000-000000000001',
+    '{"sub":"43200000-0000-0000-0000-000000000001","display_name":"System Owner"}'::jsonb,
+    null
+  ),
+  (
+    '43200000-0000-0000-0000-000000000002',
+    '{"sub":"43200000-0000-0000-0000-000000000002","name":"System Admin"}'::jsonb,
+    null
+  ),
+  (
+    '43200000-0000-0000-0000-000000000003',
+    '{"sub":"43200000-0000-0000-0000-000000000003"}'::jsonb,
+    null
+  ),
+  (
+    '43200000-0000-0000-0000-000000000004',
+    '{"sub":"43200000-0000-0000-0000-000000000004","email":"legacy-system-member@example.com"}'::jsonb,
+    null
+  ),
+  (
+    '43200000-0000-0000-0000-000000000005',
+    '{"sub":"43200000-0000-0000-0000-000000000005","display_name":"System Outsider"}'::jsonb,
+    null
+  );
+
+insert into private.roles (user_id, team_id, role, modified_at)
+values
+  (
+    '43200000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000000',
+    'owner',
+    now()
+  ),
+  (
+    '43200000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000000',
+    'admin',
+    now()
+  ),
+  (
+    '43200000-0000-0000-0000-000000000003',
+    '00000000-0000-0000-0000-000000000000',
+    'member',
+    now()
+  ),
+  (
+    '43200000-0000-0000-0000-000000000004',
+    '00000000-0000-0000-0000-000000000000',
+    'member',
+    now()
+  );
+
+select ok(
+  has_function_privilege(
+    'authenticated',
+    'api.qry_system_get_member_list(integer,integer,text,text)',
+    'EXECUTE'
+  )
+  and not has_function_privilege(
+    'anon',
+    'api.qry_system_get_member_list(integer,integer,text,text)',
+    'EXECUTE'
+  ),
+  'system member list keeps its authenticated-only execute boundary'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '43200000-0000-0000-0000-000000000001', true);
+
+select is(
+  (select count(*)::text from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')),
+  '4',
+  'system owner can read the complete system member list'
+);
+
+select is(
+  (
+    select email
+    from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')
+    where user_id = '43200000-0000-0000-0000-000000000001'
+  ),
+  'system-owner@example.com',
+  'system member email comes from the canonical auth identity when metadata omits it'
+);
+
+select is(
+  (
+    select display_name
+    from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')
+    where user_id = '43200000-0000-0000-0000-000000000001'
+  ),
+  'System Owner',
+  'display_name metadata remains the preferred system member name'
+);
+
+select is(
+  (
+    select display_name
+    from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')
+    where user_id = '43200000-0000-0000-0000-000000000002'
+  ),
+  'System Admin',
+  'name metadata is used when system member display_name is absent'
+);
+
+select is(
+  (
+    select display_name
+    from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')
+    where user_id = '43200000-0000-0000-0000-000000000003'
+  ),
+  'system-member@example.com',
+  'canonical email is the system member name fallback when profile names are absent'
+);
+
+select is(
+  (
+    select email
+    from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')
+    where user_id = '43200000-0000-0000-0000-000000000004'
+  ),
+  'legacy-system-member@example.com',
+  'metadata email remains a system member compatibility fallback when auth email is absent'
+);
+
+select is(
+  (
+    select display_name
+    from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')
+    where user_id = '43200000-0000-0000-0000-000000000004'
+  ),
+  'legacy-system-member@example.com',
+  'metadata email is also the final system member name compatibility fallback'
+);
+
+select is(
+  (select total_count::text from api.qry_system_get_member_list(1, 1, 'created_at', 'desc')),
+  '4',
+  'pagination retains the full system member count'
+);
+
+select is(
+  (
+    select role
+    from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')
+    where user_id = '43200000-0000-0000-0000-000000000003'
+  ),
+  'member',
+  'system member roles remain unchanged'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '43200000-0000-0000-0000-000000000002', true);
+
+select is(
+  (select count(*)::text from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')),
+  '4',
+  'system admin retains system member list visibility'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '43200000-0000-0000-0000-000000000003', true);
+
+select is(
+  (select count(*)::text from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')),
+  '4',
+  'ordinary system members retain their existing system member list visibility'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '43200000-0000-0000-0000-000000000005', true);
+
+select is(
+  (select count(*)::text from api.qry_system_get_member_list(1, 20, 'created_at', 'desc')),
+  '0',
+  'users outside the system team cannot read the system member list'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/20260808_team_member_identity_fields.sql
+++ b/supabase/tests/20260808_team_member_identity_fields.sql
@@ -1,0 +1,383 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(13);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43100000-0000-0000-0000-000000000001',
+    'authenticated',
+    'authenticated',
+    'owner@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43100000-0000-0000-0000-000000000001","display_name":"Team Owner"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43100000-0000-0000-0000-000000000002',
+    'authenticated',
+    'authenticated',
+    'admin@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43100000-0000-0000-0000-000000000002","name":"Team Admin"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43100000-0000-0000-0000-000000000003',
+    'authenticated',
+    'authenticated',
+    'member@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43100000-0000-0000-0000-000000000003"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43100000-0000-0000-0000-000000000004',
+    'authenticated',
+    'authenticated',
+    null,
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43100000-0000-0000-0000-000000000004","email":"legacy-invitee@example.com"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '43100000-0000-0000-0000-000000000005',
+    'authenticated',
+    'authenticated',
+    'outsider@example.com',
+    'test-password-hash',
+    now(),
+    '{"provider":"email","providers":["email"]}'::jsonb,
+    '{"sub":"43100000-0000-0000-0000-000000000005","display_name":"Outsider"}'::jsonb,
+    now(),
+    now(),
+    false,
+    false
+  );
+
+insert into private.users (id, raw_user_meta_data, contact)
+values
+  (
+    '43100000-0000-0000-0000-000000000001',
+    '{"sub":"43100000-0000-0000-0000-000000000001","display_name":"Team Owner"}'::jsonb,
+    null
+  ),
+  (
+    '43100000-0000-0000-0000-000000000002',
+    '{"sub":"43100000-0000-0000-0000-000000000002","name":"Team Admin"}'::jsonb,
+    null
+  ),
+  (
+    '43100000-0000-0000-0000-000000000003',
+    '{"sub":"43100000-0000-0000-0000-000000000003"}'::jsonb,
+    null
+  ),
+  (
+    '43100000-0000-0000-0000-000000000004',
+    '{"sub":"43100000-0000-0000-0000-000000000004","email":"legacy-invitee@example.com"}'::jsonb,
+    null
+  ),
+  (
+    '43100000-0000-0000-0000-000000000005',
+    '{"sub":"43100000-0000-0000-0000-000000000005","display_name":"Outsider"}'::jsonb,
+    null
+  );
+
+insert into private.teams (id, json, rank, is_public, modified_at)
+values (
+  '43110000-0000-0000-0000-000000000001',
+  '{"title":[{"@xml:lang":"en","#text":"Identity Team"}]}'::jsonb,
+  1,
+  false,
+  now()
+);
+
+insert into private.roles (user_id, team_id, role, modified_at)
+values
+  (
+    '43100000-0000-0000-0000-000000000001',
+    '43110000-0000-0000-0000-000000000001',
+    'owner',
+    now()
+  ),
+  (
+    '43100000-0000-0000-0000-000000000002',
+    '43110000-0000-0000-0000-000000000001',
+    'admin',
+    now()
+  ),
+  (
+    '43100000-0000-0000-0000-000000000003',
+    '43110000-0000-0000-0000-000000000001',
+    'member',
+    now()
+  ),
+  (
+    '43100000-0000-0000-0000-000000000004',
+    '43110000-0000-0000-0000-000000000001',
+    'is_invited',
+    now()
+  );
+
+select ok(
+  has_function_privilege(
+    'authenticated',
+    'api.qry_team_get_member_list(uuid,integer,integer,text,text)',
+    'EXECUTE'
+  )
+  and not has_function_privilege(
+    'anon',
+    'api.qry_team_get_member_list(uuid,integer,integer,text,text)',
+    'EXECUTE'
+  ),
+  'team member list keeps its authenticated-only execute boundary'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '43100000-0000-0000-0000-000000000001', true);
+
+select is(
+  (
+    select count(*)::text
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+  ),
+  '4',
+  'team owner can read the complete member list'
+);
+
+select is(
+  (
+    select email
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+    where user_id = '43100000-0000-0000-0000-000000000001'
+  ),
+  'owner@example.com',
+  'team member email comes from the canonical auth identity when metadata omits it'
+);
+
+select is(
+  (
+    select display_name
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+    where user_id = '43100000-0000-0000-0000-000000000001'
+  ),
+  'Team Owner',
+  'display_name metadata remains the preferred member name'
+);
+
+select is(
+  (
+    select display_name
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+    where user_id = '43100000-0000-0000-0000-000000000002'
+  ),
+  'Team Admin',
+  'name metadata is used when display_name is absent'
+);
+
+select is(
+  (
+    select display_name
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+    where user_id = '43100000-0000-0000-0000-000000000003'
+  ),
+  'member@example.com',
+  'canonical email is the member name fallback when profile names are absent'
+);
+
+select is(
+  (
+    select email
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+    where user_id = '43100000-0000-0000-0000-000000000004'
+  ),
+  'legacy-invitee@example.com',
+  'metadata email remains a compatibility fallback when auth email is absent'
+);
+
+select is(
+  (
+    select display_name
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+    where user_id = '43100000-0000-0000-0000-000000000004'
+  ),
+  'legacy-invitee@example.com',
+  'metadata email is also the final member name compatibility fallback'
+);
+
+select is(
+  (
+    select total_count::text
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      1,
+      'created_at',
+      'desc'
+    )
+  ),
+  '4',
+  'pagination retains the full team member count'
+);
+
+select is(
+  (
+    select role
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+    where user_id = '43100000-0000-0000-0000-000000000003'
+  ),
+  'member',
+  'member roles remain unchanged'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '43100000-0000-0000-0000-000000000002', true);
+
+select is(
+  (
+    select count(*)::text
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+  ),
+  '4',
+  'team admin retains manager visibility'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '43100000-0000-0000-0000-000000000003', true);
+
+select is(
+  (
+    select count(*)::text
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+  ),
+  '0',
+  'ordinary team members still cannot read the member list'
+);
+
+reset role;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '43100000-0000-0000-0000-000000000005', true);
+
+select is(
+  (
+    select count(*)::text
+    from api.qry_team_get_member_list(
+      '43110000-0000-0000-0000-000000000001',
+      1,
+      20,
+      'created_at',
+      'desc'
+    )
+  ),
+  '0',
+  'non-members cannot read the team member list'
+);
+
+select * from finish();
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
+lastReviewedCommit: 8a821145d804b44d0958fb64f7f89a7812bdf825
 lastReviewedNote: "Reviewed for Issue #422 database-only Dev deployment: generated-workspace behavior is unchanged; hosted provenance now follows the GitHub Actions db-push path."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
 lastReviewedNote: "Reviewed for Issue #422 database-only Dev deployment: generated-workspace behavior is unchanged; hosted provenance now follows the GitHub Actions db-push path."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 78134bdf89ee4a727e8b49cd0af47fb06cac10a9
+lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
 lastReviewedNote: "已为 Issue #422 数据库专用 Dev 部署复核：生成 workspace 行为不变，托管来源改由 GitHub Actions db-push 路径确认。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 88cf87cabc902d694080cb84a07e582aa15de0d7
+lastReviewedCommit: 8a821145d804b44d0958fb64f7f89a7812bdf825
 lastReviewedNote: "已为 Issue #422 数据库专用 Dev 部署复核：生成 workspace 行为不变，托管来源改由 GitHub Actions db-push 路径确认。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -20673,21 +20673,29 @@ begin
     $sql$
       with members as (
         select
-          r.user_id,
-          r.team_id,
-          r.role::text as role,
-          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          membership.user_id,
+          membership.team_id,
+          membership.role::text as role,
           coalesce(
-            nullif(u.raw_user_meta_data->>'display_name', ''),
-            u.raw_user_meta_data->>'email',
+            nullif(btrim(auth_user.email), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'email'), ''),
+            ''
+          ) as email,
+          coalesce(
+            nullif(btrim(profile.raw_user_meta_data ->> 'display_name'), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'name'), ''),
+            nullif(btrim(auth_user.email), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'email'), ''),
             '-'
           ) as display_name,
-          r.created_at,
-          r.modified_at
-        from private.roles as r
-        left join private.users as u
-          on u.id = r.user_id
-        where r.team_id = $1
+          membership.created_at,
+          membership.modified_at
+        from private.roles as membership
+        left join private.users as profile
+          on profile.id = membership.user_id
+        left join auth.users as auth_user
+          on auth_user.id = membership.user_id
+        where membership.team_id = $1
       )
       select
         m.user_id,

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -20416,22 +20416,30 @@ begin
     $sql$
       with members as (
         select
-          r.user_id,
-          r.team_id,
-          r.role::text as role,
-          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          membership.user_id,
+          membership.team_id,
+          membership.role::text as role,
           coalesce(
-            nullif(u.raw_user_meta_data->>'display_name', ''),
-            u.raw_user_meta_data->>'email',
+            nullif(btrim(auth_user.email), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'email'), ''),
+            ''
+          ) as email,
+          coalesce(
+            nullif(btrim(profile.raw_user_meta_data ->> 'display_name'), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'name'), ''),
+            nullif(btrim(auth_user.email), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'email'), ''),
             '-'
           ) as display_name,
-          r.created_at,
-          r.modified_at
-        from private.roles as r
-        left join private.users as u
-          on u.id = r.user_id
-        where r.team_id = $1
-          and r.role in ('owner', 'admin', 'member')
+          membership.created_at,
+          membership.modified_at
+        from private.roles as membership
+        left join private.users as profile
+          on profile.id = membership.user_id
+        left join auth.users as auth_user
+          on auth_user.id = membership.user_id
+        where membership.team_id = $1
+          and membership.role in ('owner', 'admin', 'member')
       )
       select
         m.user_id,

--- a/supabase/workspace/schemas/api/functions/qry_team_get_member_list/definition.sql
+++ b/supabase/workspace/schemas/api/functions/qry_team_get_member_list/definition.sql
@@ -21,21 +21,29 @@ begin
     $sql$
       with members as (
         select
-          r.user_id,
-          r.team_id,
-          r.role::text as role,
-          coalesce(u.raw_user_meta_data->>'email', '') as email,
+          membership.user_id,
+          membership.team_id,
+          membership.role::text as role,
           coalesce(
-            nullif(u.raw_user_meta_data->>'display_name', ''),
-            u.raw_user_meta_data->>'email',
+            nullif(btrim(auth_user.email), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'email'), ''),
+            ''
+          ) as email,
+          coalesce(
+            nullif(btrim(profile.raw_user_meta_data ->> 'display_name'), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'name'), ''),
+            nullif(btrim(auth_user.email), ''),
+            nullif(btrim(profile.raw_user_meta_data ->> 'email'), ''),
             '-'
           ) as display_name,
-          r.created_at,
-          r.modified_at
-        from private.roles as r
-        left join private.users as u
-          on u.id = r.user_id
-        where r.team_id = $1
+          membership.created_at,
+          membership.modified_at
+        from private.roles as membership
+        left join private.users as profile
+          on profile.id = membership.user_id
+        left join auth.users as auth_user
+          on auth_user.id = membership.user_id
+        where membership.team_id = $1
       )
       select
         m.user_id,


### PR DESCRIPTION
Closes tiangong-lca/database-engine#431

## Summary
- Return canonical email and stable display-name fallbacks from both `api.qry_team_get_member_list` and `api.qry_system_get_member_list`, fixing the empty identity columns in My Team and System Management.

## Key Decisions
- Read email from `auth.users.email` first, retain raw metadata email only as a compatibility fallback, and resolve member names through `display_name`, `name`, canonical email, then metadata email.
- Keep the existing authenticated execute grants, authorization gates, pagination, sorting, roles, and `total_count` contracts unchanged.
- Preserve the current system-list visibility for system `owner/admin/member`; users outside the system team still receive no rows.
- Add a forward-only system-list migration because the earlier team-list migration has already been applied to the PR Preview branch.

## Validation
- `supabase db reset --no-seed`
- `supabase test db --local supabase/tests/20260808_team_member_identity_fields.sql` (13/13 passed)
- `supabase test db --local supabase/tests/20260808_system_member_identity_fields.sql` (13/13 passed)
- `supabase test db --local supabase/tests/20260806_api_contract_closure.sql` (49/49 passed)
- `supabase migration list --local` (`20260808120000` applied)
- `supabase db lint --local --level warning` (completed; only baseline diagnostics and the existing dynamic-OUT warning shape for these RPCs)
- Rebuilt schema workspace and database types twice; generated outputs were byte-for-byte deterministic and database types did not change
- Staged and pre-push Docpact config validation and lint passed after merging the latest `origin/dev`

## Risks / Rollback
- Low functional risk: two read-only membership RPCs change identity field sources. Authorization, role filtering, pagination, and non-system-user denial are covered by pgTAP.

## Follow-ups
- The older `20260405_membership_profile_rpcs.sql` suite is currently blocked before membership assertions by `LEGACY_REVIEW_INSERT_DISABLED` and should be repaired separately.
- Persistent `dev`, production `main`, and root workspace integration proof remain deferred to their normal post-merge phases.

## Workspace Integration
- After this change is promoted from `database-engine/dev` to `main`, `lca-workspace` must bump the `database-engine` submodule pointer.
