### PR TITLE
Add role-separated reviewer batch decision contract

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-11"
-lastReviewedCommit: "3c9b67b8a1194266abdb2ce37ea3d8518a213f12"
+lastReviewedCommit: "340e83613d3d611f881b2fd49036ddac80f3101a"
 lastReviewedNote: "Reviewed for Issue #467: the v3 admin and member queues apply display-mode and exact target-table filters before count and pagination, default to 50 rows, reject unsupported values, and retain the 256-function API cutover contract."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 3c9b67b8a1194266abdb2ce37ea3d8518a213f12
+lastReviewedCommit: 340e83613d3d611f881b2fd49036ddac80f3101a
 lastReviewedNote: "Reviewed for Issue #467: the v3 admin and member review queues filter display mode and exact target type before totals and pagination, default to 50 rows, and keep Root and Reference reviews as independent rows; existing search and rollout ownership remains unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 3c9b67b8a1194266abdb2ce37ea3d8518a213f12
+lastReviewedCommit: 340e83613d3d611f881b2fd49036ddac80f3101a
 lastReviewedNote: "Updated for Issue #467: the API-owned v3 review queues flatten Root and Reference rows, filter display mode and exact target table before totals and pagination, and default to 50 rows while preserving the 256-function inventory."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 3c9b67b8a1194266abdb2ce37ea3d8518a213f12
+lastReviewedCommit: 340e83613d3d611f881b2fd49036ddac80f3101a
 lastReviewedNote: "Updated for Issue #467: validation covers v3 queue display modes, exact target filters, their intersections, invalid-value rejection, the 50-row default, flat row totals, and the unchanged 256-function API cutover contract."
 related:
   - ../../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 3c9b67b8a1194266abdb2ce37ea3d8518a213f12
+lastReviewedCommit: 340e83613d3d611f881b2fd49036ddac80f3101a
 lastReviewedNote: "Reviewed for Issue #467: existing exact-local workspace and Data API type commands deterministically regenerate the v3 review queue filter signatures, 50-row defaults, and supporting index; script behavior is unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 3c9b67b8a1194266abdb2ce37ea3d8518a213f12
+lastReviewedCommit: 340e83613d3d611f881b2fd49036ddac80f3101a
 lastReviewedNote: "已为 Issue #467 复核：现有 exact-local workspace 与 Data API 类型命令可确定性重建 v3 审核队列筛选签名、默认 50 行和配套索引；脚本行为不变。"
 related:
   - ../AGENTS.md

