### PR TITLE
feat: add system maintenance runtime config

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "45bb93dd783c53f4884d9d6012db2b4a6083a00b"
+lastReviewedCommit: "257de3a3c41557118ee5c87947eeb7d06df85cc3"
 lastReviewedNote: "Reviewed after restoring the generated workspace with the CI-authoritative public, api, private, util, and archive schema set; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "257de3a3c41557118ee5c87947eeb7d06df85cc3"
+lastReviewedCommit: "33b0bdcab65ef3ca5a712ac771774d5e22826378"
 lastReviewedNote: "Reviewed after restoring the generated workspace with the CI-authoritative public, api, private, util, and archive schema set; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 45bb93dd783c53f4884d9d6012db2b4a6083a00b
+lastReviewedCommit: 257de3a3c41557118ee5c87947eeb7d06df85cc3
 lastReviewedNote: "Reviewed after restoring the CI-authoritative five-schema generated workspace; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 257de3a3c41557118ee5c87947eeb7d06df85cc3
+lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
 lastReviewedNote: "Reviewed after restoring the CI-authoritative five-schema generated workspace; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 257de3a3c41557118ee5c87947eeb7d06df85cc3
+lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
 lastReviewedNote: "Reviewed after restoring the generated workspace with the complete CI schema set; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 45bb93dd783c53f4884d9d6012db2b4a6083a00b
+lastReviewedCommit: 257de3a3c41557118ee5c87947eeb7d06df85cc3
 lastReviewedNote: "Reviewed after restoring the generated workspace with the complete CI schema set; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 257de3a3c41557118ee5c87947eeb7d06df85cc3
+lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
 lastReviewedNote: "Reviewed after reproducing CI generation with public, api, private, util, and archive; deterministic rebuild and generated-artifact verification remain the required proof."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 45bb93dd783c53f4884d9d6012db2b4a6083a00b
+lastReviewedCommit: 257de3a3c41557118ee5c87947eeb7d06df85cc3
 lastReviewedNote: "Reviewed after reproducing CI generation with public, api, private, util, and archive; deterministic rebuild and generated-artifact verification remain the required proof."
 related:
   - ../../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 45bb93dd783c53f4884d9d6012db2b4a6083a00b
+lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
 lastReviewedNote: "Reviewed after an exact CI-equivalent five-schema workspace rebuild; the script catalog and invocation contract remain unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 45bb93dd783c53f4884d9d6012db2b4a6083a00b
+lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
 lastReviewedNote: "已按 CI 的五 schema 参数完成等价重建复核；脚本目录及调用契约无需改变。"
 related:
   - ../AGENTS.md

