### PR TITLE
fix: use canonical review metadata scope basis

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-08"
-lastReviewedCommit: "277ba6efddb966dd2e3562bf93b0d373c90f2756"
-lastReviewedNote: "Reviewed for Issue #435: Auth identity/profile synchronization follows the existing migration, SQL-test, and generated-workspace governance routes; no rule change is required."
+lastReviewedAt: "2026-08-09"
+lastReviewedCommit: "1b556b3c33fb486a7077cd08e913b05067f99ee7"
+lastReviewedNote: "Reviewed for Issue #323: the Reviewer metadata scope-basis fix follows the existing migration, SQL-test, and generated-workspace governance routes; no rule change is required."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 91a0817bb19882643089de2a63a3d1aad372847d
-lastReviewedNote: "Reviewed for Issue #435: Auth profile synchronization follows the existing migration, SQL-test, generated-workspace, and dev-to-main delivery contract."
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 1b556b3c33fb486a7077cd08e913b05067f99ee7
+lastReviewedNote: "Reviewed for Issue #323: the Reviewer metadata scope-basis fix follows the existing migration, SQL-test, generated-workspace, and dev-to-main delivery contract."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 277ba6efddb966dd2e3562bf93b0d373c90f2756
-lastReviewedNote: "Updated for Issue #435: auth.users is the identity authority and private.users is its internal application-profile mirror."
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 1b556b3c33fb486a7077cd08e913b05067f99ee7
+lastReviewedNote: "Reviewed for Issue #323: the Reviewer metadata scope-basis fix remains within the API function migration boundary and does not change repository architecture."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 277ba6efddb966dd2e3562bf93b0d373c90f2756
-lastReviewedNote: "Updated for Issue #435: Auth identity/profile mirror changes require clean-reset, populated-upgrade, trigger, ACL, and Auth-only lookup proof."
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 1b556b3c33fb486a7077cd08e913b05067f99ee7
+lastReviewedNote: "Reviewed for Issue #323: clean reset plus the focused and existing Root/Reference Review v2 pgTAP suites satisfy the current proof contract."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,9 +20,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 91a0817bb19882643089de2a63a3d1aad372847d
-lastReviewedNote: "Reviewed for Issue #435: the existing exact-local schema workspace and database-types refresh commands remain sufficient; script behavior is unchanged."
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 5ee102c80db8c1437777eddf098e34b77a484cab
+lastReviewedNote: "Reviewed for Issue #323: the existing exact-local schema workspace and database-types refresh commands captured the scope-basis repair deterministically; script behavior is unchanged."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 91a0817bb19882643089de2a63a3d1aad372847d
-lastReviewedNote: "已为 Issue #435 复核：现有 exact-local schema workspace 与数据库类型刷新命令仍然适用，脚本行为不变。"
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 5ee102c80db8c1437777eddf098e34b77a484cab
+lastReviewedNote: "已为 Issue #323 复核：现有 exact-local schema workspace 与数据库类型刷新命令可确定性捕获 scope-basis 修复，脚本行为不变。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/supabase/migrations/20260809184613_fix_review_metadata_scope_basis.sql
+++ b/supabase/migrations/20260809184613_fix_review_metadata_scope_basis.sql
@@ -1,0 +1,354 @@
+-- Fix the canonical scope-basis value used when Reviewer metadata adds references.
+-- Item provenance remains `reviewer_metadata`; snapshot provenance is `review_metadata`.
+
+CREATE OR REPLACE FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "sql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+  select api.cmd_review_submit_comment(
+    p_review_id,
+    p_json,
+    1,
+    p_audit
+  )
+$$;
+
+ALTER FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb") OWNER TO "postgres";
+
+CREATE OR REPLACE FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer DEFAULT 1, "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $_$
+declare
+  v_actor uuid := auth.uid();
+  v_review private.reviews%rowtype;
+  v_comment private.comments%rowtype;
+  v_ref record;
+  v_target record;
+  v_reference private.reviews%rowtype;
+  v_ref_roots jsonb := '[]'::jsonb;
+  v_current_snapshot jsonb;
+  v_items jsonb;
+  v_new_items jsonb := '[]'::jsonb;
+  v_item jsonb;
+  v_checksum text;
+  v_affected jsonb := '[]'::jsonb;
+  v_reason text;
+begin
+  select review_row.*
+  into v_review
+  from private.reviews as review_row
+  where review_row.id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404
+    );
+  end if;
+
+  if v_review.review_kind is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'LEGACY_REVIEW_READ_ONLY',
+      'status', 409
+    );
+  end if;
+
+  if v_review.review_kind = 'reference'
+    or v_review.target_table in (
+      'contacts',
+      'sources',
+      'unitgroups',
+      'flowproperties',
+      'flows'
+    ) then
+    v_reason := coalesce(
+      p_json->'comment'->>'message',
+      p_json->>'reason'
+    );
+    return api.cmd_simple_review_submit_decision(
+      p_review_id,
+      case when p_comment_state = 1 then 'approve' else 'reject' end,
+      case when p_comment_state = -3 then v_reason else null end,
+      p_audit
+    );
+  end if;
+
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401
+    );
+  end if;
+
+  if v_review.review_kind <> 'root'
+    or v_review.target_table not in ('processes', 'lifecyclemodels') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_METADATA_NOT_APPLICABLE',
+      'status', 400
+    );
+  end if;
+
+  if v_review.state_code <> 1
+    or p_comment_state not in (-3, 1)
+    or not coalesce(v_review.reviewer_id, '[]'::jsonb)
+      @> jsonb_build_array(v_actor::text) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_REQUIRED',
+      'status', 403
+    );
+  end if;
+
+  select comment_row.*
+  into v_comment
+  from private.comments as comment_row
+  where comment_row.review_id = p_review_id
+    and comment_row.reviewer_id = v_actor
+  for update;
+
+  if found and v_comment.state_code in (-2, 2) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_COMMENT_STATE',
+      'status', 409
+    );
+  end if;
+
+  if p_comment_state = 1 then
+    for v_ref in
+      select *
+      from api.cmd_review_extract_refs(coalesce(p_json, '{}'::jsonb))
+    loop
+      if api.cmd_review_ref_type_to_table(v_ref.ref_type) is not null then
+        v_ref_roots := v_ref_roots || jsonb_build_array(jsonb_build_object(
+          'table', api.cmd_review_ref_type_to_table(v_ref.ref_type),
+          'id', v_ref.ref_object_id,
+          'version', v_ref.ref_version,
+          'is_root', false
+        ));
+      end if;
+    end loop;
+
+    create temporary table if not exists review_comment_v2_targets (
+      table_name text not null,
+      dataset_id uuid not null,
+      dataset_version text not null,
+      state_code integer not null,
+      reviews jsonb,
+      dataset_row jsonb not null,
+      is_root boolean not null default false,
+      primary key (table_name, dataset_id, dataset_version)
+    ) on commit drop;
+    truncate table review_comment_v2_targets;
+
+    insert into review_comment_v2_targets
+    select *
+    from api.cmd_review_collect_dataset_targets(v_ref_roots, true);
+
+    v_current_snapshot := private.review_scope_current_snapshot_v1(
+      v_review.scope_history
+    );
+    v_items := coalesce(v_current_snapshot->'items', '[]'::jsonb);
+
+    for v_target in
+      select *
+      from review_comment_v2_targets
+      order by table_name, dataset_id, dataset_version
+    loop
+      if nullif(v_target.dataset_row->>'user_id', '') is null then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'REFERENCE_OWNER_UNRESOLVED',
+          'status', 409
+        );
+      end if;
+
+      if nullif(v_target.dataset_row->>'user_id', '')::uuid <> v_actor
+        and not private.review_dataset_can_read_v1(
+          v_actor,
+          v_target.table_name,
+          v_target.dataset_row
+        ) then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'REFERENCE_ACCESS_DENIED',
+          'status', 403
+        );
+      end if;
+
+      v_checksum := private.review_revision_fingerprint_v1(
+        v_target.table_name,
+        v_target.dataset_row
+      );
+      v_reference := private.review_get_or_create_reference_v1(
+        v_target.table_name,
+        v_target.dataset_row,
+        v_checksum,
+        v_actor
+      );
+
+      if not exists (
+        select 1
+        from private.review_scope_current_items_v1(v_review.scope_history) as current_item
+        where current_item.item_kind = 'reference'
+          and current_item.target_table = v_target.table_name
+          and current_item.data_id = v_target.dataset_id
+          and current_item.data_version = v_target.dataset_version
+          and current_item.submitted_revision_checksum = v_checksum
+          and current_item.reference_review_id = v_reference.id
+      ) then
+        v_item := jsonb_build_object(
+          'item_kind', 'reference',
+          'target_table', v_target.table_name,
+          'data_id', v_target.dataset_id,
+          'data_version', v_target.dataset_version,
+          'submitted_revision_checksum', v_checksum,
+          'reference_review_id', v_reference.id,
+          'target_owner_id', v_target.dataset_row->>'user_id',
+          'target_team_id', v_target.dataset_row->'team_id',
+          'relation_type', 'reviewer_metadata',
+          'relation_path', '$.modellingAndValidation',
+          'introduced_by', 'reviewer_metadata',
+          'introduced_field_path', '$.modellingAndValidation'
+        );
+        v_new_items := v_new_items || jsonb_build_array(v_item);
+      end if;
+
+      perform set_config('app.review_controlled_write', 'on', true);
+      execute format(
+        'update public.%I
+            set state_code = case when state_code < 20 then 20 else state_code end,
+                reviews = case when state_code < 100
+                  then api.cmd_review_append_review_ref(reviews, $1)
+                  else reviews
+                end,
+                modified_at = now()
+          where id = $2
+            and version = $3',
+        v_target.table_name
+      ) using p_review_id, v_target.dataset_id, v_target.dataset_version;
+      perform set_config('app.review_controlled_write', 'off', true);
+
+      if v_target.state_code < 20
+        and nullif(v_target.dataset_row->>'user_id', '')::uuid <> v_actor then
+        perform private.review_notify_event_v1(
+          'reference_entered_review',
+          v_reference.id,
+          nullif(v_target.dataset_row->>'user_id', '')::uuid,
+          v_actor,
+          v_target.table_name,
+          v_target.dataset_id,
+          v_target.dataset_version,
+          p_review_id,
+          (v_review.scope_history->>'current_version')::integer + 1,
+          null
+        );
+      end if;
+
+      v_affected := v_affected || jsonb_build_array(jsonb_build_object(
+        'table', v_target.table_name,
+        'id', v_target.dataset_id,
+        'version', v_target.dataset_version,
+        'reference_review_id', v_reference.id
+      ));
+    end loop;
+
+    if jsonb_array_length(v_new_items) > 0 then
+      perform private.review_append_scope_snapshot_v1(
+        p_review_id,
+        'review_metadata',
+        v_current_snapshot->>'root_revision_checksum',
+        v_items || v_new_items,
+        v_actor
+      );
+    end if;
+  end if;
+
+  insert into private.comments (
+    review_id,
+    reviewer_id,
+    json,
+    state_code
+  )
+  values (
+    p_review_id,
+    v_actor,
+    coalesce(p_json, '{}'::jsonb)::json,
+    p_comment_state
+  )
+  on conflict (review_id, reviewer_id) do update
+  set json = excluded.json,
+      state_code = excluded.state_code,
+      modified_at = now()
+  returning * into v_comment;
+
+  update private.reviews
+  set json = api.cmd_review_append_log(
+        coalesce(json, '{}'::jsonb),
+        case when p_comment_state = 1
+          then 'submit_comments'
+          else 'reviewer_rejected'
+        end,
+        v_actor,
+        jsonb_build_object(
+          'reviewer_id', v_actor,
+          'comment_state_code', p_comment_state
+        )
+      ),
+      modified_at = now()
+  where id = p_review_id
+  returning * into v_review;
+
+  insert into private.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_submit_comment',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'reviewer_id', v_actor,
+      'comment_state_code', p_comment_state,
+      'affected_datasets', v_affected
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'comment', to_jsonb(v_comment),
+      'affected_datasets', v_affected
+    )
+  );
+exception
+  when others then
+    perform set_config('app.review_controlled_write', 'off', true);
+    raise;
+end;
+$_$;
+
+ALTER FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer, "p_audit" "jsonb") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb") TO "authenticated";
+
+REVOKE ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer, "p_audit" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer, "p_audit" "jsonb") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer, "p_audit" "jsonb") TO "authenticated";

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260808215500'::text,
+  '20260809184613'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260809_review_metadata_scope_basis.sql
+++ b/supabase/tests/20260809_review_metadata_scope_basis.sql
@@ -1,0 +1,329 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+
+select plan(8);
+
+create or replace function pg_temp.disable_trigger_if_exists(
+  p_table regclass,
+  p_trigger name
+)
+returns void
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1
+    from pg_catalog.pg_trigger
+    where tgrelid = p_table
+      and tgname = p_trigger
+      and not tgisinternal
+  ) then
+    execute pg_catalog.format(
+      'alter table %s disable trigger %I',
+      p_table,
+      p_trigger
+    );
+  end if;
+end;
+$$;
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  '19800000-0000-0000-0000-000000000001',
+  'authenticated',
+  'authenticated',
+  'metadata-reviewer@example.com',
+  'test-password-hash',
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"email":"metadata-reviewer@example.com","display_name":"Metadata Reviewer"}'::jsonb,
+  now(),
+  now(),
+  false,
+  false
+);
+
+insert into private.users (id, raw_user_meta_data)
+values (
+  '19800000-0000-0000-0000-000000000001',
+  '{"email":"metadata-reviewer@example.com","display_name":"Metadata Reviewer"}'::jsonb
+)
+on conflict (id) do update
+set raw_user_meta_data = excluded.raw_user_meta_data;
+
+select pg_temp.disable_trigger_if_exists(
+  'public.sources'::regclass,
+  'sources_json_sync_trigger'
+);
+select pg_temp.disable_trigger_if_exists(
+  'public.sources'::regclass,
+  'source_dataset_extraction_trigger_insert'
+);
+select pg_temp.disable_trigger_if_exists(
+  'public.sources'::regclass,
+  'source_dataset_extraction_trigger_update'
+);
+select pg_temp.disable_trigger_if_exists(
+  'public.contacts'::regclass,
+  'contacts_json_sync_trigger'
+);
+select pg_temp.disable_trigger_if_exists(
+  'public.contacts'::regclass,
+  'contact_dataset_extraction_trigger_insert'
+);
+select pg_temp.disable_trigger_if_exists(
+  'public.contacts'::regclass,
+  'contact_dataset_extraction_trigger_update'
+);
+
+insert into public.sources (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  reviews
+)
+values (
+  '39800000-0000-0000-0000-000000000001',
+  '01.01.000',
+  '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"zh","#text":"审核员-来源"}]}}}}'::jsonb,
+  '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"zh","#text":"审核员-来源"}]}}}}'::json,
+  '19800000-0000-0000-0000-000000000001',
+  100,
+  null,
+  true,
+  '[]'::jsonb
+);
+
+insert into public.contacts (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  reviews
+)
+values (
+  '39800000-0000-0000-0000-000000000002',
+  '01.01.000',
+  '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"zh","#text":"审核员-联系人"}]}}}}'::jsonb,
+  '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"zh","#text":"审核员-联系人"}]}}}}'::json,
+  '19800000-0000-0000-0000-000000000001',
+  100,
+  null,
+  true,
+  '[]'::jsonb
+);
+
+with root_items as (
+  select pg_catalog.jsonb_build_array(
+    pg_catalog.jsonb_build_object(
+      'item_kind', 'root',
+      'target_table', 'processes',
+      'data_id', '49800000-0000-0000-0000-000000000001',
+      'data_version', '01.01.000',
+      'submitted_revision_checksum', pg_catalog.repeat('a', 64),
+      'target_owner_id', '19800000-0000-0000-0000-000000000001'
+    )
+  ) as items
+),
+root_history as (
+  select pg_catalog.jsonb_build_object(
+    'schema_version', 'review_scope.v1',
+    'current_version', 1,
+    'snapshots', pg_catalog.jsonb_build_array(
+      pg_catalog.jsonb_build_object(
+        'version_no', 1,
+        'scope_basis', 'submitted',
+        'root_revision_checksum', pg_catalog.repeat('a', 64),
+        'scope_checksum', private.review_scope_checksum_v1(root_items.items),
+        'created_by', '19800000-0000-0000-0000-000000000001',
+        'created_at', pg_catalog.to_jsonb(pg_catalog.now()),
+        'items', root_items.items
+      )
+    )
+  ) as scope_history
+  from root_items
+)
+insert into private.reviews (
+  id,
+  data_id,
+  data_version,
+  state_code,
+  reviewer_id,
+  json,
+  review_kind,
+  target_table,
+  submitted_revision_checksum,
+  target_owner_id,
+  scope_schema_version,
+  scope_history
+)
+select
+  '59800000-0000-0000-0000-000000000001',
+  '49800000-0000-0000-0000-000000000001',
+  '01.01.000',
+  1,
+  '["19800000-0000-0000-0000-000000000001"]'::jsonb,
+  '{"logs":[]}'::jsonb,
+  'root',
+  'processes',
+  pg_catalog.repeat('a', 64),
+  '19800000-0000-0000-0000-000000000001',
+  'review_scope.v1',
+  root_history.scope_history
+from root_history;
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '19800000-0000-0000-0000-000000000001',
+  true
+);
+
+create temporary table review_metadata_result as
+select api.cmd_review_submit_comment(
+  '59800000-0000-0000-0000-000000000001',
+  '{
+    "modellingAndValidation": {
+      "complianceDeclarations": {
+        "compliance": [{
+          "common:referenceToComplianceSystem": {
+            "@refObjectId": "39800000-0000-0000-0000-000000000001",
+            "@type": "source data set",
+            "@uri": "../sources/39800000-0000-0000-0000-000000000001.xml",
+            "@version": "01.01.000"
+          }
+        }]
+      },
+      "validation": {
+        "review": [{
+          "common:referenceToNameOfReviewerAndInstitution": {
+            "@refObjectId": "39800000-0000-0000-0000-000000000002",
+            "@type": "contact data set",
+            "@uri": "../contacts/39800000-0000-0000-0000-000000000002.xml",
+            "@version": "01.01.000"
+          }
+        }]
+      }
+    }
+  }'::jsonb,
+  1,
+  '{}'::jsonb
+) as result;
+
+select ok(
+  (select (result->>'ok')::boolean from review_metadata_result),
+  'Reviewer metadata comment submission succeeds when it introduces references'
+);
+
+select is(
+  (
+    select (scope_history->>'current_version')::integer
+    from private.reviews
+    where id = '59800000-0000-0000-0000-000000000001'
+  ),
+  2,
+  'Reviewer metadata appends exactly one scope snapshot'
+);
+
+select is(
+  (
+    select private.review_scope_current_snapshot_v1(scope_history)->>'scope_basis'
+    from private.reviews
+    where id = '59800000-0000-0000-0000-000000000001'
+  ),
+  'review_metadata',
+  'appended snapshot uses the canonical review_metadata scope basis'
+);
+
+select is(
+  (
+    select pg_catalog.jsonb_array_length(
+      private.review_scope_current_snapshot_v1(scope_history)->'items'
+    )
+    from private.reviews
+    where id = '59800000-0000-0000-0000-000000000001'
+  ),
+  3,
+  'current scope retains the root and adds both Reviewer metadata references'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from private.reviews as root_review
+    cross join lateral pg_catalog.jsonb_array_elements(
+      private.review_scope_current_snapshot_v1(root_review.scope_history)->'items'
+    ) as item(value)
+    where root_review.id = '59800000-0000-0000-0000-000000000001'
+      and item.value->>'item_kind' = 'reference'
+      and item.value->>'relation_type' = 'reviewer_metadata'
+      and item.value->>'introduced_by' = 'reviewer_metadata'
+  ),
+  2,
+  'item-level provenance remains reviewer_metadata for both references'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from private.reviews
+    where review_kind = 'reference'
+      and data_id in (
+        '39800000-0000-0000-0000-000000000001',
+        '39800000-0000-0000-0000-000000000002'
+      )
+  ),
+  2,
+  'Source and Contact each receive a reusable Reference Review'
+);
+
+select is(
+  (
+    select pg_catalog.jsonb_array_length(
+      result #> '{data,affected_datasets}'
+    )
+    from review_metadata_result
+  ),
+  2,
+  'command response reports both affected datasets'
+);
+
+select is(
+  (
+    select state_code
+    from private.comments
+    where review_id = '59800000-0000-0000-0000-000000000001'
+      and reviewer_id = '19800000-0000-0000-0000-000000000001'
+  ),
+  1,
+  'Reviewer approval comment is stored after scope expansion'
+);
+
+select * from finish();
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -20,9 +20,9 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 91a0817bb19882643089de2a63a3d1aad372847d
-lastReviewedNote: "Reviewed for Issue #435: the exact-local Auth profile schema snapshot was regenerated twice with identical output; workspace behavior is unchanged."
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 5ee102c80db8c1437777eddf098e34b77a484cab
+lastReviewedNote: "Reviewed for Issue #323: the exact-local scope-basis schema snapshot regenerated deterministically with no Data API type drift; workspace behavior is unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-08
-lastReviewedCommit: 91a0817bb19882643089de2a63a3d1aad372847d
-lastReviewedNote: "已为 Issue #435 复核：Auth profile 的 exact-local schema 快照连续生成结果一致，workspace 行为不变。"
+lastReviewedAt: 2026-08-09
+lastReviewedCommit: 5ee102c80db8c1437777eddf098e34b77a484cab
+lastReviewedNote: "已为 Issue #323 复核：scope-basis 的 exact-local schema 快照可确定性重建，且 Data API 类型无漂移，workspace 行为不变。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -13473,7 +13473,7 @@ begin
     if jsonb_array_length(v_new_items) > 0 then
       perform private.review_append_scope_snapshot_v1(
         p_review_id,
-        'reviewer_metadata',
+        'review_metadata',
         v_current_snapshot->>'root_revision_checksum',
         v_items || v_new_items,
         v_actor

--- a/supabase/workspace/schemas/api/functions/cmd_review_submit_comment/definition.sql
+++ b/supabase/workspace/schemas/api/functions/cmd_review_submit_comment/definition.sql
@@ -259,7 +259,7 @@ begin
     if jsonb_array_length(v_new_items) > 0 then
       perform private.review_append_scope_snapshot_v1(
         p_review_id,
-        'reviewer_metadata',
+        'review_metadata',
         v_current_snapshot->>'root_revision_checksum',
         v_items || v_new_items,
         v_actor


### PR DESCRIPTION
## Summary

- pass review_metadata to the scope snapshot append helper when Reviewer metadata introduces references
- preserve reviewer_metadata as item-level relation and introduction provenance
- add a focused Source and Contact regression for the production REVIEW_SCOPE_INVALID path
- refresh required docpact review metadata without changing governance rules

## Root cause

cmd_review_submit_comment passed reviewer_metadata as scope_basis, while the append helper and validator accept the canonical review_metadata value. The mismatch raised SQLSTATE 22023 whenever new Reviewer metadata references required a snapshot.

## Validation

- npx --yes supabase@2.98.0 db reset
- npx --yes supabase@2.98.0 test db --local supabase/tests/20260809_review_metadata_scope_basis.sql (8 tests)
- npx --yes supabase@2.98.0 test db --local supabase/tests/20260731_root_reference_review_v2.sql (23 tests)
- docpact lint enforce: pass, including pre-push gate
- migration list confirms 20260809184613 locally applied

## Deployment

This is an additive forward migration. Persistent dev deployment remains owned by the database workflow after merge to dev; production follows the normal dev-to-main promotion path.

Closes #323