--- a/supabase/migrations/20260811113000_add_reviewer_submit_decision.sql
+++ b/supabase/migrations/20260811113000_add_reviewer_submit_decision.sql
@@ -1,0 +1,190 @@
+create or replace function api.cmd_reviewer_submit_decision(
+  p_review_id uuid,
+  p_decision text,
+  p_reason text default null,
+  p_audit jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_review private.reviews%rowtype;
+  v_comment private.comments%rowtype;
+  v_decision text := pg_catalog.lower(pg_catalog.btrim(coalesce(p_decision, '')));
+  v_reason text := pg_catalog.btrim(coalesce(p_reason, ''));
+  v_comment_json jsonb;
+  v_is_simple boolean;
+begin
+  if v_actor is null then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if v_decision not in ('approve', 'reject') then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DECISION_INVALID',
+      'status', 400,
+      'message', 'decision must be approve or reject'
+    );
+  end if;
+
+  if v_decision = 'approve' and v_reason <> '' then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DECISION_PAYLOAD_INVALID',
+      'status', 400,
+      'message', 'approve does not accept a reason'
+    );
+  end if;
+
+  if v_decision = 'reject' and v_reason = '' then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_REJECT_REASON_REQUIRED',
+      'status', 400,
+      'message', 'reason is required for reject'
+    );
+  end if;
+
+  if pg_catalog.length(v_reason) > 1000 then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_REJECT_REASON_TOO_LONG',
+      'status', 400,
+      'message', 'reason must not exceed 1000 characters'
+    );
+  end if;
+
+  select review_row.*
+  into v_review
+  from private.reviews as review_row
+  where review_row.id = p_review_id
+  for update;
+
+  if not found or v_review.review_kind not in ('root', 'reference') then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code <> 1
+    or not api.cmd_review_json_array(v_review.reviewer_id)
+      @> pg_catalog.jsonb_build_array(pg_catalog.to_jsonb(v_actor::text)) then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_REQUIRED',
+      'status', 403,
+      'message', 'Only an assigned reviewer can submit a pending decision'
+    );
+  end if;
+
+  select comment_row.*
+  into v_comment
+  from private.comments as comment_row
+  where comment_row.review_id = p_review_id
+    and comment_row.reviewer_id = v_actor
+  for update;
+
+  if not found or v_comment.state_code <> 0 then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_COMMENT_NOT_PENDING',
+      'status', 409,
+      'message', 'Reviewer decision is no longer pending'
+    );
+  end if;
+
+  v_is_simple := v_review.review_kind = 'reference'
+    or v_review.target_table in (
+      'contacts',
+      'sources',
+      'unitgroups',
+      'flowproperties',
+      'flows'
+    );
+
+  if v_is_simple then
+    return api.cmd_simple_review_submit_decision(
+      p_review_id,
+      v_decision,
+      case when v_decision = 'reject' then v_reason else null end,
+      coalesce(p_audit, '{}'::jsonb)
+        || pg_catalog.jsonb_build_object('reviewer_decision_command', true)
+    );
+  end if;
+
+  v_comment_json := coalesce(pg_catalog.to_jsonb(v_comment.json), '{}'::jsonb);
+
+  if v_decision = 'approve' and v_comment_json = '{}'::jsonb then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DRAFT_REQUIRED',
+      'status', 409,
+      'message', 'Process and LifecycleModel approvals require a saved review draft'
+    );
+  end if;
+
+  if v_decision = 'reject' then
+    v_comment_json := pg_catalog.jsonb_set(
+      v_comment_json,
+      '{comment}',
+      coalesce(v_comment_json->'comment', '{}'::jsonb)
+        || pg_catalog.jsonb_build_object('message', v_reason),
+      true
+    );
+  end if;
+
+  return api.cmd_review_submit_comment(
+    p_review_id,
+    v_comment_json,
+    case when v_decision = 'approve' then 1 else -3 end,
+    coalesce(p_audit, '{}'::jsonb)
+      || pg_catalog.jsonb_build_object('reviewer_decision_command', true)
+  );
+end;
+$$;
+
+alter function api.cmd_reviewer_submit_decision(uuid, text, text, jsonb)
+  owner to postgres;
+
+revoke all on function api.cmd_reviewer_submit_decision(uuid, text, text, jsonb)
+  from public;
+
+grant execute on function api.cmd_reviewer_submit_decision(uuid, text, text, jsonb)
+  to api_internal_executor;
+
+grant execute on function api.cmd_reviewer_submit_decision(uuid, text, text, jsonb)
+  to authenticated;
+
+comment on function api.cmd_reviewer_submit_decision(uuid, text, text, jsonb) is
+  'Submits one assigned reviewer opinion without performing review-admin finalization. Approve records Comment state 1; reject records Comment state -3.';
+
+insert into private.api_capability_grants (
+  routine_identity,
+  capability_id,
+  allow_anon,
+  allow_authenticated,
+  allow_service_role
+)
+values (
+  'api.cmd_reviewer_submit_decision(uuid, text, text, jsonb)',
+  'NX-CMD-01',
+  false,
+  true,
+  false
+)
+on conflict (routine_identity) do update
+set capability_id = excluded.capability_id,
+    allow_anon = excluded.allow_anon,
+    allow_authenticated = excluded.allow_authenticated,
+    allow_service_role = excluded.allow_service_role;

