### PR TITLE
fix: keep worker job recovery non-blocking

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-11"
-lastReviewedCommit: "79d7befb12023d8c0d45160dbaeafc3e7aeafa70"
+lastReviewedAt: "2026-08-12"
+lastReviewedCommit: "19454d0fd9d40e8062ecf14d06de2caf8cc253e7"
 lastReviewedNote: "Reviewed for Issue #474 and PR #475 CI: schema routine-count and exact-head assertions remain governed by the existing SQL-test contract."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-12"
-lastReviewedCommit: "19454d0fd9d40e8062ecf14d06de2caf8cc253e7"
-lastReviewedNote: "Reviewed for Issue #474 and PR #475 CI: schema routine-count and exact-head assertions remain governed by the existing SQL-test contract."
+lastReviewedCommit: "7ea0843fe34ef53930a7d4030b6ab7a0790c1bd0"
+lastReviewedNote: "Reviewed for Issue #422 and PR #476 CI: the service-only exact-head assertion advances with the worker control-plane recovery migration; SQL-test governance is unchanged."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: 79d7befb12023d8c0d45160dbaeafc3e7aeafa70
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 19454d0fd9d40e8062ecf14d06de2caf8cc253e7
 lastReviewedNote: "Reviewed for Issue #474 and PR #475 CI: immutable hotfix history, private-schema reconciliation, and exact contract-head assertions follow existing repository governance."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: 79d7befb12023d8c0d45160dbaeafc3e7aeafa70
-lastReviewedNote: "Reviewed for Issue #474 and PR #475 CI: the added private reused-certificate helper is part of the governed internal-function inventory and exact migration head."
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 19454d0fd9d40e8062ecf14d06de2caf8cc253e7
+lastReviewedNote: "Reviewed for Issue #422 worker control-plane recovery: bounded skip-locked lease cleanup and same-lease terminal idempotency remain database-owned queue semantics."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -242,6 +242,8 @@ or duplicate indexes.
 ## Worker Jobs And Domain State
 
 `worker_jobs` is the canonical lifecycle and queue-control table for work that cannot be safely carried by Edge Function request/response execution.
+
+Claim must remain non-blocking under concurrent recovery: expired max-attempt rows are selected in bounded `FOR UPDATE SKIP LOCKED` batches before they are marked failed, while claimable queued/stale or expired-retry rows use their own skip-locked candidate set. Terminal result recording is lease-fenced; an exact repeat with the same lease token, status, and normalized result content is an idempotent acknowledgement, while any conflicting replay remains rejected. This permits a Worker to retry an ambiguous database/transport failure without leaving completed compute stranded in `running`.
 
 Retained domain tables such as `lca_package_artifacts`, `lca_package_export_items`, `lca_package_request_cache`, `lca_results`, `lca_result_cache`, `lca_latest_all_unit_results`, `lca_network_snapshots`, `dataset_review_submit_requests`, and `dataset_review_submit_gate_runs` are not replacement job tables. They store worker-produced artifacts, caches, projections, reports, or coordinator domain state. The package request cache deduplicates active work for mutable scopes (`current_user`, `open_data`, and `current_user_and_open_data`), but a new intent after completion must advance to a fresh Worker/package job; only `selected_roots`, whose exact root IDs and versions are request content, retains terminal artifact reuse. Post-cutover rows should be traceable back to `worker_jobs` through the appropriate worker job reference columns, except for explicitly documented exceptions such as snapshot identity rows that are traced through downstream worker-linked records.
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-11
-lastReviewedCommit: 79d7befb12023d8c0d45160dbaeafc3e7aeafa70
+lastReviewedAt: 2026-08-12
+lastReviewedCommit: 19454d0fd9d40e8062ecf14d06de2caf8cc253e7
 lastReviewedNote: "Reviewed for Issue #474 and PR #475 CI: full-schema routine counts and service-only migration-head readback must advance with additive governed migrations."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: 19454d0fd9d40e8062ecf14d06de2caf8cc253e7