--- a/supabase/migrations/20260814090000_system_maintenance_runtime_config.sql
+++ b/supabase/migrations/20260814090000_system_maintenance_runtime_config.sql
@@ -1,0 +1,128 @@
+-- Browser-visible system maintenance state is stored outside exposed schemas
+-- and projected through one fixed, read-only API facade.
+
+set lock_timeout = '5s';
+set statement_timeout = '120s';
+
+create table util.app_runtime_config (
+  config_key text primary key,
+  config_value jsonb not null,
+  updated_at timestamptz not null default statement_timestamp(),
+  constraint app_runtime_config_key_not_blank_check check (btrim(config_key) <> ''),
+  constraint app_runtime_config_value_object_check check (
+    jsonb_typeof(config_value) = 'object'
+  ),
+  constraint app_runtime_config_schema_version_check check (
+    coalesce(config_value -> 'schemaVersion' = '1'::jsonb, false)
+  ),
+  constraint app_runtime_config_phase_check check (
+    coalesce(config_value ->> 'phase' in ('normal', 'maintenance', 'verifying'), false)
+  ),
+  constraint app_runtime_config_reason_check check (
+    not (config_value ? 'reason')
+    or config_value -> 'reason' = 'null'::jsonb
+    or config_value ->> 'reason' in ('release_upgrade', 'emergency')
+  ),
+  constraint app_runtime_config_target_version_check check (
+    not (config_value ? 'targetVersion')
+    or config_value -> 'targetVersion' = 'null'::jsonb
+    or jsonb_typeof(config_value -> 'targetVersion') = 'string'
+  ),
+  constraint app_runtime_config_estimated_end_at_check check (
+    not (config_value ? 'estimatedEndAt')
+    or config_value -> 'estimatedEndAt' = 'null'::jsonb
+    or (
+      jsonb_typeof(config_value -> 'estimatedEndAt') = 'string'
+      and config_value ->> 'estimatedEndAt'
+        ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([.]\d+)?(Z|[+-]\d{2}:\d{2})$'
+    )
+  ),
+  constraint app_runtime_config_release_id_check check (
+    not (config_value ? 'releaseId')
+    or config_value -> 'releaseId' = 'null'::jsonb
+    or jsonb_typeof(config_value -> 'releaseId') = 'string'
+  ),
+  constraint app_runtime_config_active_reason_check check (
+    coalesce(
+      config_value ->> 'phase' = 'normal'
+      or config_value ->> 'reason' in ('release_upgrade', 'emergency'),
+      false
+    )
+  )
+);
+
+alter table util.app_runtime_config owner to postgres;
+revoke all on table util.app_runtime_config from public, anon, authenticated, service_role;
+
+comment on table util.app_runtime_config is
+  'Operational runtime configuration. Values are not Data API relations and are exposed only by fixed api facades.';
+comment on column util.app_runtime_config.config_key is
+  'Stable application/environment/config identity.';
+comment on column util.app_runtime_config.config_value is
+  'Versioned JSON payload validated by database constraints.';
+
+insert into util.app_runtime_config (config_key, config_value)
+values (
+  'tiangong-lca-next.production.system-status',
+  jsonb_build_object(
+    'schemaVersion', 1,
+    'phase', 'normal',
+    'reason', null,
+    'targetVersion', null,
+    'estimatedEndAt', null,
+    'releaseId', null
+  )
+)
+on conflict (config_key) do nothing;
+
+create or replace function api.qry_system_status()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = ''
+as $function$
+  select coalesce(
+    (
+      select config.config_value || jsonb_build_object('updatedAt', config.updated_at)
+      from util.app_runtime_config as config
+      where config.config_key = 'tiangong-lca-next.production.system-status'
+    ),
+    jsonb_build_object(
+      'schemaVersion', 1,
+      'phase', 'normal',
+      'reason', null,
+      'targetVersion', null,
+      'estimatedEndAt', null,
+      'releaseId', null,
+      'updatedAt', null
+    )
+  );
+$function$;
+
+alter function api.qry_system_status() owner to postgres;
+revoke all on function api.qry_system_status() from public, anon, authenticated, service_role;
+grant execute on function api.qry_system_status() to anon, authenticated;
+
+comment on function api.qry_system_status() is
+  'Returns the public browser startup status for tiangong-lca-next without exposing the operational config table.';
+
+insert into private.api_capability_grants (
+  routine_identity,
+  capability_id,
+  allow_anon,
+  allow_authenticated,
+  allow_service_role
+)
+values (
+  'api.qry_system_status()',
+  'NX-RUNTIME-01',
+  true,
+  true,
+  false
+)
+on conflict (routine_identity) do update
+set capability_id = excluded.capability_id,
+    allow_anon = excluded.allow_anon,
+    allow_authenticated = excluded.allow_authenticated,
+    allow_service_role = excluded.allow_service_role;

--- a/supabase/tests/20260805_full_schema_cutover.sql
+++ b/supabase/tests/20260805_full_schema_cutover.sql
@@ -68,7 +68,7 @@ select is(
     where namespace.nspname = 'api'
       and routine.prokind = 'f'
   ),
-  259::bigint,
+  260::bigint,
   'api contains the cutover functions, reviewed consumer facades, and Database A Search RPCs'
 );
 
@@ -136,7 +136,7 @@ select is(
       'util'::regnamespace
     )
   ),
