### PR TITLE
fix: enforce TIDAS package ownership and attempt diagnostics

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-10"
-lastReviewedCommit: "bf614555b27df207a45b6673e4bd23768befba5c"
-lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: package artifact ownership and per-attempt worker diagnostics remain migration/test owned; routing and ownership are unchanged."
+lastReviewedCommit: "4f6607c7778827556fb29f8b62bd85bf98edf19a"
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: migration, pgTAP, and exact-local schema snapshot paths remain correctly governed; routing and ownership are unchanged."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-10"
-lastReviewedCommit: "8fa104141ff1fb30731acd6159cd6f144943606a"
-lastReviewedNote: "Reviewed for Issue #442 main-to-dev hotfix reconciliation: current routing and ownership remain correct; the older-timestamped public hotfix stays migration/test owned and no-ops after the dev private-schema cutover."
+lastReviewedCommit: "bf614555b27df207a45b6673e4bd23768befba5c"
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: package artifact ownership and per-attempt worker diagnostics remain migration/test owned; routing and ownership are unchanged."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: bf614555b27df207a45b6673e4bd23768befba5c
+lastReviewedCommit: 4f6607c7778827556fb29f8b62bd85bf98edf19a
 lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: the ownership-safe package read fix and attempt-local diagnostics belong in versioned migrations with pgTAP coverage; governance is unchanged."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 8fa104141ff1fb30731acd6159cd6f144943606a