--- a/supabase/tests/20260731_root_reference_review_v2.sql
+++ b/supabase/tests/20260731_root_reference_review_v2.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(23);
+select plan(29);
 
 select is((
   select count(*)::integer
@@ -180,7 +180,7 @@ select set_config(
   true
 );
 select ok((
-  api.cmd_simple_review_submit_decision(
+  api.cmd_reviewer_submit_decision(
     (select id from private.reviews where review_kind = 'root'),
     'approve',
     null,
@@ -189,11 +189,24 @@ select ok((
 )::boolean, 'Reviewer approval requires no opinion payload');
 select is((select state_code from private.comments limit 1), 1,
   'Reviewer approval is stored as comment state 1');
+select is((select state_code from private.reviews
+  where review_kind = 'root'), 1,
+  'Reviewer approval does not perform the Review Admin final transition');
 
 select set_config(
   'request.jwt.claim.sub',
   '19000000-0000-0000-0000-000000000003',
   true
+);
+select is(
+  api.cmd_reviewer_submit_decision(
+    (select id from private.reviews where review_kind = 'root'),
+    'approve',
+    null,
+    '{}'::jsonb
+  )->>'code',
+  'REVIEWER_REQUIRED',
+  'Review Admin cannot submit a Reviewer opinion without a Reviewer assignment'
 );
 select ok((
   api.cmd_review_finalize_approve(
@@ -244,6 +257,58 @@ select api.cmd_review_submit_v2(
   null,
   '{}'::jsonb
 );
+
+select set_config(
+  'request.jwt.claim.sub',
+  '19000000-0000-0000-0000-000000000003',
+  true
+);
+
+select ok((
+  api.cmd_review_assign_reviewers(
+    (select id from private.reviews
+      where review_kind = 'root'
+        and data_id = '39000000-0000-0000-0000-000000000002'),
+    '["19000000-0000-0000-0000-000000000002"]'::jsonb,
+    now() + interval '7 days',
+    '{}'::jsonb
+  )->>'ok'
+)::boolean, 'Review Admin assigns the Root Review before Reviewer rejection');
+
+select set_config(
+  'request.jwt.claim.sub',
+  '19000000-0000-0000-0000-000000000002',
+  true
+);
+
+select ok((
+  api.cmd_reviewer_submit_decision(
+    (select id from private.reviews
+      where review_kind = 'root'
+        and data_id = '39000000-0000-0000-0000-000000000002'),
+    'reject',
+    'Reviewer batch rejection',
+    '{"command":"reviewer_batch_decision","batch_id":"test-batch"}'::jsonb
+  )->>'ok'
+)::boolean, 'Reviewer rejection is accepted as an opinion');
+
+select is((
+  select state_code
+  from private.comments
+  where review_id = (
+    select id from private.reviews
+    where review_kind = 'root'
+      and data_id = '39000000-0000-0000-0000-000000000002'
+  )
+    and reviewer_id = '19000000-0000-0000-0000-000000000002'
+), -3, 'Reviewer rejection is stored as Comment state -3');
+
+select is((
+  select state_code
+  from private.reviews
+  where review_kind = 'root'
+    and data_id = '39000000-0000-0000-0000-000000000002'
+), 1, 'Reviewer rejection leaves the Review assigned for final admin action');
 
 select set_config(
   'request.jwt.claim.sub',

--- a/supabase/tests/20260805_full_schema_cutover.sql
+++ b/supabase/tests/20260805_full_schema_cutover.sql
@@ -68,7 +68,7 @@ select is(
     where namespace.nspname = 'api'
       and routine.prokind = 'f'
   ),
-  256::bigint,
+  257::bigint,
   'api contains the cutover functions, reviewed consumer facades, and Database A Search RPCs'
 );
 

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260811110000'::text,
+  '20260811113000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 3c9b67b8a1194266abdb2ce37ea3d8518a213f12
+lastReviewedCommit: 340e83613d3d611f881b2fd49036ddac80f3101a
 lastReviewedNote: "Reviewed for Issue #467: the exact-local snapshot deterministically regenerates the v3 review queue filter signatures, 50-row defaults, canonical types, and supporting index; workspace behavior is unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-11
-lastReviewedCommit: 3c9b67b8a1194266abdb2ce37ea3d8518a213f12
+lastReviewedCommit: 340e83613d3d611f881b2fd49036ddac80f3101a
 lastReviewedNote: "已为 Issue #467 复核：exact-local 快照可确定性重建 v3 审核队列筛选签名、默认 50 行、正式类型和配套索引；workspace 行为不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/database.types.ts
+++ b/supabase/workspace/database.types.ts
@@ -612,6 +612,15 @@ export type Database = {
         }
         Returns: Json
       }
+      cmd_reviewer_submit_decision: {
+        Args: {
+          p_audit?: Json
+          p_decision: string
+          p_reason?: string
+          p_review_id: string
+        }
+        Returns: Json
+      }
       cmd_simple_review_submit_decision: {
         Args: {
           p_audit?: Json

--- a/supabase/workspace/global/other/db5e4bfc92.sql
+++ b/supabase/workspace/global/other/db5e4bfc92.sql
@@ -1,0 +1,1 @@
+COMMENT ON FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") IS 'Submits one assigned reviewer opinion without performing review-admin finalization. Approve records Comment state 1; reject records Comment state -3.';

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -14039,6 +14039,164 @@ $$;
 ALTER FUNCTION "api"."cmd_review_submit_without_gate"("p_table" "text", "p_id" "uuid", "p_version" "text", "p_audit" "jsonb") OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text" DEFAULT NULL::"text", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_review private.reviews%rowtype;
+  v_comment private.comments%rowtype;
+  v_decision text := pg_catalog.lower(pg_catalog.btrim(coalesce(p_decision, '')));
+  v_reason text := pg_catalog.btrim(coalesce(p_reason, ''));
+  v_comment_json jsonb;
+  v_is_simple boolean;
+begin
+  if v_actor is null then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if v_decision not in ('approve', 'reject') then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DECISION_INVALID',
+      'status', 400,
+      'message', 'decision must be approve or reject'
+    );
+  end if;
+
+  if v_decision = 'approve' and v_reason <> '' then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DECISION_PAYLOAD_INVALID',
+      'status', 400,
+      'message', 'approve does not accept a reason'
+    );
+  end if;
+
+  if v_decision = 'reject' and v_reason = '' then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_REJECT_REASON_REQUIRED',
+      'status', 400,
+      'message', 'reason is required for reject'
+    );
+  end if;
+
+  if pg_catalog.length(v_reason) > 1000 then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_REJECT_REASON_TOO_LONG',
+      'status', 400,
+      'message', 'reason must not exceed 1000 characters'
+    );
+  end if;
+
+  select review_row.*
+  into v_review
+  from private.reviews as review_row
+  where review_row.id = p_review_id
+  for update;
+
+  if not found or v_review.review_kind not in ('root', 'reference') then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code <> 1
+    or not api.cmd_review_json_array(v_review.reviewer_id)
+      @> pg_catalog.jsonb_build_array(pg_catalog.to_jsonb(v_actor::text)) then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_REQUIRED',
+      'status', 403,
+      'message', 'Only an assigned reviewer can submit a pending decision'
+    );
+  end if;
+
+  select comment_row.*
+  into v_comment
+  from private.comments as comment_row
+  where comment_row.review_id = p_review_id
+    and comment_row.reviewer_id = v_actor
+  for update;
+
+  if not found or v_comment.state_code <> 0 then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_COMMENT_NOT_PENDING',
+      'status', 409,
+      'message', 'Reviewer decision is no longer pending'
+    );
+  end if;
+
+  v_is_simple := v_review.review_kind = 'reference'
+    or v_review.target_table in (
+      'contacts',
+      'sources',
+      'unitgroups',
+      'flowproperties',
+      'flows'
+    );
+
+  if v_is_simple then
+    return api.cmd_simple_review_submit_decision(
+      p_review_id,
+      v_decision,
+      case when v_decision = 'reject' then v_reason else null end,
+      coalesce(p_audit, '{}'::jsonb)
+        || pg_catalog.jsonb_build_object('reviewer_decision_command', true)
+    );
+  end if;
+
+  v_comment_json := coalesce(pg_catalog.to_jsonb(v_comment.json), '{}'::jsonb);
+
+  if v_decision = 'approve' and v_comment_json = '{}'::jsonb then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DRAFT_REQUIRED',
+      'status', 409,
+      'message', 'Process and LifecycleModel approvals require a saved review draft'
+    );
+  end if;
+
+  if v_decision = 'reject' then
+    v_comment_json := pg_catalog.jsonb_set(
+      v_comment_json,
+      '{comment}',
+      coalesce(v_comment_json->'comment', '{}'::jsonb)
+        || pg_catalog.jsonb_build_object('message', v_reason),
+      true
+    );
+  end if;
+
+  return api.cmd_review_submit_comment(
+    p_review_id,
+    v_comment_json,
+    case when v_decision = 'approve' then 1 else -3 end,
+    coalesce(p_audit, '{}'::jsonb)
+      || pg_catalog.jsonb_build_object('reviewer_decision_command', true)
+  );
+end;
+$$;
+
+
+ALTER FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") OWNER TO "postgres";
+
+
+COMMENT ON FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") IS 'Submits one assigned reviewer opinion without performing review-admin finalization. Approve records Comment state 1; reject records Comment state -3.';
+
+
+
 CREATE OR REPLACE FUNCTION "api"."cmd_simple_review_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text" DEFAULT NULL::"text", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO ''
@@ -61397,6 +61555,12 @@ GRANT ALL ON FUNCTION "api"."cmd_review_submit_v2"("p_target_table" "text", "p_t
 
 REVOKE ALL ON FUNCTION "api"."cmd_review_submit_without_gate"("p_table" "text", "p_id" "uuid", "p_version" "text", "p_audit" "jsonb") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."cmd_review_submit_without_gate"("p_table" "text", "p_id" "uuid", "p_version" "text", "p_audit" "jsonb") TO "api_internal_executor";
+
+
+
+REVOKE ALL ON FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") FROM PUBLIC;
+GRANT ALL ON FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") TO "api_internal_executor";
+GRANT ALL ON FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") TO "authenticated";
 
 
 

--- a/supabase/workspace/schemas/api/functions/cmd_reviewer_submit_decision/definition.sql
+++ b/supabase/workspace/schemas/api/functions/cmd_reviewer_submit_decision/definition.sql
@@ -1,0 +1,157 @@
+CREATE OR REPLACE FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text" DEFAULT NULL::"text", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_review private.reviews%rowtype;
+  v_comment private.comments%rowtype;
+  v_decision text := pg_catalog.lower(pg_catalog.btrim(coalesce(p_decision, '')));
+  v_reason text := pg_catalog.btrim(coalesce(p_reason, ''));
+  v_comment_json jsonb;
+  v_is_simple boolean;
+begin
+  if v_actor is null then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if v_decision not in ('approve', 'reject') then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DECISION_INVALID',
+      'status', 400,
+      'message', 'decision must be approve or reject'
+    );
+  end if;
+
+  if v_decision = 'approve' and v_reason <> '' then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DECISION_PAYLOAD_INVALID',
+      'status', 400,
+      'message', 'approve does not accept a reason'
+    );
+  end if;
+
+  if v_decision = 'reject' and v_reason = '' then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_REJECT_REASON_REQUIRED',
+      'status', 400,
+      'message', 'reason is required for reject'
+    );
+  end if;
+
+  if pg_catalog.length(v_reason) > 1000 then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_REJECT_REASON_TOO_LONG',
+      'status', 400,
+      'message', 'reason must not exceed 1000 characters'
+    );
+  end if;
+
+  select review_row.*
+  into v_review
+  from private.reviews as review_row
+  where review_row.id = p_review_id
+  for update;
+
+  if not found or v_review.review_kind not in ('root', 'reference') then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404,
+      'message', 'Review not found'
+    );
+  end if;
+
+  if v_review.state_code <> 1
+    or not api.cmd_review_json_array(v_review.reviewer_id)
+      @> pg_catalog.jsonb_build_array(pg_catalog.to_jsonb(v_actor::text)) then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_REQUIRED',
+      'status', 403,
+      'message', 'Only an assigned reviewer can submit a pending decision'
+    );
+  end if;
+
+  select comment_row.*
+  into v_comment
+  from private.comments as comment_row
+  where comment_row.review_id = p_review_id
+    and comment_row.reviewer_id = v_actor
+  for update;
+
+  if not found or v_comment.state_code <> 0 then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_COMMENT_NOT_PENDING',
+      'status', 409,
+      'message', 'Reviewer decision is no longer pending'
+    );
+  end if;
+
+  v_is_simple := v_review.review_kind = 'reference'
+    or v_review.target_table in (
+      'contacts',
+      'sources',
+      'unitgroups',
+      'flowproperties',
+      'flows'
+    );
+
+  if v_is_simple then
+    return api.cmd_simple_review_submit_decision(
+      p_review_id,
+      v_decision,
+      case when v_decision = 'reject' then v_reason else null end,
+      coalesce(p_audit, '{}'::jsonb)
+        || pg_catalog.jsonb_build_object('reviewer_decision_command', true)
+    );
+  end if;
+
+  v_comment_json := coalesce(pg_catalog.to_jsonb(v_comment.json), '{}'::jsonb);
+
+  if v_decision = 'approve' and v_comment_json = '{}'::jsonb then
+    return pg_catalog.jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_DRAFT_REQUIRED',
+      'status', 409,
+      'message', 'Process and LifecycleModel approvals require a saved review draft'
+    );
+  end if;
+
+  if v_decision = 'reject' then
+    v_comment_json := pg_catalog.jsonb_set(
+      v_comment_json,
+      '{comment}',
+      coalesce(v_comment_json->'comment', '{}'::jsonb)
+        || pg_catalog.jsonb_build_object('message', v_reason),
+      true
+    );
+  end if;
+
+  return api.cmd_review_submit_comment(
+    p_review_id,
+    v_comment_json,
+    case when v_decision = 'approve' then 1 else -3 end,
+    coalesce(p_audit, '{}'::jsonb)
+      || pg_catalog.jsonb_build_object('reviewer_decision_command', true)
+  );
+end;
+$$;
+
+ALTER FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."cmd_reviewer_submit_decision"("p_review_id" "uuid", "p_decision" "text", "p_reason" "text", "p_audit" "jsonb") TO "authenticated";


### PR DESCRIPTION
## Summary
- add cmd_reviewer_submit_decision for reviewer advisory approve/reject decisions
- preserve reviews.state_code while updating only the assigned reviewer comment
- delegate simple root/reference decisions to the existing simple review command
- add capability manifest, ACL, contract docs, and regression coverage

## Validation
- clean Supabase reset with current dev migrations
- 188/188 SQL contract tests passed
- database lint completed; generated schema and TypeScript types are reproducible
- staged Docpact gate passed

Closes #469

Parent: tiangong-lca/workspace#572