-  447::bigint,
+  457::bigint,
   'all application constraints remain present'
 );
 

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260813160000'::text,
+  '20260814090000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260814_system_maintenance_runtime_config.sql
+++ b/supabase/tests/20260814_system_maintenance_runtime_config.sql
@@ -1,0 +1,132 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, api, private, util;
+
+select plan(17);
+
+select has_table('util', 'app_runtime_config', 'runtime config is owned by the util schema');
+select col_is_pk('util', 'app_runtime_config', 'config_key', 'config key is the primary key');
+
+select ok(
+  not has_table_privilege('anon', 'util.app_runtime_config', 'SELECT')
+    and not has_table_privilege('authenticated', 'util.app_runtime_config', 'SELECT')
+    and not has_table_privilege('service_role', 'util.app_runtime_config', 'SELECT'),
+  'external roles cannot read the runtime config table directly'
+);
+
+select ok(
+  not has_table_privilege('anon', 'util.app_runtime_config', 'UPDATE')
+    and not has_table_privilege('authenticated', 'util.app_runtime_config', 'UPDATE')
+    and not has_table_privilege('service_role', 'util.app_runtime_config', 'UPDATE'),
+  'external roles cannot mutate the runtime config table directly'
+);
+
+select has_function('api', 'qry_system_status', array[]::text[], 'system status facade exists');
+
+select is(
+  (
+    select routine.prosecdef
+    from pg_proc as routine
+    where routine.oid = 'api.qry_system_status()'::regprocedure
+  ),
+  true,
+  'system status facade is SECURITY DEFINER'
+);
+
+select is(
+  (
+    select routine.proconfig
+    from pg_proc as routine
+    where routine.oid = 'api.qry_system_status()'::regprocedure
+  ),
+  array['search_path=""']::text[],
+  'system status facade has an empty fixed search path'
+);
+
+select ok(
+  has_function_privilege('anon', 'api.qry_system_status()', 'EXECUTE'),
+  'anonymous browser startup can read system status'
+);
+
+select ok(
+  has_function_privilege('authenticated', 'api.qry_system_status()', 'EXECUTE'),
+  'authenticated browser startup can read system status'
+);
+
+select ok(
+  not has_function_privilege('service_role', 'api.qry_system_status()', 'EXECUTE'),
+  'service role receives no unnecessary system status grant'
+);
+
+select results_eq(
+  $$
+    select capability_id, allow_anon, allow_authenticated, allow_service_role
+    from private.api_capability_grants
+    where routine_identity = 'api.qry_system_status()'
+  $$,
+  $$values ('NX-RUNTIME-01'::text, true, true, false)$$,
+  'the capability manifest exactly describes the facade grants'
+);
+
+select is(
+  api.qry_system_status() ->> 'phase',
+  'normal',
+  'the seeded production status is normal'
+);
+
+set local role anon;
+select is(
+  api.qry_system_status() ->> 'schemaVersion',
+  '1',
+  'anonymous callers receive the versioned public payload'
+);
+reset role;
+
+update util.app_runtime_config
+set config_value = jsonb_build_object(
+      'schemaVersion', 1,
+      'phase', 'maintenance',
+      'reason', 'release_upgrade',
+      'targetVersion', '0.0.71',
+      'estimatedEndAt', '2026-08-14T10:30:00+08:00',
+      'releaseId', 'release-20260814'
+    ),
+    updated_at = '2026-08-14T09:00:00+08:00'::timestamptz
+where config_key = 'tiangong-lca-next.production.system-status';
+
+select is(
+  api.qry_system_status() ->> 'targetVersion',
+  '0.0.71',
+  'the facade returns the active release target'
+);
+
+select is(
+  api.qry_system_status() ->> 'updatedAt',
+  to_jsonb('2026-08-14T09:00:00+08:00'::timestamptz) #>> '{}',
+  'the facade appends the authoritative update timestamp'
+);
+
+select throws_ok(
+  $$
+    update util.app_runtime_config
+    set config_value = '{"schemaVersion":1,"phase":"broken"}'::jsonb
+    where config_key = 'tiangong-lca-next.production.system-status'
+  $$,
+  '23514',
+  null,
+  'an unsupported phase cannot be persisted'
+);
+
+select throws_ok(
+  $$
+    insert into util.app_runtime_config (config_key, config_value)
+    values ('missing-required-fields', '{}'::jsonb)
+  $$,
+  '23514',
+  null,
+  'required schema version and phase fields cannot be omitted'
+);
+
+select * from finish();
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 45bb93dd783c53f4884d9d6012db2b4a6083a00b
+lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
 lastReviewedNote: "Restored and reviewed the exact-local workspace for the CI-authoritative public, api, private, util, and archive schemas; deterministic generation behavior is unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-14
-lastReviewedCommit: 45bb93dd783c53f4884d9d6012db2b4a6083a00b
+lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
 lastReviewedNote: "已恢复并复核 CI 权威的 public、api、private、util、archive 五 schema exact-local workspace；确定性生成行为不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/database.types.ts