-lastReviewedNote: "Reviewed for Issue #442 main-to-dev reconciliation: database ownership, migration source-of-truth, the production hotfix path, and the include-all persistent-dev deployment contract remain unchanged."
+lastReviewedCommit: bf614555b27df207a45b6673e4bd23768befba5c
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: the ownership-safe package read fix and attempt-local diagnostics belong in versioned migrations with pgTAP coverage; governance is unchanged."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: cab102d900d1be38a42666ee0b6025aad6503ff1
-lastReviewedNote: "Reviewed for Issue #439: unchanged rejected Reference Review resubmission remains within the API/private function migration boundary and does not change repository architecture."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: bf614555b27df207a45b6673e4bd23768befba5c
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: package authorization remains in the API facade and worker attempt state remains private; repository architecture is unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,8 +28,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: bf614555b27df207a45b6673e4bd23768befba5c
-lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: package authorization remains in the API facade and worker attempt state remains private; repository architecture is unchanged."
+lastReviewedCommit: 4f6607c7778827556fb29f8b62bd85bf98edf19a
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: the exact-local snapshot reflects API-owned package authorization and private attempt state without changing repository architecture."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: bf614555b27df207a45b6673e4bd23768befba5c
-lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: validate the forward migration with a blank reset and focused pgTAP coverage for ownership and retry diagnostics."
+lastReviewedCommit: 4f6607c7778827556fb29f8b62bd85bf98edf19a
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: blank reset, focused pgTAP, deterministic exact-local schema regeneration, and CI remain the required proof layers."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,9 +29,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-09
-lastReviewedCommit: cab102d900d1be38a42666ee0b6025aad6503ff1
-lastReviewedNote: "Updated for Issue #439: rejected Reference Review revisions may re-enter review without a checksum change, with historical rejection preservation and active-review reuse proof."
+lastReviewedAt: 2026-08-10
+lastReviewedCommit: bf614555b27df207a45b6673e4bd23768befba5c
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: validate the forward migration with a blank reset and focused pgTAP coverage for ownership and retry diagnostics."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 24ba3e64eedd8c557277e9fe62ee6f86e8cc4d83
-lastReviewedNote: "Reviewed for Issue #442: the existing exact-local schema workspace and database-types refresh commands deterministically capture canonical cutoff normalization; script behavior is unchanged."
+lastReviewedCommit: 4f6607c7778827556fb29f8b62bd85bf98edf19a
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: the existing exact-local schema workspace and Data API type commands capture the package and worker function contract; script behavior is unchanged."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 24ba3e64eedd8c557277e9fe62ee6f86e8cc4d83
-lastReviewedNote: "已为 Issue #442 复核：现有 exact-local schema workspace 与数据库类型刷新命令可确定性捕获 canonical cutoff 规范化，脚本行为不变。"
+lastReviewedCommit: 4f6607c7778827556fb29f8b62bd85bf98edf19a
+lastReviewedNote: "已为 database-engine Issue #448 / workspace Issue #566 复核：现有 exact-local schema workspace 与 Data API 类型命令可捕获 package 和 worker 函数合同，脚本行为不变。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/supabase/migrations/20260810143000_fix_tidas_package_ownership_and_attempt_diagnostics.sql
+++ b/supabase/migrations/20260810143000_fix_tidas_package_ownership_and_attempt_diagnostics.sql
@@ -1,0 +1,182 @@
+-- Issue #448 / workspace #566
+--
+-- Package artifacts are authorized by ownership of their request cache or
+-- canonical worker job. Artifact metadata is worker output and must not be an
+-- authorization source. Worker diagnostics describe only the current attempt;
+-- the append-only worker_job_events table retains attempt history.
+
+do $worker_attempt_diagnostics$
+declare
+  v_oid oid;
+  v_definition text;
+  v_rewritten text;
+begin
+  select routine.oid
+    into strict v_oid
+  from pg_proc as routine
+  join pg_namespace as namespace on namespace.oid = routine.pronamespace
+  where namespace.nspname = 'private'
+    and routine.proname = 'worker_claim_jobs';
+
+  v_definition := pg_get_functiondef(v_oid);
+  v_rewritten := replace(
+    v_definition,
+    $old$          updated_at = now(),
+          error_code = null,$old$,
+    $new$          updated_at = now(),
+          diagnostics = case
+            when j.attempt_count > 0 then '{}'::jsonb
+            else j.diagnostics
+          end,
+          error_code = null,$new$
+  );
+  if v_rewritten = v_definition then
+    raise exception 'private.worker_claim_jobs diagnostics rewrite target not found';
+  end if;
+  execute v_rewritten;
+
+  select routine.oid
+    into strict v_oid
+  from pg_proc as routine
+  join pg_namespace as namespace on namespace.oid = routine.pronamespace
+  where namespace.nspname = 'private'
+    and routine.proname = 'worker_record_job_result';
+
+  v_definition := pg_get_functiondef(v_oid);
+  v_rewritten := replace(
+    v_definition,
+    $old$        diagnostics = diagnostics || coalesce(p_diagnostics, '{}'::jsonb),$old$,
+    $new$        diagnostics = coalesce(p_diagnostics, '{}'::jsonb),$new$
+  );
+  if v_rewritten = v_definition then
+    raise exception 'private.worker_record_job_result diagnostics rewrite target not found';
+  end if;
+  execute v_rewritten;
+
+  select routine.oid
+    into strict v_oid
+  from pg_proc as routine
+  join pg_namespace as namespace on namespace.oid = routine.pronamespace
+  where namespace.nspname = 'private'
+    and routine.proname = 'worker_retry_job';
+
+  v_definition := pg_get_functiondef(v_oid);
+  v_rewritten := replace(
+    v_definition,
+    $old$        lease_expires_at = null,
+        error_code = null,$old$,
+    $new$        lease_expires_at = null,
+        diagnostics = '{}'::jsonb,
+        error_code = null,$new$
+  );
+  if v_rewritten = v_definition then
+    raise exception 'private.worker_retry_job diagnostics rewrite target not found';
+  end if;
+  execute v_rewritten;
+end
+$worker_attempt_diagnostics$;
+
+create or replace function api.svc_tidas_package_read(
+  p_requested_by uuid,
+  p_lookup_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $function$
+declare
+  v_cache private.lca_package_request_cache%rowtype;
+  v_job private.worker_jobs%rowtype;
+  v_effective_job_id uuid;
+  v_artifacts jsonb := '[]'::jsonb;
+begin
+  select *
+    into v_cache
+  from private.lca_package_request_cache
+  where requested_by = p_requested_by
+    and (job_id = p_lookup_id or worker_job_id = p_lookup_id)
+  order by updated_at desc, id
+  limit 1;
+
+  select *
+    into v_job
+  from private.worker_jobs
+  where requested_by = p_requested_by
+    and job_kind in ('tidas.export_package', 'tidas.import_package')
+    and (
+      id = p_lookup_id
+      or subject_id = p_lookup_id
+      or (v_cache.job_id is not null and subject_id = v_cache.job_id)
+    )
+  order by (id = p_lookup_id) desc, created_at desc, id
+  limit 1;
+
+  -- Authorization must complete before an artifact lookup. In particular, a
+  -- caller who knows another user's logical or worker job UUID receives the
+  -- same null result as an unknown UUID.
+  if v_cache.id is null and v_job.id is null then
+    return jsonb_build_object('ok', true, 'data', null);
+  end if;
+
+  v_effective_job_id := coalesce(v_cache.job_id, v_job.subject_id);
+
+  if v_effective_job_id is not null then
+    select coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
+      'id', artifact.id,
+      'workerJobId', artifact.worker_job_id,
+      'artifactKind', artifact.artifact_kind,
+      'status', artifact.status,
+      'artifactUrl', artifact.artifact_url,
+      'artifactSha256', artifact.artifact_sha256,
+      'artifactByteSize', artifact.artifact_byte_size,
+      'artifactFormat', artifact.artifact_format,
+      'contentType', artifact.content_type,
+      'metadata', artifact.metadata - 'requested_by' - 'import_prepare_idempotency_key',
+      'expiresAt', artifact.expires_at,
+      'isPinned', artifact.is_pinned,
+      'createdAt', artifact.created_at,
+      'updatedAt', artifact.updated_at
+    )) order by artifact.created_at, artifact.id), '[]'::jsonb)
+      into v_artifacts
+    from private.lca_package_artifacts as artifact
+    where artifact.job_id = v_effective_job_id;
+  end if;
+
+  return jsonb_build_object('ok', true, 'data', jsonb_strip_nulls(jsonb_build_object(
+    'jobId', v_effective_job_id,
+    'workerJobId', coalesce(v_job.id, v_cache.worker_job_id),
+    'status', coalesce(v_job.status, v_cache.status),
+    'operation', coalesce(
+      v_cache.operation,
+      case v_job.job_kind
+        when 'tidas.export_package' then 'export_package'
+        when 'tidas.import_package' then 'import_package'
+      end
+    ),
+    'scope', v_job.payload_json ->> 'scope',
+    'rootCount', coalesce(jsonb_array_length(v_job.payload_json -> 'roots'), 0),
+    'requestKey', coalesce(v_cache.request_key, v_job.request_hash),
+    'payload', v_job.payload_json,
+    'diagnostics', v_job.diagnostics,
+    'startedAt', v_job.started_at,
+    'finishedAt', v_job.finished_at,
+    'artifacts', v_artifacts,
+    'requestCache', case when v_cache.id is null then null else jsonb_strip_nulls(jsonb_build_object(
+      'id', v_cache.id,
+      'status', v_cache.status,
+      'error_code', v_cache.error_code,
+      'error_message', v_cache.error_message,
+      'hit_count', v_cache.hit_count,
+      'last_accessed_at', v_cache.last_accessed_at,
+      'created_at', v_cache.created_at,
+      'updated_at', v_cache.updated_at,
+      'export_artifact_id', v_cache.export_artifact_id,
+      'report_artifact_id', v_cache.report_artifact_id
+    )) end,
+    'createdAt', coalesce(v_job.created_at, v_cache.created_at),
+    'updatedAt', coalesce(v_job.updated_at, v_cache.updated_at)
+  )));
+end
+$function$;

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260810003106'::text,
+  '20260810143000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260810_issue_448_package_ownership_and_attempt_diagnostics.sql
+++ b/supabase/tests/20260810_issue_448_package_ownership_and_attempt_diagnostics.sql
@@ -1,0 +1,302 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, api, private, auth;
+
+select plan(14);
+
+set local role service_role;
+select set_config('request.jwt.claim.sub', '', true);
+select set_config('request.jwt.claim.role', 'service_role', true);
+select set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
+create temporary table issue_448_ids (
+  label text primary key,
+  job_id uuid not null,
+  lease_token uuid
+) on commit drop;
+grant all on issue_448_ids to service_role;
+
+create temporary table issue_448_results (
+  label text primary key,
+  value jsonb not null
+) on commit drop;
+grant all on issue_448_results to service_role;
+
+insert into issue_448_results values (
+  'export',
+  api.svc_tidas_package_export_enqueue(
+    '44800000-0000-4000-8000-000000000001',
+    'current_user',
+    '[]'::jsonb,
+    'issue448-export',
+    '{"scope":"current_user","roots":[]}'::jsonb,
+    '44810000-0000-4000-8000-000000000001',
+    'issue448:export'
+  )
+);
+
+select is(
+  (select value ->> 'mode' from issue_448_results where label = 'export'),
+  'queued',
+  'package fixture is queued through the capability facade'
+);
+
+insert into private.lca_package_artifacts (
+  id, job_id, worker_job_id, artifact_kind, status, artifact_url,
+  artifact_sha256, artifact_byte_size, artifact_format, content_type, metadata
+) values (
+  '44820000-0000-4000-8000-000000000001',
+  '44810000-0000-4000-8000-000000000001',
+  (select (value ->> 'worker_job_id')::uuid from issue_448_results where label = 'export'),
+  'export_zip', 'ready', 's3://packages/issue448.zip', repeat('a', 64), 448,
+  'tidas-package-zip:v1', 'application/zip', '{"producer":"worker"}'::jsonb
+);
+
+select is(
+  api.svc_tidas_package_read(
+    '44800000-0000-4000-8000-000000000001',
+    '44810000-0000-4000-8000-000000000001'
+  ) #>> '{data,artifacts,0,id}',
+  '44820000-0000-4000-8000-000000000001',
+  'owner can read worker-produced artifacts without requested_by metadata by logical job id'
+);
+
+select is(
+  api.svc_tidas_package_read(
+    '44800000-0000-4000-8000-000000000001',
+    (select (value ->> 'worker_job_id')::uuid from issue_448_results where label = 'export')
+  ) #>> '{data,artifacts,0,metadata,producer}',
+  'worker',
+  'owner can read the same artifact by canonical worker job id'
+);
+
+select is(
+  api.svc_tidas_package_read(
+    '44800000-0000-4000-8000-000000000002',
+    '44810000-0000-4000-8000-000000000001'
+  ) -> 'data',
+  'null'::jsonb,
+  'another user cannot read a known logical job id'
+);
+
+select is(
+  api.svc_tidas_package_read(
+    '44800000-0000-4000-8000-000000000002',
+    (select (value ->> 'worker_job_id')::uuid from issue_448_results where label = 'export')
+  ) -> 'data',
+  'null'::jsonb,
+  'another user cannot read a known canonical worker job id'
+);
+
+insert into issue_448_results values (
+  'import_prepare',
+  api.svc_tidas_package_import_prepare(
+    '44800000-0000-4000-8000-000000000001',
+    '44810000-0000-4000-8000-000000000002',
+    '44820000-0000-4000-8000-000000000002',
+    's3://packages/issue448-source.zip',
+    'application/zip',
+    'issue448-source.zip',
+    'issue448:import-prepare'
+  )
+);
+
+select is(
+  (
+    select metadata ->> 'requested_by'
+    from private.lca_package_artifacts
+    where id = '44820000-0000-4000-8000-000000000002'
+  ),
+  '44800000-0000-4000-8000-000000000001',
+  'import prepare keeps its internal admission metadata contract'
+);
+
+insert into issue_448_ids (label, job_id)
+select 'explicit_retry', (value #>> '{data,id}')::uuid
+from (
+  select private.worker_enqueue_job(
+    p_job_kind => 'review_submit.gate',
+    p_payload_json => '{"fixture":"explicit-retry"}'::jsonb,
+    p_requested_by => '44800000-0000-4000-8000-000000000001',
+    p_idempotency_key => 'issue448:explicit-retry',
+    p_max_attempts => 2
+  ) as value
+) as enqueue;
+
+update private.worker_jobs
+set diagnostics = '{"admission":"preserved"}'::jsonb
+where id = (select job_id from issue_448_ids where label = 'explicit_retry');
+
+update issue_448_ids
+set lease_token = (claimed ->> 'leaseToken')::uuid
+from jsonb_array_elements(
+  private.worker_claim_jobs('review_submit_gate', 'issue448-worker-a', 1, 300) -> 'data'
+) as claimed
+where label = 'explicit_retry'
+  and job_id = (claimed ->> 'id')::uuid;
+
+select is(
+  (
+    select diagnostics
+    from private.worker_jobs
+    where id = (select job_id from issue_448_ids where label = 'explicit_retry')
+  ),
+  '{"admission":"preserved"}'::jsonb,
+  'the first claim preserves admission diagnostics'
+);
+
+select private.worker_heartbeat_job(
+  p_job_id => (select job_id from issue_448_ids where label = 'explicit_retry'),
+  p_lease_token => (select lease_token from issue_448_ids where label = 'explicit_retry'),
+  p_diagnostics => '{"failedField":"stale"}'::jsonb
+);
+
+select private.worker_record_job_result(
+  p_job_id => (select job_id from issue_448_ids where label = 'explicit_retry'),
+  p_lease_token => (select lease_token from issue_448_ids where label = 'explicit_retry'),
+  p_status => 'failed',
+  p_diagnostics => '{"attempt":"failed"}'::jsonb,
+  p_error_code => 'ISSUE448_FIXTURE_FAILURE'
+);
+
+select is(
+  (
+    select diagnostics
+    from private.worker_jobs
+    where id = (select job_id from issue_448_ids where label = 'explicit_retry')
+  ),
+  '{"attempt":"failed"}'::jsonb,
+  'terminal result diagnostics replace heartbeat diagnostics for the attempt'
+);
+
+select ok(
+  exists (
+    select 1
+    from private.worker_job_events
+    where job_id = (select job_id from issue_448_ids where label = 'explicit_retry')
+      and event_type = 'heartbeat'
+      and details #>> '{diagnostics,failedField}' = 'stale'
+  ),
+  'append-only events retain the prior attempt heartbeat diagnostics'
+);
+
+select private.worker_retry_job(
+  p_job_id => (select job_id from issue_448_ids where label = 'explicit_retry'),
+  p_reason => 'issue448 retry fixture'
+);
+
+select is(
+  (
+    select diagnostics
+    from private.worker_jobs
+    where id = (select job_id from issue_448_ids where label = 'explicit_retry')
+  ),
+  '{}'::jsonb,
+  'explicit retry clears diagnostics before the next attempt'
+);
+
+update issue_448_ids
+set lease_token = (claimed ->> 'leaseToken')::uuid
+from jsonb_array_elements(
+  private.worker_claim_jobs('review_submit_gate', 'issue448-worker-b', 1, 300) -> 'data'
+) as claimed
+where label = 'explicit_retry'
+  and job_id = (claimed ->> 'id')::uuid;
+
+select private.worker_heartbeat_job(
+  p_job_id => (select job_id from issue_448_ids where label = 'explicit_retry'),
+  p_lease_token => (select lease_token from issue_448_ids where label = 'explicit_retry'),
+  p_diagnostics => '{"newHeartbeat":true}'::jsonb
+);
+
+select private.worker_record_job_result(
+  p_job_id => (select job_id from issue_448_ids where label = 'explicit_retry'),
+  p_lease_token => (select lease_token from issue_448_ids where label = 'explicit_retry'),
+  p_status => 'completed',
+  p_diagnostics => '{"attempt":"completed"}'::jsonb
+);
+
+select is(
+  (
+    select diagnostics
+    from private.worker_jobs
+    where id = (select job_id from issue_448_ids where label = 'explicit_retry')
+  ),
+  '{"attempt":"completed"}'::jsonb,
+  'successful retry exposes only the current terminal diagnostics'
+);
+
+insert into issue_448_ids (label, job_id)
+select 'expired_lease', (value #>> '{data,id}')::uuid
+from (
+  select private.worker_enqueue_job(
+    p_job_kind => 'review_submit.gate',
+    p_payload_json => '{"fixture":"expired-lease"}'::jsonb,
+    p_requested_by => '44800000-0000-4000-8000-000000000001',
+    p_idempotency_key => 'issue448:expired-lease',
+    p_max_attempts => 2
+  ) as value
+) as enqueue;
+
+update issue_448_ids
+set lease_token = (claimed ->> 'leaseToken')::uuid
+from jsonb_array_elements(
+  private.worker_claim_jobs('review_submit_gate', 'issue448-worker-c', 1, 300) -> 'data'
+) as claimed
+where label = 'expired_lease'
+  and job_id = (claimed ->> 'id')::uuid;
+
+select private.worker_heartbeat_job(
+  p_job_id => (select job_id from issue_448_ids where label = 'expired_lease'),
+  p_lease_token => (select lease_token from issue_448_ids where label = 'expired_lease'),
+  p_diagnostics => '{"expiredAttempt":"stale"}'::jsonb
+);
+
+update private.worker_jobs
+set lease_expires_at = now() - interval '1 second'
+where id = (select job_id from issue_448_ids where label = 'expired_lease');
+
+update issue_448_ids
+set lease_token = (claimed ->> 'leaseToken')::uuid
+from jsonb_array_elements(
+  private.worker_claim_jobs('review_submit_gate', 'issue448-worker-d', 1, 300) -> 'data'
+) as claimed
+where label = 'expired_lease'
+  and job_id = (claimed ->> 'id')::uuid;
+
+select is(
+  (
+    select diagnostics
+    from private.worker_jobs
+    where id = (select job_id from issue_448_ids where label = 'expired_lease')
+  ),
+  '{}'::jsonb,
+  'an expired lease starts a new attempt with empty diagnostics'
+);
+
+select is(
+  (
+    select attempt_count::text
+    from private.worker_jobs
+    where id = (select job_id from issue_448_ids where label = 'expired_lease')
+  ),
+  '2',
+  'expired lease reclaim still increments the attempt counter'
+);
+
+select is(
+  (
+    select count(*)::text
+    from pg_proc as routine
+    join pg_namespace as namespace on namespace.oid = routine.pronamespace
+    where namespace.nspname = 'public'
+      and routine.proname like 'worker_%'
+  ),
+  '0',
+  'the fix does not recreate public worker routines'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 24ba3e64eedd8c557277e9fe62ee6f86e8cc4d83
-lastReviewedNote: "Reviewed for Issue #442: the exact-local canonical cutoff snapshot regenerates deterministically with no Data API type drift; workspace behavior is unchanged."
+lastReviewedCommit: 4f6607c7778827556fb29f8b62bd85bf98edf19a
+lastReviewedNote: "Reviewed for database-engine Issue #448 / workspace Issue #566: the exact-local package and worker function snapshot regenerates deterministically with no Data API type drift; workspace behavior is unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-10
-lastReviewedCommit: 24ba3e64eedd8c557277e9fe62ee6f86e8cc4d83
-lastReviewedNote: "已为 Issue #442 复核：canonical cutoff 的 exact-local schema 快照可确定性重建，且 Data API 类型无漂移，workspace 行为不变。"
+lastReviewedCommit: 4f6607c7778827556fb29f8b62bd85bf98edf19a
+lastReviewedNote: "已为 database-engine Issue #448 / workspace Issue #566 复核：package 与 worker 函数的 exact-local schema 快照可确定性重建，且 Data API 类型无漂移，workspace 行为不变。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -22714,43 +22714,58 @@ declare
   v_cache private.lca_package_request_cache%rowtype;
   v_job private.worker_jobs%rowtype;
   v_effective_job_id uuid;
-  v_artifacts jsonb;
+  v_artifacts jsonb := '[]'::jsonb;
 begin
-  select * into v_cache from private.lca_package_request_cache
+  select *
+    into v_cache
+  from private.lca_package_request_cache
   where requested_by = p_requested_by
     and (job_id = p_lookup_id or worker_job_id = p_lookup_id)
-  order by updated_at desc, id limit 1;
-  v_effective_job_id := coalesce(v_cache.job_id, p_lookup_id);
+  order by updated_at desc, id
+  limit 1;
 
-  select * into v_job from private.worker_jobs
+  select *
+    into v_job
+  from private.worker_jobs
   where requested_by = p_requested_by
     and job_kind in ('tidas.export_package', 'tidas.import_package')
-    and (id = p_lookup_id or subject_id = v_effective_job_id)
-  order by created_at desc, id limit 1;
+    and (
+      id = p_lookup_id
+      or subject_id = p_lookup_id
+      or (v_cache.job_id is not null and subject_id = v_cache.job_id)
+    )
+  order by (id = p_lookup_id) desc, created_at desc, id
+  limit 1;
 
-  select coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
-    'id', artifact.id,
-    'workerJobId', artifact.worker_job_id,
-    'artifactKind', artifact.artifact_kind,
-    'status', artifact.status,
-    'artifactUrl', artifact.artifact_url,
-    'artifactSha256', artifact.artifact_sha256,
-    'artifactByteSize', artifact.artifact_byte_size,
-    'artifactFormat', artifact.artifact_format,
-    'contentType', artifact.content_type,
-    'metadata', artifact.metadata - 'requested_by' - 'import_prepare_idempotency_key',
-    'expiresAt', artifact.expires_at,
-    'isPinned', artifact.is_pinned,
-    'createdAt', artifact.created_at,
-    'updatedAt', artifact.updated_at
-  )) order by artifact.created_at, artifact.id), '[]'::jsonb)
-  into v_artifacts
-  from private.lca_package_artifacts as artifact
-  where artifact.job_id = v_effective_job_id
-    and artifact.metadata ->> 'requested_by' = p_requested_by::text;
-
-  if v_cache.id is null and v_job.id is null and jsonb_array_length(v_artifacts) = 0 then
+  -- Authorization must complete before an artifact lookup. In particular, a
+  -- caller who knows another user's logical or worker job UUID receives the
+  -- same null result as an unknown UUID.
+  if v_cache.id is null and v_job.id is null then
     return jsonb_build_object('ok', true, 'data', null);
