### PR TITLE
docs: 补充数据库部署后的 Edge Functions Gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "8be75648495ddc6a582ce63b5723bcbc75c03119"
-lastReviewedNote: "Updated for Issue #422: persistent Dev uses the database-only db-push workflow again, with native Git dev deployment excluded from ownership."
+lastReviewedCommit: "1d1d153edb92aa01dd5fb7717441b16bedc4a96b"
+lastReviewedNote: "Reviewed for Issue #422: routing remains unchanged while persistent-Dev operations add an Edge-owned post-database completion gate."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
-lastReviewedNote: "Updated for Issue #422: persistent Dev migrations are again deployed by the database-only GitHub Actions db-push path; Supabase native deployment must not compete for Git dev."
+lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedNote: "Updated for Issue #422: persistent Dev completion now includes the Edge-owned redeploy and readback gate while native Git synchronization can still replace Functions."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -118,6 +118,7 @@ Keep these entry-level facts in `AGENTS.md`. Use `docs/agents/repo-validation.md
 - migration authoring starts from Git `dev`, not GitHub default-branch UI
 - preview-branch proof belongs to the repo PR
 - persistent `dev` migration deployment belongs to `.github/workflows/supabase-dev.yml`; after the local contract passes, it links the configured Dev project, runs exactly one `supabase db push --include-all`, derives the expected head from the checkout, reads back the ordered hosted PostgREST schema/search-path lists, and probes the default `public`, explicit `api`, rejected `private`, and retired `public` RPC routes; it must never deploy or delete Edge Functions or push project configuration
+- while Supabase native Git synchronization can still replace persistent-Dev Functions, every Git `dev` database deployment remains operationally incomplete until the Edge repository's post-database redeploy and readback gate in `docs/agents/supabase-branching.md` passes
 - production `main` proof belongs after `dev -> main` promote and should confirm Supabase GitHub integration applied migrations automatically; when `supabase/config.toml` changes, the operator must also push and verify that configuration against the production project
 - production-volume administrative backfills must fit the platform statement timeout or use a bounded session override that is restored immediately after the statement; Preview row counts alone are not sufficient volume proof
 - root workspace proof belongs later in `lca-workspace`
@@ -185,7 +186,7 @@ Use the role table in this file as the update map.
 ## Hard Boundaries
 
 - do not treat `supabase/workspace/remote_schema.sql`, `global/**`, or `schemas/**` as stable edit locations
-- do not leave Supabase native deployment bound to Git `dev` while the checked-in persistent-Dev migration workflow is active; one target must have one deployer
+- the target state is to prevent Supabase native Git synchronization from deploying persistent-Dev Functions; until the platform binding can enforce that boundary, the database workflow must remain database-only and the Edge-owned post-database redeploy/readback gate is mandatory
 - do not move frontend `.env` or app-side client logic into this repo
 - do not treat a merged PR here as delivery-complete when the workspace still needs a submodule bump
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,8 +28,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
-lastReviewedNote: "Updated for Issue #422: persistent Dev migration ownership returns to the database-only GitHub Actions db-push path without changing schema ownership."
+lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedNote: "Reviewed for Issue #422: the post-database Edge deployment gate changes operational sequencing, not repository or schema ownership."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
-lastReviewedNote: "Updated for Issue #422: workflow proof now requires one database-only db push followed by exact-head and hosted-boundary verification, with no Functions or config deployment."
+lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedNote: "Updated for Issue #422: persistent-Dev proof now includes the Edge-owned redeploy/readback gate while native Git synchronization can still replace Functions."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -89,7 +89,7 @@ need Git provenance still check out full history (`fetch-depth: 0`).
 | `supabase/tests/**` only | run the relevant SQL assertion files against a reset local DB | add a nearby migration or policy smoke check if the new assertions expose a gap | This repo stores PGTAP-style SQL assertions, not a single canonical runner wrapper. |
 | `supabase/seed.sql` or `supabase/seeds/dev.sql` | `supabase db reset` succeeds with expected seed behavior | rerun targeted SQL assertions that depend on the seeded rows; for shared-seed changes, confirm the hosted Preview seed stage completes | Keep shared seed and dev-only seed expectations separate. A shared seed with no data must still contain an executable no-op statement; a comments-only batch is not deployment-safe. |
 | `supabase/config.toml` | `supabase start` and `supabase db reset` still work locally | verify the changed branch-binding or auth assumption against `docs/agents/supabase-branching.md`; for exposed-schema changes, prove the Supabase GitHub integration applies the configuration or record the explicit operator gate, then read back exact ordered hosted PostgREST schema/search-path lists | Config changes affect preview, persistent dev, and local behavior together; local CLI order is not hosted default-profile proof. |
-| `.github/workflows/supabase-dev.yml` | inspect and parse YAML; run `python scripts/test_resolve_migration_head.py` and `python scripts/test_supabase_dev_workflow_contract.py`; regenerate `supabase/workspace/database.types.ts` from the full local migration state; assert the hosted job links the configured Dev project, runs exactly one `supabase db push --include-all`, contains no pinned migration head, Functions deploy/delete, `config push`, or Management API mutation | prove local contract success gates the remote deploy, generated type drift is rejected, the expected head is derived from the checkout, and post-deploy verification performs only Management API GET plus read-only Data API probes: profile-less `public`, explicit `api`, rejected `private`, and retired `public` RPC | GitHub Actions is the sole persistent-Dev migration deployer. Disable the native Git `dev` deployment binding before merge so it cannot race this workflow or touch Edge Functions. |
+| `.github/workflows/supabase-dev.yml` | inspect and parse YAML; run `python scripts/test_resolve_migration_head.py` and `python scripts/test_supabase_dev_workflow_contract.py`; regenerate `supabase/workspace/database.types.ts` from the full local migration state; assert the hosted job links the configured Dev project, runs exactly one `supabase db push --include-all`, contains no pinned migration head, Functions deploy/delete, `config push`, or Management API mutation | prove local contract success gates the remote deploy, generated type drift is rejected, the expected head is derived from the checkout, and post-deploy verification performs only Management API GET plus read-only Data API probes: profile-less `public`, explicit `api`, rejected `private`, and retired `public` RPC; while native Git synchronization can still replace Functions, also complete the Edge-owned post-database gate in `docs/agents/supabase-branching.md` | GitHub Actions is the sole persistent-Dev migration deployer, but its success alone is not operational completion while native Git synchronization can still replace Functions. The database workflow must remain database-only; the Edge repository owns the required redeploy command and Function proof. |
 | `scripts/**` | run the touched script with `--help` when possible, or execute the narrowest safe non-destructive path | if a script changes generated workspace behavior, refresh the workspace in a safe environment and inspect git diff | Avoid remote-destructive script runs unless the task explicitly requires them. |
 | `supabase/workspace/**` | prove whether the touched file is generated or stable | if stable manual overlay files changed, explain how they feed migration generation | Generated files alone are not sufficient evidence of a durable schema change. |
 | repo docs only | `scripts/docpact lint --root . --files "<csv>" --mode enforce` | `scripts/docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | Refresh review metadata even when prose stays unchanged. |
@@ -208,7 +208,7 @@ For a schema-changing PR, an exact-local reconstruction may be committed as a re
 For branch-oriented changes:
 
 - preview-branch proof usually happens on the repo PR
-- persistent remote `dev` proof happens after merge into Git `dev`
+- persistent remote `dev` proof happens after merge into Git `dev`; while native Git synchronization can still replace Functions, it includes both the database workflow proof and the Edge-owned post-database redeploy/readback gate
 - production `main` proof happens after `dev -> main` promote and should confirm the Supabase GitHub integration applied migrations automatically
 - root workspace proof happens later in `lca-workspace`
 

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -21,8 +21,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
-lastReviewedNote: "Updated for Issue #422: added deterministic Edge Function verification for Supabase Preview and native branch runs."
+lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedNote: "Updated for Issue #422: added the mandatory Edge-owned post-database redeploy and readback gate for persistent Dev."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -78,7 +78,7 @@ When review changes an already-applied PR migration, add a later migration that 
 - Keep branch-specific overrides in `[remotes.<branch>]` inside `supabase/config.toml`.
 - Do not create a separate `supabase/` directory per Git branch.
 - Keep `.github/workflows/supabase-dev.yml` as the sole persistent-`dev` migration deployer. It may run `supabase link` and exactly one `supabase db push --include-all`, but must not deploy/delete Edge Functions or push project configuration.
-- Disable the Supabase native deployment binding for Git `dev` before this workflow reaches `dev`; two deployers must never target the same persistent branch.
+- The target state is to disable persistent-Dev Function synchronization from the Supabase native Git binding. Until the platform binding can enforce that boundary, apply the mandatory post-database Edge Functions gate below after every Git `dev` database deployment.
 - Do not add a checked-in GitHub Actions production deploy for Git `main`; the production project is migrated by the Supabase GitHub integration bound to this repository.
 - Do not author normal schema changes by editing the remote database first and reconstructing migrations later.
 
@@ -88,6 +88,30 @@ When review changes an already-applied PR migration, add a later migration that 
 - `tiangong-lca-edge-functions` remains the source of truth and deployer for Edge Function runtime code. This repository must not add or deploy Edge Function sources.
 - To determine whether a database-native run changed the persistent Dev Functions, capture the same sorted inventory of Edge-repo-owned function slugs and their hosted content hashes immediately before and after the run, then compare the deterministic inventory digest.
 - An unchanged digest means the owned Function content was preserved. Treat a changed digest, owned-function inventory, `verify_jwt` setting, or active state as an ownership-boundary failure that requires investigation.
+
+### Post-database Edge Functions gate
+
+This gate is mandatory after every database-engine push to Git `dev` while the
+Supabase native Git binding can still replace persistent-Dev Functions. A
+successful database workflow is necessary, but persistent Dev is not
+operationally complete until this gate passes.
+
+1. Wait for `.github/workflows/supabase-dev.yml` to finish successfully, including its exact migration-head, hosted PostgREST, and Data API readbacks.
+2. Select the exact reviewed `tiangong-lca-edge-functions` Git SHA intended for persistent Dev. Do not infer Function source from a database-engine commit or a hosted bundle.
+3. From that Edge checkout, use the published Function inventory and the official `npm run deploy:dev -- <function-names...>` entrypoint documented in `tiangong-lca-edge-functions/README.md`. That command is implemented by `scripts/deploy-function.cjs`; do not reconstruct its CLI flags here, omit the explicit names, or use `--prune`.
+4. Read back the hosted inventory and prove that every expected Edge-owned Function exists, is `ACTIVE`, and has the `verify_jwt` setting required by the Edge deployment contract. Prove that no unexpected foreign bundle source remains and that remote-only legacy Functions outside the reviewed inventory were unchanged.
+5. Run representative authentication and invalid-payload probes against the restored Dev Functions, and record the exact Edge SHA, inventory, deployment result, and readback evidence on the delivery Issue or PR.
+
+A pre/post deterministic content digest is useful for detecting whether the
+native run changed hosted Functions. It is not a requirement that a fresh
+redeploy reproduce an older bundle digest: rebundling or toolchain changes can
+change the hosted hash without changing the reviewed source. After redeploy,
+the authoritative proof is the exact Edge source SHA plus inventory, active
+state, auth-setting, foreign-source, legacy-preservation, and smoke readbacks.
+
+This sequencing rule does not transfer Edge runtime ownership into
+`database-engine`. The Edge repository remains the command and source owner;
+this document owns only the database-to-Edge completion gate.
 
 ## Files to maintain
 
@@ -148,8 +172,8 @@ Normal PR path:
    the checked-in `supabase/` directory.
 4. The preview branch is PR-scoped proof only; it is not the persistent
    Supabase `dev` branch.
-5. Before the PR merges, confirm that Supabase native deployment is no longer
-   bound to Git `dev`.
+5. Confirm whether the Supabase native Git binding can still synchronize
+   persistent-Dev Functions; when it can, plan the post-database Edge gate.
 6. After merge, `.github/workflows/supabase-dev.yml` performs a blank local
    rebuild, links the configured persistent Dev project, and runs
    `supabase db push --include-all` after the local contract passes.
@@ -159,6 +183,8 @@ Normal PR path:
 8. The workflow reads `public,api,graphql_public` and
    `public,api,extensions` through the Management API and probes the hosted
    Data API boundary. After `db push`, these checks are read-only.
+9. While the native Git binding can still replace Functions, complete the
+   post-database Edge Functions gate before declaring persistent Dev healthy.
 
 An existing Preview branch applies newly added migration files on later PR
 pushes. Editing a migration already recorded in that Preview's migration
@@ -230,7 +256,7 @@ Rules:
 7. Commit migrations, seeds, tests, and config together.
 8. Open the PR into Git `dev`.
 9. Let Supabase create or update the preview branch for that PR.
-10. After merge, validate the persistent remote `dev` branch.
+10. After merge, validate the persistent remote `dev` database and complete the post-database Edge Functions gate when required.
 11. Promote `dev` to `main` when ready to release.
 12. Validate that the production Supabase project was migrated automatically by
     the Supabase GitHub integration.
@@ -246,8 +272,7 @@ Rules:
   the checked-in contract.
 - The workflow owns database migrations only. It must not run `supabase
   functions deploy`, `supabase functions delete`, or `supabase config push`.
-- Supabase native deployment must not remain bound to Git `dev`, because it
-  would race this workflow and may synchronize Edge Functions.
+- The target state is for the native Git binding not to synchronize persistent-Dev Functions. While it still can, the Edge-owned post-database gate is mandatory after each deployment; do not treat database workflow success alone as a healthy Dev release.
 
 ### Production `main` deployment
 

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
 lastReviewedAt: 2026-08-08
-lastReviewedCommit: 8be75648495ddc6a582ce63b5723bcbc75c03119
-lastReviewedNote: "已为 Issue #422 更新：增加 Supabase Preview 与原生分支流程的确定性 Edge Function 验证规则。"
+lastReviewedCommit: 1d1d153edb92aa01dd5fb7717441b16bedc4a96b
+lastReviewedNote: "已为 Issue #422 更新：增加持久化 Dev 数据库部署后强制执行的 Edge 仓重部署与回读 Gate。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -76,7 +76,7 @@ related:
 - 分支差异放在 `supabase/config.toml` 的 `[remotes.<branch>]` 中。
 - 不要为不同 Git 分支复制多套 `supabase/` 目录。
 - 把 `.github/workflows/supabase-dev.yml` 作为持久化 `dev` 的唯一 migration 部署者；它可以执行 `supabase link` 和准确一次 `supabase db push --include-all`，但不得部署/删除 Edge Functions 或推送项目配置。
-- 在该 workflow 进入 `dev` 前关闭 Git `dev` 的 Supabase 原生部署绑定；同一个持久化分支不能同时存在两个部署者。
+- 目标状态是关闭 Supabase 原生 Git 绑定对持久化 Dev Functions 的同步；在平台绑定还不能落实这个边界时，每次 Git `dev` 数据库部署后都必须执行下文的 Edge Functions Gate。
 - 不要为 Git `main` 增加 checked-in 的 GitHub Actions 生产部署流程；生产项目由绑定到本仓的 Supabase GitHub integration 自动迁移。
 - 不要先手改远端数据库再回头补 migration。
 
@@ -86,6 +86,26 @@ related:
 - `tiangong-lca-edge-functions` 仍是 Edge Function 运行时代码的真相源与部署者；本仓不得新增或部署 Edge Function 源码。
 - 要判断 database-native 流程是否修改了持久化 Dev Functions，应在流程运行前后，对同一组 Edge 仓所拥有的 function slug 与托管内容哈希进行排序并计算确定性清单摘要，然后比较两次结果。
 - 摘要不变表示受管 Function 内容得到保留；如果摘要、受管函数清单、`verify_jwt` 设置或 active 状态发生变化，则视为所有权边界失败并继续调查。
+
+### 数据库部署后的 Edge Functions Gate
+
+只要 Supabase 原生 Git 绑定仍可能替换持久化 Dev Functions，这个 Gate 就必须在
+database-engine 每次 push 到 Git `dev` 后执行。数据库 workflow 成功是必要条件，
+但 Gate 通过前不能把持久化 Dev 视为完成部署或恢复健康。
+
+1. 等待 `.github/workflows/supabase-dev.yml` 成功完成，包括准确 migration head、托管 PostgREST 配置和 Data API 边界回读。
+2. 选择本次持久化 Dev 应使用的、已经过评审的 `tiangong-lca-edge-functions` 准确 Git SHA；不得从 database-engine commit 或托管 bundle 反推 Function 源码。
+3. 在该 Edge checkout 中，按 `tiangong-lca-edge-functions/README.md` 维护的已发布 Function 清单，使用官方入口 `npm run deploy:dev -- <function-names...>`。该入口由 `scripts/deploy-function.cjs` 实现；不要在本文复制其 CLI 参数，不要省略显式函数名，也不要使用 `--prune`。
+4. 回读托管清单，证明所有预期的 Edge 自有 Function 都存在、状态为 `ACTIVE`，且 `verify_jwt` 符合 Edge 部署合同；同时证明没有遗留非预期的外部 bundle source，并且评审清单之外的 remote-only legacy Functions 没有变化。
+5. 对恢复后的 Dev Functions 执行有代表性的认证与非法 payload 探测，并在交付 Issue 或 PR 中记录准确 Edge SHA、函数清单、部署结果与回读证据。
+
+流程前后的确定性内容摘要适合判断原生同步是否修改了托管 Functions，但不能要求
+一次新的部署必须复现旧的 bundle digest：重新打包或工具链变化可能在源码不变时改变
+托管哈希。重部署后的权威证据是准确 Edge 源码 SHA，以及函数清单、active 状态、
+认证设置、外部来源清除、legacy 保留和 smoke readback。
+
+这条时序规则不会把 Edge 运行时所有权转移给 `database-engine`。Edge 仓仍然拥有
+源码和部署命令；本文只拥有数据库部署到 Edge 恢复之间的完成 Gate。
 
 ## 需要维护的文件
 
@@ -142,11 +162,12 @@ related:
 2. PR 目标分支是 Git `dev`。
 3. Supabase GitHub integration 根据已提交的 `supabase/` 目录创建或更新该 PR 的 preview branch。
 4. preview branch 只用于 PR 级别验证；它不是持久化 Supabase `dev` 分支。
-5. PR 合并前，确认 Git `dev` 已不再绑定 Supabase 原生部署。
+5. 确认 Supabase 原生 Git 绑定是否仍会同步持久化 Dev Functions；如果会，提前安排数据库部署后的 Edge Gate。
 6. 合并后，`.github/workflows/supabase-dev.yml` 先完成本地空库重建；本地合同通过后，绑定配置的持久化 Dev 项目并执行 `supabase db push --include-all`。
 7. workflow 从当前 checkout 的 migration 目录推导期望 head，再等待 service-only readback 报告该准确 head；workflow 中不手工固定 migration head。
 8. workflow 通过 Management API 回读 `public,api,graphql_public` 与
    `public,api,extensions`，并验证托管 Data API 边界；`db push` 后的这些检查均为只读。
+9. 只要原生 Git 绑定仍可能替换 Functions，就必须在宣布持久化 Dev 健康前完成数据库部署后的 Edge Functions Gate。
 
 `--include-all` 表示所有尚未出现在远端 migration history 中的已提交 migration
 都可以被应用。受治理的 `main -> dev` 回合并可能带入时间戳早于 `dev` 已记录新
@@ -204,7 +225,7 @@ Git `main` 由 Supabase GitHub integration 处理。运维人员仍可在本地�
 7. 把 migration、seed、测试和 config 一起提交。
 8. 向 Git `dev` 发起 PR。
 9. 让 Supabase 为该 PR 自动创建或更新 preview branch。
-10. 合并后，在持久化远端 `dev` 分支验证结果。
+10. 合并后，验证持久化远端 `dev` 数据库，并在需要时完成数据库部署后的 Edge Functions Gate。
 11. 准备发布时，再把 `dev` 晋升到 `main`。
 12. 验证生产 Supabase 项目已经由 Supabase GitHub integration 自动完成迁移。
 
@@ -217,7 +238,7 @@ Git `main` 由 Supabase GitHub integration 处理。运维人员仍可在本地�
   回读或 REST profile 探测不符合合同时失败。
 - workflow 只负责数据库 migration，不得执行 `supabase functions deploy`、
   `supabase functions delete` 或 `supabase config push`。
-- Git `dev` 不得继续绑定 Supabase 原生部署，否则会与该 workflow 竞争，并可能同步 Edge Functions。
+- 目标状态是原生 Git 绑定不再同步持久化 Dev Functions；在它仍可能同步时，每次部署后都必须执行 Edge 仓拥有的 Gate，不能仅凭数据库 workflow 成功就判断 Dev 健康。
 
 ### 生产 `main` 部署
 


### PR DESCRIPTION
## 说明

将当前持久化 Dev 的实际恢复要求写入仓库治理文档：只要 Supabase 原生 Git 绑定仍可能替换 Edge Functions，每次 database-engine 合并并完成数据库部署后，都必须由 Edge 仓官方脚本按准确源码 SHA 全量重部署已发布 Functions，并完成清单、状态、认证设置、来源、legacy 保留与代表性 smoke 回读。

职责边界保持不变：database-engine 只规定数据库到 Edge 的完成时序；Edge 仓继续拥有 Function 源码、发布清单与 `deploy:dev` 命令。文档同时明确新打包的托管 digest 不要求与旧 digest 相等。

## 变更

- 更新中英文 Supabase branching 文档，新增强制 post-database Edge Functions Gate
- 更新 repo contract 与验证矩阵，避免仅凭数据库 workflow 成功判断 Dev 健康
- 复核 Docpact 配置和架构文档；路由与所有权不变

## 验证

- `scripts/docpact lint --root . --files "AGENTS.md,.docpact/config.yaml,docs/agents/repo-architecture.md,docs/agents/repo-validation.md,docs/agents/supabase-branching.md,docs/agents/supabase-branching_CN.md" --mode enforce --format json --output .docpact/runs/latest.json`
- `scripts/docpact validate-config --root . --strict`
- `scripts/docpact-gate.sh --base origin/dev`（push 时对提交范围执行，pass）
- `git diff --check`

本 PR 仅修改文档，不修改 migration、workflow 或 Edge runtime。

Part of #422