+++ b/supabase/workspace/database.types.ts
@@ -2012,6 +2012,7 @@ export type Database = {
           user_id: string
         }[]
       }
+      qry_system_status: { Args: never; Returns: Json }
       qry_team_find_invitable_user_by_email: {
         Args: { p_email: string; p_team_id: string }
         Returns: Json

--- a/supabase/workspace/global/other/e7a34a34f0.sql
+++ b/supabase/workspace/global/other/e7a34a34f0.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN "util"."app_runtime_config"."config_key" IS 'Stable application/environment/config identity.';

--- a/supabase/workspace/global/other/eb0f97372c.sql
+++ b/supabase/workspace/global/other/eb0f97372c.sql
@@ -1,0 +1,1 @@
+COMMENT ON FUNCTION "api"."qry_system_status"() IS 'Returns the public browser startup status for tiangong-lca-next without exposing the operational config table.';

--- a/supabase/workspace/global/other/fb8864eaaa.sql
+++ b/supabase/workspace/global/other/fb8864eaaa.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN "util"."app_runtime_config"."config_value" IS 'Versioned JSON payload validated by database constraints.';

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -21093,6 +21093,36 @@ $_$;
 ALTER FUNCTION "api"."qry_system_get_member_list"("p_page" integer, "p_page_size" integer, "p_sort_by" "text", "p_sort_order" "text") OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "api"."qry_system_status"() RETURNS "jsonb"
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+  select coalesce(
+    (
+      select config.config_value || jsonb_build_object('updatedAt', config.updated_at)
+      from util.app_runtime_config as config
+      where config.config_key = 'tiangong-lca-next.production.system-status'
+    ),
+    jsonb_build_object(
+      'schemaVersion', 1,
+      'phase', 'normal',
+      'reason', null,
+      'targetVersion', null,
+      'estimatedEndAt', null,
+      'releaseId', null,
+      'updatedAt', null
+    )
+  );
+$$;
+
+
+ALTER FUNCTION "api"."qry_system_status"() OWNER TO "postgres";
+
+
+COMMENT ON FUNCTION "api"."qry_system_status"() IS 'Returns the public browser startup status for tiangong-lca-next without exposing the operational config table.';
+
+
+
 CREATE OR REPLACE FUNCTION "api"."qry_team_find_invitable_user_by_email"("p_team_id" "uuid", "p_email" "text") RETURNS "jsonb"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
@@ -56704,6 +56734,37 @@ CREATE TABLE IF NOT EXISTS "public"."lciamethods" (
 ALTER TABLE "public"."lciamethods" OWNER TO "postgres";
 
 
+CREATE TABLE IF NOT EXISTS "util"."app_runtime_config" (
+    "config_key" "text" NOT NULL,
+    "config_value" "jsonb" NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "statement_timestamp"() NOT NULL,
+    CONSTRAINT "app_runtime_config_active_reason_check" CHECK (COALESCE(((("config_value" ->> 'phase'::"text") = 'normal'::"text") OR (("config_value" ->> 'reason'::"text") = ANY (ARRAY['release_upgrade'::"text", 'emergency'::"text"]))), false)),
+    CONSTRAINT "app_runtime_config_estimated_end_at_check" CHECK (((NOT ("config_value" ? 'estimatedEndAt'::"text")) OR (("config_value" -> 'estimatedEndAt'::"text") = 'null'::"jsonb") OR (("jsonb_typeof"(("config_value" -> 'estimatedEndAt'::"text")) = 'string'::"text") AND (("config_value" ->> 'estimatedEndAt'::"text") ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([.]\d+)?(Z|[+-]\d{2}:\d{2})$'::"text")))),
+    CONSTRAINT "app_runtime_config_key_not_blank_check" CHECK (("btrim"("config_key") <> ''::"text")),
+    CONSTRAINT "app_runtime_config_phase_check" CHECK (COALESCE((("config_value" ->> 'phase'::"text") = ANY (ARRAY['normal'::"text", 'maintenance'::"text", 'verifying'::"text"])), false)),
+    CONSTRAINT "app_runtime_config_reason_check" CHECK (((NOT ("config_value" ? 'reason'::"text")) OR (("config_value" -> 'reason'::"text") = 'null'::"jsonb") OR (("config_value" ->> 'reason'::"text") = ANY (ARRAY['release_upgrade'::"text", 'emergency'::"text"])))),
+    CONSTRAINT "app_runtime_config_release_id_check" CHECK (((NOT ("config_value" ? 'releaseId'::"text")) OR (("config_value" -> 'releaseId'::"text") = 'null'::"jsonb") OR ("jsonb_typeof"(("config_value" -> 'releaseId'::"text")) = 'string'::"text"))),
+    CONSTRAINT "app_runtime_config_schema_version_check" CHECK (COALESCE((("config_value" -> 'schemaVersion'::"text") = '1'::"jsonb"), false)),
+    CONSTRAINT "app_runtime_config_target_version_check" CHECK (((NOT ("config_value" ? 'targetVersion'::"text")) OR (("config_value" -> 'targetVersion'::"text") = 'null'::"jsonb") OR ("jsonb_typeof"(("config_value" -> 'targetVersion'::"text")) = 'string'::"text"))),
+    CONSTRAINT "app_runtime_config_value_object_check" CHECK (("jsonb_typeof"("config_value") = 'object'::"text"))
+);
+
+
+ALTER TABLE "util"."app_runtime_config" OWNER TO "postgres";
+
+
+COMMENT ON TABLE "util"."app_runtime_config" IS 'Operational runtime configuration. Values are not Data API relations and are exposed only by fixed api facades.';
+
+
+
+COMMENT ON COLUMN "util"."app_runtime_config"."config_key" IS 'Stable application/environment/config identity.';
+
+
+
+COMMENT ON COLUMN "util"."app_runtime_config"."config_value" IS 'Versioned JSON payload validated by database constraints.';
+
+
+
 CREATE TABLE IF NOT EXISTS "util"."dataset_alias_execution_gate_receipts" (
     "preflight_id" "uuid" NOT NULL,
     "actor_user_id" "uuid" NOT NULL,
@@ -58084,6 +58145,11 @@ ALTER TABLE ONLY "public"."sources"
 
 ALTER TABLE ONLY "public"."unitgroups"
     ADD CONSTRAINT "unitgroups_pkey" PRIMARY KEY ("id", "version");
+
+
+
+ALTER TABLE ONLY "util"."app_runtime_config"
+    ADD CONSTRAINT "app_runtime_config_pkey" PRIMARY KEY ("config_key");
 
 
 
@@ -61896,6 +61962,12 @@ GRANT ALL ON FUNCTION "api"."qry_system_find_member_candidate_by_email"("p_email
 REVOKE ALL ON FUNCTION "api"."qry_system_get_member_list"("p_page" integer, "p_page_size" integer, "p_sort_by" "text", "p_sort_order" "text") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."qry_system_get_member_list"("p_page" integer, "p_page_size" integer, "p_sort_by" "text", "p_sort_order" "text") TO "api_internal_executor";
 GRANT ALL ON FUNCTION "api"."qry_system_get_member_list"("p_page" integer, "p_page_size" integer, "p_sort_by" "text", "p_sort_order" "text") TO "authenticated";
+
+
+
+REVOKE ALL ON FUNCTION "api"."qry_system_status"() FROM PUBLIC;
+GRANT ALL ON FUNCTION "api"."qry_system_status"() TO "anon";
+GRANT ALL ON FUNCTION "api"."qry_system_status"() TO "authenticated";
 
 
 

--- a/supabase/workspace/schemas/api/functions/qry_system_status/definition.sql
+++ b/supabase/workspace/schemas/api/functions/qry_system_status/definition.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION "api"."qry_system_status"() RETURNS "jsonb"
+    LANGUAGE "sql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+  select coalesce(
+    (
+      select config.config_value || jsonb_build_object('updatedAt', config.updated_at)
+      from util.app_runtime_config as config
+      where config.config_key = 'tiangong-lca-next.production.system-status'
+    ),
+    jsonb_build_object(
+      'schemaVersion', 1,
+      'phase', 'normal',
+      'reason', null,
+      'targetVersion', null,
+      'estimatedEndAt', null,
+      'releaseId', null,
+      'updatedAt', null
+    )
+  );
+$$;
+
+ALTER FUNCTION "api"."qry_system_status"() OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."qry_system_status"() FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."qry_system_status"() TO "anon";
+
+GRANT ALL ON FUNCTION "api"."qry_system_status"() TO "authenticated";

--- a/supabase/workspace/schemas/util/tables/app_runtime_config/table.sql
+++ b/supabase/workspace/schemas/util/tables/app_runtime_config/table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS "util"."app_runtime_config" (
+    "config_key" "text" NOT NULL,
+    "config_value" "jsonb" NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "statement_timestamp"() NOT NULL,
+    CONSTRAINT "app_runtime_config_active_reason_check" CHECK (COALESCE(((("config_value" ->> 'phase'::"text") = 'normal'::"text") OR (("config_value" ->> 'reason'::"text") = ANY (ARRAY['release_upgrade'::"text", 'emergency'::"text"]))), false)),
+    CONSTRAINT "app_runtime_config_estimated_end_at_check" CHECK (((NOT ("config_value" ? 'estimatedEndAt'::"text")) OR (("config_value" -> 'estimatedEndAt'::"text") = 'null'::"jsonb") OR (("jsonb_typeof"(("config_value" -> 'estimatedEndAt'::"text")) = 'string'::"text") AND (("config_value" ->> 'estimatedEndAt'::"text") ~ '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([.]\d+)?(Z|[+-]\d{2}:\d{2})$'::"text")))),
+    CONSTRAINT "app_runtime_config_key_not_blank_check" CHECK (("btrim"("config_key") <> ''::"text")),
+    CONSTRAINT "app_runtime_config_phase_check" CHECK (COALESCE((("config_value" ->> 'phase'::"text") = ANY (ARRAY['normal'::"text", 'maintenance'::"text", 'verifying'::"text"])), false)),
+    CONSTRAINT "app_runtime_config_reason_check" CHECK (((NOT ("config_value" ? 'reason'::"text")) OR (("config_value" -> 'reason'::"text") = 'null'::"jsonb") OR (("config_value" ->> 'reason'::"text") = ANY (ARRAY['release_upgrade'::"text", 'emergency'::"text"])))),
+    CONSTRAINT "app_runtime_config_release_id_check" CHECK (((NOT ("config_value" ? 'releaseId'::"text")) OR (("config_value" -> 'releaseId'::"text") = 'null'::"jsonb") OR ("jsonb_typeof"(("config_value" -> 'releaseId'::"text")) = 'string'::"text"))),
+    CONSTRAINT "app_runtime_config_schema_version_check" CHECK (COALESCE((("config_value" -> 'schemaVersion'::"text") = '1'::"jsonb"), false)),
+    CONSTRAINT "app_runtime_config_target_version_check" CHECK (((NOT ("config_value" ? 'targetVersion'::"text")) OR (("config_value" -> 'targetVersion'::"text") = 'null'::"jsonb") OR ("jsonb_typeof"(("config_value" -> 'targetVersion'::"text")) = 'string'::"text"))),
+    CONSTRAINT "app_runtime_config_value_object_check" CHECK (("jsonb_typeof"("config_value") = 'object'::"text"))
+);
+
+ALTER TABLE "util"."app_runtime_config" OWNER TO "postgres";
+
+COMMENT ON TABLE "util"."app_runtime_config" IS 'Operational runtime configuration. Values are not Data API relations and are exposed only by fixed api facades.';
+
+ALTER TABLE ONLY "util"."app_runtime_config"
+    ADD CONSTRAINT "app_runtime_config_pkey" PRIMARY KEY ("config_key");


### PR DESCRIPTION
Closes #492\n\n## Summary\n\n- add util.app_runtime_config with a versioned system-status JSON contract and a seeded normal production state\n- expose only api.qry_system_status() to anon/authenticated browser clients through a fixed SECURITY DEFINER facade\n- enforce payload shape, active-phase reason, timestamp semantics, and least-privilege ACL closure\n- register the NX-RUNTIME-01 capability and add pgTAP coverage\n\n## Validation\n\n- applied the complete migration chain in an isolated PostgreSQL/Supabase container\n- new pgTAP suite: 17/17 passed\n- relevant existing API ACL closure assertions passed; the remaining isolated-image failure was caused by that image lacking auth.users.email_confirmed_at\n- Docpact strict validation and lint passed\n\n## Operations\n\nRelease automation or a privileged operator changes only the row keyed by tiangong-lca-next.production.system-status. Browser clients cannot update or directly read the table.