+  end if;
+
+  v_effective_job_id := coalesce(v_cache.job_id, v_job.subject_id);
+
+  if v_effective_job_id is not null then
+    select coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
+      'id', artifact.id,
+      'workerJobId', artifact.worker_job_id,
+      'artifactKind', artifact.artifact_kind,
+      'status', artifact.status,
+      'artifactUrl', artifact.artifact_url,
+      'artifactSha256', artifact.artifact_sha256,
+      'artifactByteSize', artifact.artifact_byte_size,
+      'artifactFormat', artifact.artifact_format,
+      'contentType', artifact.content_type,
+      'metadata', artifact.metadata - 'requested_by' - 'import_prepare_idempotency_key',
+      'expiresAt', artifact.expires_at,
+      'isPinned', artifact.is_pinned,
+      'createdAt', artifact.created_at,
+      'updatedAt', artifact.updated_at
+    )) order by artifact.created_at, artifact.id), '[]'::jsonb)
+      into v_artifacts
+    from private.lca_package_artifacts as artifact
+    where artifact.job_id = v_effective_job_id;
   end if;
 
   return jsonb_build_object('ok', true, 'data', jsonb_strip_nulls(jsonb_build_object(
@@ -46640,6 +46655,10 @@ begin
           heartbeat_at = now(),
           started_at = coalesce(j.started_at, now()),
           updated_at = now(),
+          diagnostics = case
+            when j.attempt_count > 0 then '{}'::jsonb
+            else j.diagnostics
+          end,
           error_code = null,
           error_message = null,
           error_details = null
@@ -47507,7 +47526,7 @@ begin
         result_schema_version = coalesce(nullif(trim(p_result_schema_version), ''), result_schema_version),
         result_json = p_result_json,
         result_ref = p_result_ref,
-        diagnostics = diagnostics || coalesce(p_diagnostics, '{}'::jsonb),
+        diagnostics = coalesce(p_diagnostics, '{}'::jsonb),
         error_code = nullif(trim(p_error_code), ''),
         error_message = nullif(trim(p_error_message), ''),
         error_details = p_error_details,
@@ -47621,6 +47640,7 @@ begin
         leased_by = null,
         lease_token = null,
         lease_expires_at = null,
+        diagnostics = '{}'::jsonb,
         error_code = null,
         error_message = null,
         error_details = null,

--- a/supabase/workspace/schemas/api/functions/svc_tidas_package_read/definition.sql
+++ b/supabase/workspace/schemas/api/functions/svc_tidas_package_read/definition.sql
@@ -6,43 +6,58 @@ declare
   v_cache private.lca_package_request_cache%rowtype;
   v_job private.worker_jobs%rowtype;
   v_effective_job_id uuid;
-  v_artifacts jsonb;
+  v_artifacts jsonb := '[]'::jsonb;
 begin
-  select * into v_cache from private.lca_package_request_cache
+  select *
+    into v_cache
+  from private.lca_package_request_cache
   where requested_by = p_requested_by
     and (job_id = p_lookup_id or worker_job_id = p_lookup_id)
-  order by updated_at desc, id limit 1;
-  v_effective_job_id := coalesce(v_cache.job_id, p_lookup_id);
+  order by updated_at desc, id
+  limit 1;
 
-  select * into v_job from private.worker_jobs
+  select *
+    into v_job
+  from private.worker_jobs
   where requested_by = p_requested_by
     and job_kind in ('tidas.export_package', 'tidas.import_package')
-    and (id = p_lookup_id or subject_id = v_effective_job_id)
-  order by created_at desc, id limit 1;
+    and (
+      id = p_lookup_id
+      or subject_id = p_lookup_id
+      or (v_cache.job_id is not null and subject_id = v_cache.job_id)
+    )
+  order by (id = p_lookup_id) desc, created_at desc, id
+  limit 1;
 
-  select coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
-    'id', artifact.id,
-    'workerJobId', artifact.worker_job_id,
-    'artifactKind', artifact.artifact_kind,
-    'status', artifact.status,
-    'artifactUrl', artifact.artifact_url,
-    'artifactSha256', artifact.artifact_sha256,
-    'artifactByteSize', artifact.artifact_byte_size,
-    'artifactFormat', artifact.artifact_format,
-    'contentType', artifact.content_type,
-    'metadata', artifact.metadata - 'requested_by' - 'import_prepare_idempotency_key',
-    'expiresAt', artifact.expires_at,
-    'isPinned', artifact.is_pinned,
-    'createdAt', artifact.created_at,
-    'updatedAt', artifact.updated_at
-  )) order by artifact.created_at, artifact.id), '[]'::jsonb)
-  into v_artifacts
-  from private.lca_package_artifacts as artifact
-  where artifact.job_id = v_effective_job_id
-    and artifact.metadata ->> 'requested_by' = p_requested_by::text;
-
-  if v_cache.id is null and v_job.id is null and jsonb_array_length(v_artifacts) = 0 then
+  -- Authorization must complete before an artifact lookup. In particular, a
+  -- caller who knows another user's logical or worker job UUID receives the
+  -- same null result as an unknown UUID.
+  if v_cache.id is null and v_job.id is null then
     return jsonb_build_object('ok', true, 'data', null);
