### PR TITLE
fix: advance scope closure lineage scanner revision

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "33b0bdcab65ef3ca5a712ac771774d5e22826378"
+lastReviewedAt: "2026-08-17"
+lastReviewedCommit: "42ab3ea04d15deb72fd0ec03114a067730dcba1c"
 lastReviewedNote: "Reviewed after restoring the generated workspace with the CI-authoritative public, api, private, util, and archive schema set; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 42ab3ea04d15deb72fd0ec03114a067730dcba1c
 lastReviewedNote: "Reviewed after restoring the CI-authoritative five-schema generated workspace; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,9 +27,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
+lastReviewedAt: 2026-08-17
 lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
-lastReviewedNote: "Reviewed after restoring the generated workspace with the complete CI schema set; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
+lastReviewedNote: "Advanced the internal Scope Closure scanner cache identity to cutoff-readiness-r2 so lineage-aware Worker semantics cannot reuse earlier completed scans; public contracts and schema ownership remain unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -273,7 +273,7 @@ Certificate-grade Scope Closure normalization canonicalizes omitted and supporte
 
 A passed reused Scope Closure certificate owns a new target report while retaining the direct source check's immutable numerical snapshot and Closure Bundle. Calculation admission, Worker binding, and package publication validate that single-hop source through `reused_from_check_id`; they never relabel or copy the source Bundle. The target and source must retain exact scope, policy, data-snapshot, numerical-snapshot, Bundle identity, and checksum parity. Independently, `worker_jobs.status = completed` implies canonical `progress = 1`; blocked and failed terminal states retain their actual partial progress.
 
-The current internal scanner cache identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r1`; changing it creates a distinct request fingerprint and scan execution without changing any public V1 DTO or artifact schema. Historical requests retain their recorded revision for in-flight compatibility. A completed `blocked` scan has complete reusable administrative evidence but deliberately no numerical snapshot, even though its scan-execution row retains a preallocated `numerical_snapshot_id`. Reuse therefore compares that ID with the source check snapshot only for `passed` certificate evidence; all immutable scope, policy, data-snapshot, completion, and source-status fences still apply to both terminal outcomes.
+The current internal scanner cache identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r2`; changing it creates a distinct request fingerprint and scan execution without changing any public V1 DTO or artifact schema. The r2 revision separates exact-identity Process lineage traversal from numerical provider-universe enforcement. Historical requests retain their recorded revision for in-flight compatibility. A completed `blocked` scan has complete reusable administrative evidence but deliberately no numerical snapshot, even though its scan-execution row retains a preallocated `numerical_snapshot_id`. Reuse therefore compares that ID with the source check snapshot only for `passed` certificate evidence; all immutable scope, policy, data-snapshot, completion, and source-status fences still apply to both terminal outcomes.
 
 ## Scope-Closure Evidence Retention
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 42ab3ea04d15deb72fd0ec03114a067730dcba1c
 lastReviewedNote: "Reviewed after reproducing CI generation with public, api, private, util, and archive; deterministic rebuild and generated-artifact verification remain the required proof."
 related:
   - ../../AGENTS.md

--- a/supabase/migrations/20260817090000_advance_scope_closure_lineage_scanner_revision.sql
+++ b/supabase/migrations/20260817090000_advance_scope_closure_lineage_scanner_revision.sql
@@ -1,0 +1,19 @@
+-- Advance the internal scanner cache identity after Worker scope-closure
+-- semantics stop treating Process lineage as a numerical provider dependency.
+-- Historical requests retain their recorded fingerprint and remain readable;
+-- new requests receive a distinct request and scan-execution identity.
+
+set lock_timeout = '5s';
+set statement_timeout = '120s';
+
+insert into private.lcia_scope_closure_config (
+  singleton,
+  expected_validator_scanner_fingerprint
+)
+values (
+  true,
+  'scope-closure-validator-scanner.v1+cutoff-readiness-r2'
+)
+on conflict (singleton) do update
+set expected_validator_scanner_fingerprint = excluded.expected_validator_scanner_fingerprint,
+    updated_at = statement_timestamp();

--- a/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
+++ b/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
@@ -8,8 +8,8 @@ select is(
   (select expected_validator_scanner_fingerprint
    from private.lcia_scope_closure_config
    where singleton),
-  'scope-closure-validator-scanner.v1+cutoff-readiness-r1',
-  'new closure requests use the cutoff-readiness scanner cache revision'
+  'scope-closure-validator-scanner.v1+cutoff-readiness-r2',
+  'new closure requests use the lineage-aware scanner cache revision'
 );
 
 -- A minimal immutable current release.  The closure request must use this
@@ -265,27 +265,27 @@ select is((select status from private.lcia_scope_closure_scan_executions limit 1
 -- rollout may still have old requests in flight, but new requests must not
 -- select their completed evidence after the configured revision changes.
 update private.lcia_scope_closure_config
-set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1',
+set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r1',
     updated_at=now()
 where singleton;
 select set_config('request.jwt.claim.role','authenticated',true);
 select is(api.cmd_lcia_scope_closure_check_request_v2(
   '{"coverageMode":"subset","processes":[{"id":"c7220000-0000-4000-8000-000000000020","version":"01.00.000"}],"lciaMethods":[{"id":"c7220000-0000-4000-8000-000000000021","version":"01.00.000"}]}'::jsonb,
   'closure-e2e-old-scanner','{}'
-)->>'ok','true','historical scanner request fixture is accepted by the database command');
+)->>'ok','true','previous scanner revision request fixture is accepted by the database command');
 update private.lcia_scope_closure_config
-set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r1',
+set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r2',
     updated_at=now()
 where singleton;
 select is(api.cmd_lcia_scope_closure_check_request_v2(
   '{"coverageMode":"subset","processes":[{"id":"c7220000-0000-4000-8000-000000000020","version":"01.00.000"}],"lciaMethods":[{"id":"c7220000-0000-4000-8000-000000000021","version":"01.00.000"}]}'::jsonb,
   'closure-e2e-new-scanner','{}'
-)->>'ok','true','cutoff-readiness scanner request fixture is accepted');
+)->>'ok','true','lineage-aware scanner request fixture is accepted');
 select ok((
   select old_scan.scan_execution_id <> new_scan.scan_execution_id
      and old_scan.request_fingerprint <> new_scan.request_fingerprint
-     and old_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1'
-     and new_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r1'
+     and old_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r1'
+     and new_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r2'
   from private.lcia_scope_closure_checks old_scan
   join private.lcia_scope_closure_checks new_scan on true
   where old_scan.request_idempotency_token='closure-e2e-old-scanner'

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260814090000'::text,
+  '20260817090000'::text,
   'service-only schema readback reports the exact migration head'
 );
 


### PR DESCRIPTION
## Summary

- advance the internal Scope Closure scanner fingerprint from cutoff-readiness-r1 to cutoff-readiness-r2
- force new requests onto a fresh request fingerprint and scan execution after the Worker lineage semantic fix
- retain historical request rows and public V1 contracts unchanged
- extend the release-binding regression to prove r1 and r2 cannot share completed scan evidence

## Validation

- supabase db reset
- four Scope Closure pgTAP files: 214 assertions passed
- supabase migration list
- supabase db lint --level warning (existing repository-wide findings only; no finding points to this migration)
- Docpact strict config validation and enforced lint

## Rollout

Apply only after the matching Worker PR is deployed, because new r2 requests require a Worker that accepts r2. Persistent dev, production main, and root workspace integration proof remain post-merge gates.

Closes tiangong-lca/database-engine#495

Parent: tiangong-lca/workspace#589
Follow-up coupling redesign: tiangong-lca/workspace#590