### PR TITLE
chore: upgrade actions/checkout to v7

### DIFF
--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/scripts/test_supabase_dev_workflow_contract.py
+++ b/scripts/test_supabase_dev_workflow_contract.py
@@ -31,7 +31,7 @@ def main() -> int:
 
     hosted_workflow = text.split("  deploy-and-verify:", 1)[-1]
     hosted_required = (
-        "uses: actions/checkout@v6",
+        "uses: actions/checkout@v7",
         "needs: local-contract",
         "SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}",
         'supabase link --project-ref "$SUPABASE_PROJECT_ID"',


### PR DESCRIPTION
Closes tiangong-lca/database-engine#436

## Summary
- Upgrade every active workflow checkout reference to actions/checkout@v7.

## Validation
- Workflow YAML parse passed.
- Docpact lint passed.
- git diff --check passed.

## Workspace Integration
- Requires an exact-SHA workspace pointer update after merge.