+  end if;
+
+  v_effective_job_id := coalesce(v_cache.job_id, v_job.subject_id);
+
+  if v_effective_job_id is not null then
+    select coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
+      'id', artifact.id,
+      'workerJobId', artifact.worker_job_id,
+      'artifactKind', artifact.artifact_kind,
+      'status', artifact.status,
+      'artifactUrl', artifact.artifact_url,
+      'artifactSha256', artifact.artifact_sha256,
+      'artifactByteSize', artifact.artifact_byte_size,
+      'artifactFormat', artifact.artifact_format,
+      'contentType', artifact.content_type,
+      'metadata', artifact.metadata - 'requested_by' - 'import_prepare_idempotency_key',
+      'expiresAt', artifact.expires_at,
+      'isPinned', artifact.is_pinned,
+      'createdAt', artifact.created_at,
+      'updatedAt', artifact.updated_at
+    )) order by artifact.created_at, artifact.id), '[]'::jsonb)
+      into v_artifacts
+    from private.lca_package_artifacts as artifact
+    where artifact.job_id = v_effective_job_id;
   end if;
 
   return jsonb_build_object('ok', true, 'data', jsonb_strip_nulls(jsonb_build_object(

--- a/supabase/workspace/schemas/private/functions/worker_claim_jobs/definition.sql
+++ b/supabase/workspace/schemas/private/functions/worker_claim_jobs/definition.sql
@@ -99,6 +99,10 @@ begin
           heartbeat_at = now(),
           started_at = coalesce(j.started_at, now()),
           updated_at = now(),
+          diagnostics = case
+            when j.attempt_count > 0 then '{}'::jsonb
+            else j.diagnostics
+          end,
           error_code = null,
           error_message = null,
           error_details = null

--- a/supabase/workspace/schemas/private/functions/worker_record_job_result/definition.sql
+++ b/supabase/workspace/schemas/private/functions/worker_record_job_result/definition.sql
@@ -136,7 +136,7 @@ begin
         result_schema_version = coalesce(nullif(trim(p_result_schema_version), ''), result_schema_version),
         result_json = p_result_json,
         result_ref = p_result_ref,
-        diagnostics = diagnostics || coalesce(p_diagnostics, '{}'::jsonb),
+        diagnostics = coalesce(p_diagnostics, '{}'::jsonb),
         error_code = nullif(trim(p_error_code), ''),
         error_message = nullif(trim(p_error_message), ''),
         error_details = p_error_details,

--- a/supabase/workspace/schemas/private/functions/worker_retry_job/definition.sql
+++ b/supabase/workspace/schemas/private/functions/worker_retry_job/definition.sql
@@ -46,6 +46,7 @@ begin
         leased_by = null,
         lease_token = null,
         lease_expires_at = null,
+        diagnostics = '{}'::jsonb,
         error_code = null,
         error_message = null,
         error_details = null,


### PR DESCRIPTION
Closes #448

## Summary
- Authorize package artifact reads through the caller-owned request cache or canonical worker job rather than worker-supplied artifact metadata.
- Make worker diagnostics attempt-local while retaining historical heartbeat details in append-only events.

## Key Decisions
- Keep requested_by metadata only as the import admission contract; it is never an artifact authorization source.
- Preserve first-attempt admission diagnostics, clear them on retry or expired-lease reclaim, and replace them with each terminal result.

## Validation
- Supabase blank database reset completed with the full migration chain.
- 109 pgTAP assertions passed across worker foundation, package facades, and Issue #448 regressions.
- 147 schema/capability contract assertions passed, including the exact migration-head readback.
- The populated full-schema cutover upgrade harness passed.
- Exact-local schema workspace regeneration was deterministic across two runs; Data API types did not drift.
- Docpact staged lint and the local pre-push gate passed for all 16 changed paths.

## Risks / Rollback
- Function rewrites fail closed during migration if the expected prior definition is absent; rollback is the migration commit revert before deployment.

## Workspace Integration
- PR targets dev. Root workspace integration waits for the database-engine change to be promoted to child main under the M2 branch policy.