-lastReviewedNote: "Reviewed for Issue #474 and PR #475 CI: full-schema routine counts and service-only migration-head readback must advance with additive governed migrations."
+lastReviewedCommit: 7ea0843fe34ef53930a7d4030b6ab7a0790c1bd0
+lastReviewedNote: "Reviewed for Issue #422 and PR #476 CI: the service-only migration-head readback was advanced with the additive worker control-plane recovery migration; validation commands are unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: f9973d9b16c5b4a7391fd0d5aa5e8695fd9a5da3
-lastReviewedNote: "Reviewed for Issue #474: existing exact-local refresh and migration-head validation commands cover the reconciliation; script behavior is unchanged."
+lastReviewedCommit: 8be2ea266bcbcebd5acf74392ad1839407347a77
+lastReviewedNote: "Reviewed for Issue #422: existing exact-local refresh commands generated the worker control-plane recovery schema snapshots; script behavior is unchanged."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: f9973d9b16c5b4a7391fd0d5aa5e8695fd9a5da3
-lastReviewedNote: "已为 Issue #474 复核：现有 exact-local 刷新与 migration head 校验命令覆盖本次收敛；脚本行为不变。"
+lastReviewedCommit: 8be2ea266bcbcebd5acf74392ad1839407347a77
+lastReviewedNote: "已为 Issue #422 复核：现有 exact-local 刷新命令已生成 worker 控制面恢复 schema 快照；脚本行为不变。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/supabase/migrations/20260812130000_harden_worker_job_control_plane_recovery.sql
+++ b/supabase/migrations/20260812130000_harden_worker_job_control_plane_recovery.sql
@@ -1,0 +1,420 @@
+-- Keep queue polling non-blocking when another transaction owns an expired row,
+-- and make ambiguous terminal-result retries safe for the same lease.
+
+create or replace function private.worker_claim_jobs(
+  p_worker_queue text,
+  p_worker_id text default null,
+  p_limit integer default 10,
+  p_lease_seconds integer default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = private, api, public, util, extensions, pg_temp
+as $$
+declare
+  v_worker_queue text := lower(trim(coalesce(p_worker_queue, '')));
+  v_worker_id text := nullif(trim(p_worker_id), '');
+  v_limit integer := greatest(1, least(coalesce(p_limit, 10), 50));
+  v_lease_seconds integer := greatest(1, least(coalesce(p_lease_seconds, 300), 86400));
+  v_jobs jsonb := '[]'::jsonb;
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required to claim worker jobs'
+    );
+  end if;
+
+  if v_worker_queue not in ('solver', 'review_submit', 'review_submit_gate', 'package', 'maintenance') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_WORKER_QUEUE',
+      'status', 400,
+      'message', 'workerQueue must be solver, review_submit, review_submit_gate, package, or maintenance'
+    );
+  end if;
+
+  with expired_candidates as (
+    select id
+    from private.worker_jobs
+    where worker_runtime = 'calculator'
+      and worker_queue = v_worker_queue
+      and status = 'running'
+      and lease_expires_at < now()
+      and attempt_count >= max_attempts
+    order by lease_expires_at asc, created_at asc
+    limit v_limit
+    for update skip locked
+  ),
+  expired as (
+    update private.worker_jobs as j
+      set status = 'failed',
+          error_code = coalesce(j.error_code, 'lease_expired_max_attempts'),
+          error_message = coalesce(j.error_message, 'Worker job lease expired after the maximum attempt count'),
+          error_details = coalesce(j.error_details, '{}'::jsonb) || jsonb_build_object(
+            'leasedBy', j.leased_by,
+            'leaseExpiresAt', j.lease_expires_at,
+            'attemptCount', j.attempt_count,
+            'maxAttempts', j.max_attempts
+          ),
+          leased_by = null,
+          lease_token = null,
+          lease_expires_at = null,
+          heartbeat_at = coalesce(j.heartbeat_at, now()),
+          updated_at = now(),
+          finished_at = now()
+    from expired_candidates
+    where j.id = expired_candidates.id
+    returning j.*
+  ),
+  expired_events as (
+    insert into private.worker_job_events (
+      job_id,
+      event_type,
+      status,
+      worker_id,
+      message,
+      details
+    )
+    select
+      expired.id,
+      'failed',
+      expired.status,
+      expired.leased_by,
+      'Worker job lease expired after the maximum attempt count',
+      jsonb_build_object(
+        'errorCode', expired.error_code,
+        'attemptCount', expired.attempt_count,
+        'maxAttempts', expired.max_attempts
+      )
+    from expired
+    returning id
+  ),
+  candidate as (
+    select id
+    from private.worker_jobs
+    where worker_runtime = 'calculator'
+      and worker_queue = v_worker_queue
+      and run_after <= now()
+      and attempt_count < max_attempts
+      and (
+        status in ('queued', 'stale')
+        or (status = 'running' and lease_expires_at < now())
+      )
+    order by priority desc, run_after asc, created_at asc
+    limit v_limit
+    for update skip locked
+  ),
+  updated as (
+    update private.worker_jobs as j
+      set status = 'running',
+          attempt_count = j.attempt_count + 1,
+          leased_by = v_worker_id,
+          lease_token = gen_random_uuid(),
+          lease_expires_at = now() + make_interval(secs => v_lease_seconds),
+          heartbeat_at = now(),
+          started_at = coalesce(j.started_at, now()),
+          updated_at = now(),
+          diagnostics = case
+            when j.attempt_count > 0 then '{}'::jsonb
+            else j.diagnostics
+          end,
+          error_code = null,
+          error_message = null,
+          error_details = null
+    from candidate
+    where j.id = candidate.id
+    returning j.*
+  ),
+  claim_events as (
+    insert into private.worker_job_events (
+      job_id,
+      event_type,
+      status,
+      phase,
+      progress,
+      worker_id,
+      lease_token,
+      details
+    )
+    select
+      updated.id,
+      'claimed',
+      updated.status,
+      updated.phase,
+      updated.progress,
+      updated.leased_by,
+      updated.lease_token,
+      jsonb_build_object(
+        'attemptCount', updated.attempt_count,
+        'leaseExpiresAt', updated.lease_expires_at
+      )
+    from updated
+    returning id
+  )
+  select coalesce(jsonb_agg(private.worker_job_payload(updated, true)), '[]'::jsonb)
+    into v_jobs
+  from updated;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', v_jobs
+  );
+end;
+$$;
+
+create or replace function private.worker_record_job_result(
+  p_job_id uuid,
+  p_lease_token uuid,
+  p_status text,
+  p_result_json jsonb default null,
+  p_result_schema_version text default null,
+  p_result_ref jsonb default null,
+  p_diagnostics jsonb default null,
+  p_error_code text default null,
+  p_error_message text default null,
+  p_error_details jsonb default null,
+  p_blocker_codes text[] default null,
+  p_resolution_scope text default null,
+  p_retryable boolean default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = private, api, public, util, extensions, pg_temp
+as $$
+declare
+  v_status text := lower(trim(coalesce(p_status, '')));
+  v_resolution_scope text := lower(trim(coalesce(p_resolution_scope, '')));
+  v_blocker_codes text[] := coalesce(p_blocker_codes, '{}'::text[]);
+  v_job private.worker_jobs%rowtype;
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'SERVICE_ROLE_REQUIRED',
+      'status', 403,
+      'message', 'Service role is required to record worker job results'
+    );
+  end if;
+
+  if v_status not in ('completed', 'blocked', 'failed', 'waiting') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_WORKER_JOB_RESULT_STATUS',
+      'status', 400,
+      'message', 'status must be completed, blocked, failed, or waiting'
+    );
+  end if;
+
+  if p_result_json is not null and jsonb_typeof(p_result_json) <> 'object' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_WORKER_JOB_RESULT',
+      'status', 400,
+      'message', 'result must be a JSON object'
+    );
+  end if;
+
+  if p_result_ref is not null and jsonb_typeof(p_result_ref) <> 'object' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_WORKER_JOB_RESULT_REF',
+      'status', 400,
+      'message', 'resultRef must be a JSON object'
+    );
+  end if;
+
+  if p_diagnostics is not null and jsonb_typeof(p_diagnostics) <> 'object' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_WORKER_JOB_DIAGNOSTICS',
+      'status', 400,
+      'message', 'diagnostics must be a JSON object'
+    );
+  end if;
+
+  if p_error_details is not null and jsonb_typeof(p_error_details) <> 'object' then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_WORKER_JOB_ERROR_DETAILS',
+      'status', 400,
+      'message', 'error details must be a JSON object'
+    );
+  end if;
+
+  if v_status = 'blocked' and (cardinality(v_blocker_codes) = 0 or v_resolution_scope = '') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'WORKER_JOB_BLOCKER_DETAILS_REQUIRED',
+      'status', 400,
+      'message', 'blocked worker jobs require blockerCodes and resolutionScope'
+    );
+  end if;
+
+  if v_status = 'blocked' and v_resolution_scope not in ('user', 'operator', 'system') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_WORKER_JOB_RESOLUTION_SCOPE',
+      'status', 400,
+      'message', 'resolutionScope must be user, operator, or system'
+    );
+  end if;
+
+  if v_status = 'failed' and nullif(trim(p_error_code), '') is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'WORKER_JOB_ERROR_CODE_REQUIRED',
+      'status', 400,
+      'message', 'failed worker jobs require an errorCode'
+    );
+  end if;
+
+  select *
+    into v_job
+  from private.worker_jobs
+  where id = p_job_id
+  for update;
+
+  if v_job.id is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'WORKER_JOB_NOT_FOUND',
+      'status', 404,
+      'message', 'Worker job not found'
+    );
+  end if;
+
+  if v_job.status <> 'running' then
+    if v_job.status = v_status
+      and v_job.result_json is not distinct from p_result_json
+      and v_job.result_schema_version is not distinct from coalesce(
+        nullif(trim(p_result_schema_version), ''),
+        v_job.result_schema_version
+      )
+      and v_job.result_ref is not distinct from p_result_ref
+      and v_job.diagnostics is not distinct from coalesce(p_diagnostics, '{}'::jsonb)
+      and v_job.error_code is not distinct from nullif(trim(p_error_code), '')
+      and v_job.error_message is not distinct from nullif(trim(p_error_message), '')
+      and v_job.error_details is not distinct from p_error_details
+      and v_job.blocker_codes is not distinct from (case
+        when v_status = 'blocked' then v_blocker_codes
+        else '{}'::text[]
+      end)
+      and v_job.resolution_scope is not distinct from (case
+        when v_status = 'blocked' then v_resolution_scope
+        else null
+      end)
+      and v_job.retryable is not distinct from p_retryable
+      and exists (
+        select 1
+        from private.worker_job_events as event
+        where event.job_id = v_job.id
+          and event.event_type = v_status
+          and event.lease_token is not distinct from p_lease_token
+      )
+    then
+      return jsonb_build_object(
+        'ok', true,
+        'data', private.worker_job_payload(v_job, true),
+        'idempotentReplay', true
+      );
+    end if;
+
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'WORKER_JOB_NOT_RUNNING',
+      'status', 409,
+      'message', 'Worker job is not running'
+    );
+  end if;
+
+  if v_job.lease_token is distinct from p_lease_token then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'WORKER_JOB_LEASE_TOKEN_MISMATCH',
+      'status', 409,
+      'message', 'Worker job lease token does not match'
+    );
+  end if;
+
+  if v_job.lease_expires_at < now() then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'WORKER_JOB_LEASE_EXPIRED',
+      'status', 409,
+      'message', 'Worker job lease has expired'
+    );
+  end if;
+
+  update private.worker_jobs
+    set status = v_status,
+        progress = case
+          when v_status = 'completed' then 1
+          else progress
+        end,
+        result_schema_version = coalesce(nullif(trim(p_result_schema_version), ''), result_schema_version),
+        result_json = p_result_json,
+        result_ref = p_result_ref,
+        diagnostics = coalesce(p_diagnostics, '{}'::jsonb),
+        error_code = nullif(trim(p_error_code), ''),
+        error_message = nullif(trim(p_error_message), ''),
+        error_details = p_error_details,
+        blocker_codes = case
+          when v_status = 'blocked' then v_blocker_codes
+          else '{}'::text[]
+        end,
+        resolution_scope = case
+          when v_status = 'blocked' then v_resolution_scope
+          else null
+        end,
+        retryable = p_retryable,
+        leased_by = null,
+        lease_token = null,
+        lease_expires_at = null,
+        heartbeat_at = coalesce(heartbeat_at, now()),
+        updated_at = now(),
+        finished_at = case
+          when v_status in ('completed', 'blocked', 'failed') then now()
+          else null
+        end
+  where id = v_job.id
+  returning *
+    into v_job;
+
+  insert into private.worker_job_events (
+    job_id,
+    event_type,
+    status,
+    phase,
+    progress,
+    worker_id,
+    lease_token,
+    message,
+    details
+  ) values (
+    v_job.id,
+    v_status,
+    v_job.status,
+    v_job.phase,
+    v_job.progress,
+    null,
+    p_lease_token,
+    coalesce(p_error_message, null),
+    jsonb_strip_nulls(
+      jsonb_build_object(
+        'errorCode', v_job.error_code,
+        'blockerCodes', to_jsonb(v_job.blocker_codes),
+        'resolutionScope', v_job.resolution_scope,
+        'retryable', v_job.retryable
+      )
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', private.worker_job_payload(v_job, true)
+  );
+end;
+$$;

--- a/supabase/tests/20260531_worker_jobs_foundation.sql
+++ b/supabase/tests/20260531_worker_jobs_foundation.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(50);
+select plan(52);
 
 select ok(to_regclass('private.worker_job_kinds') is not null, 'worker job kind registry exists');
 select ok(to_regclass('private.worker_jobs') is not null, 'worker_jobs table exists');
@@ -428,6 +428,17 @@ select is(
 );
 
 select is(
+  private.worker_record_job_result(
+    p_job_id => (select job_id from worker_job_test_ids where label = 'gate_primary'),
+    p_lease_token => (select lease_token from worker_job_test_ids where label = 'claimed_gate'),
+    p_status => 'completed',
+    p_result_json => '{"revisionChecksum":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'::jsonb
+  )->>'idempotentReplay',
+  'true',
+  'an identical terminal result from the same lease is an idempotent replay'
+);
+
+select is(
   (
     select progress::text
     from private.worker_jobs
@@ -552,6 +563,12 @@ select is(
   ),
   'failed:lease_expired_max_attempts',
   'expired running job at max attempts is marked failed'
+);
+
+select ok(
+  pg_get_functiondef('private.worker_claim_jobs(text,text,integer,integer)'::regprocedure)
+    like '%expired_candidates as (%for update skip locked%',
+  'expired max-attempt cleanup selects a bounded skip-locked candidate set'
 );
 
 insert into worker_job_test_ids (label, job_id, lease_token)

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260812090000'::text,
+  '20260812130000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: f9973d9b16c5b4a7391fd0d5aa5e8695fd9a5da3
-lastReviewedNote: "Reviewed for Issue #474: the exact-local snapshot deterministically includes completed-progress normalization and direct reused-certificate Bundle binding; workspace behavior is unchanged."
+lastReviewedCommit: 8be2ea266bcbcebd5acf74392ad1839407347a77
+lastReviewedNote: "Reviewed for Issue #422: the exact-local snapshot now reflects bounded skip-locked expired-lease recovery and idempotent terminal-result replay; workspace behavior is unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-12
-lastReviewedCommit: f9973d9b16c5b4a7391fd0d5aa5e8695fd9a5da3
-lastReviewedNote: "已为 Issue #474 复核：exact-local 快照可确定性包含 completed progress 归一化与直接复用证书 Bundle 绑定；workspace 行为不变。"
+lastReviewedCommit: 8be2ea266bcbcebd5acf74392ad1839407347a77
+lastReviewedNote: "已为 Issue #422 复核：exact-local 快照现已反映有界 SKIP LOCKED 过期租约恢复与终态结果幂等重放；workspace 行为不变。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -46881,7 +46881,19 @@ begin
     );
   end if;
 
-  with expired as (
+  with expired_candidates as (
+    select id
+    from private.worker_jobs
+    where worker_runtime = 'calculator'
+      and worker_queue = v_worker_queue
+      and status = 'running'
+      and lease_expires_at < now()
+      and attempt_count >= max_attempts
+    order by lease_expires_at asc, created_at asc
+    limit v_limit
+    for update skip locked
+  ),
+  expired as (
     update private.worker_jobs as j
       set status = 'failed',
           error_code = coalesce(j.error_code, 'lease_expired_max_attempts'),
@@ -46898,11 +46910,8 @@ begin
           heartbeat_at = coalesce(j.heartbeat_at, now()),
           updated_at = now(),
           finished_at = now()
-    where j.worker_runtime = 'calculator'
-      and j.worker_queue = v_worker_queue
-      and j.status = 'running'
-      and j.lease_expires_at < now()
-      and j.attempt_count >= j.max_attempts
+    from expired_candidates
+    where j.id = expired_candidates.id
     returning j.*
   ),
   expired_events as (
@@ -47793,6 +47802,41 @@ begin
   end if;
 
   if v_job.status <> 'running' then
+    if v_job.status = v_status
+      and v_job.result_json is not distinct from p_result_json
+      and v_job.result_schema_version is not distinct from coalesce(
+        nullif(trim(p_result_schema_version), ''),
+        v_job.result_schema_version
+      )
+      and v_job.result_ref is not distinct from p_result_ref
+      and v_job.diagnostics is not distinct from coalesce(p_diagnostics, '{}'::jsonb)
+      and v_job.error_code is not distinct from nullif(trim(p_error_code), '')
+      and v_job.error_message is not distinct from nullif(trim(p_error_message), '')
+      and v_job.error_details is not distinct from p_error_details
+      and v_job.blocker_codes is not distinct from (case
+        when v_status = 'blocked' then v_blocker_codes
+        else '{}'::text[]
+      end)
+      and v_job.resolution_scope is not distinct from (case
+        when v_status = 'blocked' then v_resolution_scope
+        else null
+      end)
+      and v_job.retryable is not distinct from p_retryable
+      and exists (
+        select 1
+        from private.worker_job_events as event
+        where event.job_id = v_job.id
+          and event.event_type = v_status
+          and event.lease_token is not distinct from p_lease_token
+      )
+    then
+      return jsonb_build_object(
+        'ok', true,
+        'data', private.worker_job_payload(v_job, true),
+        'idempotentReplay', true
+      );
+    end if;
+
     return jsonb_build_object(
       'ok', false,
       'code', 'WORKER_JOB_NOT_RUNNING',

--- a/supabase/workspace/schemas/private/functions/worker_claim_jobs/definition.sql
+++ b/supabase/workspace/schemas/private/functions/worker_claim_jobs/definition.sql
@@ -27,7 +27,19 @@ begin
     );
   end if;
 
-  with expired as (
+  with expired_candidates as (
+    select id
+    from private.worker_jobs
+    where worker_runtime = 'calculator'
+      and worker_queue = v_worker_queue
+      and status = 'running'
+      and lease_expires_at < now()
+      and attempt_count >= max_attempts
+    order by lease_expires_at asc, created_at asc
+    limit v_limit
+    for update skip locked
+  ),
+  expired as (
     update private.worker_jobs as j
       set status = 'failed',
           error_code = coalesce(j.error_code, 'lease_expired_max_attempts'),
@@ -44,11 +56,8 @@ begin
           heartbeat_at = coalesce(j.heartbeat_at, now()),
           updated_at = now(),
           finished_at = now()
-    where j.worker_runtime = 'calculator'
-      and j.worker_queue = v_worker_queue
-      and j.status = 'running'
-      and j.lease_expires_at < now()
-      and j.attempt_count >= j.max_attempts
+    from expired_candidates
+    where j.id = expired_candidates.id
     returning j.*
   ),
   expired_events as (

--- a/supabase/workspace/schemas/private/functions/worker_record_job_result/definition.sql
+++ b/supabase/workspace/schemas/private/functions/worker_record_job_result/definition.sql
@@ -105,6 +105,41 @@ begin
   end if;
 
   if v_job.status <> 'running' then
+    if v_job.status = v_status
+      and v_job.result_json is not distinct from p_result_json
+      and v_job.result_schema_version is not distinct from coalesce(
+        nullif(trim(p_result_schema_version), ''),
+        v_job.result_schema_version
+      )
+      and v_job.result_ref is not distinct from p_result_ref
+      and v_job.diagnostics is not distinct from coalesce(p_diagnostics, '{}'::jsonb)
+      and v_job.error_code is not distinct from nullif(trim(p_error_code), '')
+      and v_job.error_message is not distinct from nullif(trim(p_error_message), '')
+      and v_job.error_details is not distinct from p_error_details
+      and v_job.blocker_codes is not distinct from (case
+        when v_status = 'blocked' then v_blocker_codes
+        else '{}'::text[]
+      end)
+      and v_job.resolution_scope is not distinct from (case
+        when v_status = 'blocked' then v_resolution_scope
+        else null
+      end)
+      and v_job.retryable is not distinct from p_retryable
+      and exists (
+        select 1
+        from private.worker_job_events as event
+        where event.job_id = v_job.id
+          and event.event_type = v_status
+          and event.lease_token is not distinct from p_lease_token
+      )
+    then
+      return jsonb_build_object(
+        'ok', true,
+        'data', private.worker_job_payload(v_job, true),
+        'idempotentReplay', true
+      );
+    end if;
+
     return jsonb_build_object(
       'ok', false,
       'code', 'WORKER_JOB_NOT_RUNNING',


### PR DESCRIPTION
## Summary
- Bound expired max-attempt cleanup with FOR UPDATE SKIP LOCKED so one locked stale row cannot block queue claims.
- Accept exact same-lease terminal-result replays so Worker can retry ambiguous database or transport failures safely.

## Key Decisions
- Target dev from the temporary issue-422 recovery branch; do not promote or modify main.
- Keep conflicting terminal replays lease-fenced and rejected.

## Validation
- 52/52 assertions passed in supabase/tests/20260531_worker_jobs_foundation.sql with the migration applied inside a rollback-only local transaction.
- Docpact strict config validation and enforce lint passed.

## Risks / Rollback
- Low and bounded: two existing private RPCs are replaced; rollback is the prior function definitions.

## Follow-ups
- Refs tiangong-lca/database-engine#422.
- After Preview verification, deploy to persistent dev before deploying Worker commit 800de2c.

## Workspace Integration
- Temporary dev-only schema-cutover recovery; no main or root-main integration in this change.