### PR TITLE
fix: allow approved ownerless review references

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-08-14"
-lastReviewedCommit: "33b0bdcab65ef3ca5a712ac771774d5e22826378"
+lastReviewedAt: "2026-08-17"
+lastReviewedCommit: "8c81e3fa501d708fd0bee999debbab2408c91a3c"
 lastReviewedNote: "Reviewed after restoring the generated workspace with the CI-authoritative public, api, private, util, and archive schema set; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
 lastReviewedNote: "Reviewed after restoring the CI-authoritative five-schema generated workspace; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -27,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
 lastReviewedNote: "Reviewed after restoring the generated workspace with the complete CI schema set; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
 lastReviewedNote: "Reviewed after reproducing CI generation with public, api, private, util, and archive; deterministic rebuild and generated-artifact verification remain the required proof."
 related:
   - ../../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
 lastReviewedNote: "Reviewed after an exact CI-equivalent five-schema workspace rebuild; the script catalog and invocation contract remain unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
 lastReviewedNote: "已按 CI 的五 schema 参数完成等价重建复核；脚本目录及调用契约无需改变。"
 related:
   - ../AGENTS.md

--- a/supabase/migrations/20260817090000_allow_approved_ownerless_review_references.sql
+++ b/supabase/migrations/20260817090000_allow_approved_ownerless_review_references.sql
@@ -1,0 +1,829 @@
+CREATE OR REPLACE FUNCTION "private"."review_get_or_create_reference_v1"("p_target_table" "text", "p_target_row" "jsonb", "p_checksum" "text", "p_actor" "uuid") RETURNS "private"."reviews"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare
+  v_reference private.reviews%rowtype;
+  v_owner_id uuid := nullif(p_target_row->>'user_id', '')::uuid;
+  v_team_id uuid := nullif(p_target_row->>'team_id', '')::uuid;
+  v_state integer := coalesce((p_target_row->>'state_code')::integer, 0);
+begin
+  if v_owner_id is null and v_state < 100 then
+    raise exception using
+      errcode = '23502',
+      message = 'REFERENCE_OWNER_UNRESOLVED';
+  end if;
+
+
+  select reference_row.*
+  into v_reference
+  from private.reviews as reference_row
+  where reference_row.review_kind = 'reference'
+    and reference_row.target_table = p_target_table
+    and reference_row.data_id = (p_target_row->>'id')::uuid
+    and btrim(reference_row.data_version::text) = p_target_row->>'version'
+    and reference_row.submitted_revision_checksum = p_checksum
+    and reference_row.state_code in (0, 1, 2)
+  order by reference_row.state_code desc, reference_row.created_at
+  limit 1
+  for update;
+
+  if found then
+    return v_reference;
+  end if;
+
+  begin
+    insert into private.reviews (
+      id,
+      data_id,
+      data_version,
+      state_code,
+      reviewer_id,
+      json,
+      review_kind,
+      target_table,
+      submitted_revision_checksum,
+      approved_revision_checksum,
+      target_owner_id,
+      target_team_id
+    )
+    values (
+      gen_random_uuid(),
+      (p_target_row->>'id')::uuid,
+      p_target_row->>'version',
+      case when v_state >= 100 then 2 else 0 end,
+      '[]'::jsonb,
+      private.review_build_json_v1(
+        p_target_table,
+        p_target_row,
+        v_owner_id,
+        'submit_reference_review',
+        p_actor
+      ),
+      'reference',
+      p_target_table,
+      p_checksum,
+      case when v_state >= 100 then p_checksum else null end,
+      v_owner_id,
+      v_team_id
+    )
+    returning * into v_reference;
+  exception
+    when unique_violation then
+      select reference_row.*
+      into strict v_reference
+      from private.reviews as reference_row
+      where reference_row.review_kind = 'reference'
+        and reference_row.target_table = p_target_table
+        and reference_row.data_id = (p_target_row->>'id')::uuid
+        and btrim(reference_row.data_version::text) = p_target_row->>'version'
+        and reference_row.submitted_revision_checksum = p_checksum
+        and reference_row.state_code in (0, 1, 2)
+      order by reference_row.state_code desc, reference_row.created_at
+      limit 1
+      for update;
+  end;
+
+  return v_reference;
+end;
+$$;
+
+ALTER FUNCTION "private"."review_get_or_create_reference_v1"("p_target_table" "text", "p_target_row" "jsonb", "p_checksum" "text", "p_actor" "uuid") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "private"."review_get_or_create_reference_v1"("p_target_table" "text", "p_target_row" "jsonb", "p_checksum" "text", "p_actor" "uuid") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "private"."review_get_or_create_reference_v1"("p_target_table" "text", "p_target_row" "jsonb", "p_checksum" "text", "p_actor" "uuid") TO "api_internal_executor";
+
+CREATE OR REPLACE FUNCTION "api"."cmd_review_submit"("p_target_table" "text", "p_target_id" "uuid", "p_target_version" "text", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    AS $_$
+declare
+  v_actor uuid := auth.uid();
+  v_table text := lower(coalesce(p_target_table, ''));
+  v_root_row jsonb;
+  v_checksum text;
+  v_root_review_id uuid := gen_random_uuid();
+  v_root_review private.reviews%rowtype;
+  v_reference private.reviews%rowtype;
+  v_target record;
+  v_target_checksum text;
+  v_affected jsonb := '[]'::jsonb;
+  v_conflict_version text;
+  v_event_key text;
+begin
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401,
+      'message', 'Authentication required'
+    );
+  end if;
+
+  if v_table not in (
+    'contacts',
+    'sources',
+    'unitgroups',
+    'flowproperties',
+    'flows',
+    'processes',
+    'lifecyclemodels'
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_DATASET_TABLE',
+      'status', 400,
+      'message', 'Unsupported dataset table for review submission'
+    );
+  end if;
+
+  v_root_row := api.cmd_review_get_dataset_row(
+    v_table,
+    p_target_id,
+    p_target_version,
+    true
+  );
+
+  if v_root_row is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  if nullif(v_root_row->>'user_id', '')::uuid is distinct from v_actor then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'ROOT_DATASET_NOT_OWNED',
+      'status', 403,
+      'message', 'Only the dataset owner can submit review'
+    );
+  end if;
+
+  if coalesce((v_root_row->>'state_code')::integer, 0) <> 0 then
+    return jsonb_build_object(
+      'ok', false,
+      'code', case
+        when coalesce((v_root_row->>'state_code')::integer, 0) = 100
+          then 'APPROVED_DATASET_IMMUTABLE'
+        else 'DATA_UNDER_REVIEW'
+      end,
+      'status', 409,
+      'message', 'Only a Draft dataset can be submitted'
+    );
+  end if;
+
+  v_checksum := private.review_revision_fingerprint_v1(v_table, v_root_row);
+
+  if exists (
+    select 1
+    from private.review_candidate_root_ids_v1(
+      v_table,
+      p_target_id,
+      p_target_version
+    ) as candidate
+    where private.review_root_currently_references_target_v1(
+      candidate.root_review_id,
+      v_table,
+      p_target_id,
+      p_target_version
+    )
+  ) then
+    v_reference := private.review_get_or_create_reference_v1(
+      v_table,
+      v_root_row,
+      v_checksum,
+      v_actor
+    );
+
+    perform set_config('app.review_controlled_write', 'on', true);
+    execute format(
+      'update public.%I
+          set state_code = 20,
+              modified_at = now()
+        where id = $1
+          and version = $2
+          and state_code = 0',
+      v_table
+    ) using p_target_id, p_target_version;
+    perform set_config('app.review_controlled_write', 'off', true);
+
+    insert into private.command_audit_log (
+      command, actor_user_id, target_table, target_id, target_version, payload
+    ) values (
+      'cmd_review_submit', v_actor, v_table, p_target_id, p_target_version,
+      coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+        'review_id', v_reference.id,
+        'review_kind', 'reference',
+        'submission_mode', 'reference_repair'
+      )
+    );
+
+    return jsonb_build_object(
+      'ok', true,
+      'data', jsonb_build_object(
+        'reviewId', v_reference.id,
+        'reviewKind', 'reference',
+        'submissionMode', 'reference_repair'
+      )
+    );
+  end if;
+
+  if exists (
+    select 1
+    from private.reviews as active_root
+    where active_root.review_kind = 'root'
+      and active_root.target_table = v_table
+      and active_root.data_id = p_target_id
+      and btrim(active_root.data_version::text) = p_target_version
+      and active_root.state_code in (0, 1)
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATA_UNDER_REVIEW',
+      'status', 409,
+      'message', 'An active Root Review already exists'
+    );
+  end if;
+
+  create temporary table if not exists review_submit_targets (
+    table_name text not null,
+    dataset_id uuid not null,
+    dataset_version text not null,
+    state_code integer not null,
+    reviews jsonb,
+    dataset_row jsonb not null,
+    is_root boolean not null default false,
+    primary key (table_name, dataset_id, dataset_version)
+  ) on commit drop;
+  truncate table review_submit_targets;
+
+  insert into review_submit_targets
+  select *
+  from api.cmd_review_collect_dataset_targets(
+    jsonb_build_array(jsonb_build_object(
+      'table', v_table,
+      'id', p_target_id,
+      'version', p_target_version,
+      'is_root', true
+    )),
+    true
+  );
+
+  if not exists (
+    select 1
+    from review_submit_targets
+    where is_root
+      and table_name = v_table
+      and dataset_id = p_target_id
+      and dataset_version = p_target_version
+  ) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'DATASET_NOT_FOUND',
+      'status', 404,
+      'message', 'Dataset not found'
+    );
+  end if;
+
+  for v_target in
+    select *
+    from review_submit_targets
+    order by is_root desc, table_name, dataset_id, dataset_version
+  loop
+    if nullif(v_target.dataset_row->>'user_id', '') is null
+      and (v_target.is_root or v_target.state_code < 100) then
+      return jsonb_build_object(
+        'ok', false,
+        'code', case when v_target.is_root
+          then 'ROOT_OWNER_UNRESOLVED'
+          else 'REFERENCE_OWNER_UNRESOLVED'
+        end,
+        'status', 409,
+        'message', 'Dataset owner could not be resolved'
+      );
+    end if;
+
+    if not v_target.is_root
+      and nullif(v_target.dataset_row->>'user_id', '')::uuid <> v_actor
+      and not private.review_dataset_can_read_v1(
+        v_actor,
+        v_target.table_name,
+        v_target.dataset_row
+      ) then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'REFERENCE_ACCESS_DENIED',
+        'status', 403,
+        'message', 'A referenced dataset is not accessible'
+      );
+    end if;
+
+    select btrim(active_reference.data_version::text)
+    into v_conflict_version
+    from private.reviews as active_reference
+    where active_reference.review_kind = 'reference'
+      and active_reference.target_table = v_target.table_name
+      and active_reference.data_id = v_target.dataset_id
+      and btrim(active_reference.data_version::text)
+        <> v_target.dataset_version
+      and active_reference.state_code in (0, 1)
+    order by active_reference.created_at desc
+    limit 1;
+
+    if v_conflict_version is not null then
+      return jsonb_build_object(
+        'ok', false,
+        'code', 'REFERENCE_REVISION_CONFLICT',
+        'status', 409,
+        'message', 'Another version of a referenced dataset is under review'
+      );
+    end if;
+
+    v_target_checksum := private.review_revision_fingerprint_v1(
+      v_target.table_name,
+      v_target.dataset_row
+    );
+
+    if not v_target.is_root then
+      v_reference := private.review_get_or_create_reference_v1(
+        v_target.table_name,
+        v_target.dataset_row,
+        v_target_checksum,
+        v_actor
+      );
+    end if;
+  end loop;
+
+  insert into private.reviews (
+    id,
+    data_id,
+    data_version,
+    state_code,
+    reviewer_id,
+    json,
+    review_kind,
+    target_table,
+    submitted_revision_checksum,
+    target_owner_id,
+    target_team_id
+  )
+  values (
+    v_root_review_id,
+    p_target_id,
+    p_target_version,
+    0,
+    '[]'::jsonb,
+    private.review_build_json_v1(
+      v_table,
+      v_root_row,
+      v_actor,
+      'submit_review',
+      v_actor
+    ),
+    'root',
+    v_table,
+    v_checksum,
+    v_actor,
+    nullif(v_root_row->>'team_id', '')::uuid
+  )
+  returning * into v_root_review;
+
+  perform set_config('app.review_controlled_write', 'on', true);
+  for v_target in
+    select *
+    from review_submit_targets
+    order by is_root desc, table_name, dataset_id, dataset_version
+  loop
+    execute format(
+      'update public.%I
+          set state_code = case when state_code < 20 then 20 else state_code end,
+              reviews = case
+                when state_code < 100
+                  then api.cmd_review_append_review_ref(reviews, $1)
+                else reviews
+              end,
+              modified_at = now()
+        where id = $2
+          and version = $3',
+      v_target.table_name
+    ) using v_root_review_id, v_target.dataset_id, v_target.dataset_version;
+
+    if not v_target.is_root
+      and v_target.state_code < 20
+      and nullif(v_target.dataset_row->>'user_id', '')::uuid <> v_actor then
+      v_event_key := private.review_notify_event_v1(
+        'reference_entered_review',
+        (
+          select reference_review.id
+          from private.reviews as reference_review
+          where reference_review.review_kind = 'reference'
+            and reference_review.target_table = v_target.table_name
+            and reference_review.data_id = v_target.dataset_id
+            and btrim(reference_review.data_version::text) = v_target.dataset_version
+            and reference_review.submitted_revision_checksum =
+              private.review_revision_fingerprint_v1(
+                v_target.table_name,
+                v_target.dataset_row
+              )
+            and reference_review.state_code in (-1, 0, 1, 2)
+          order by case when reference_review.state_code in (0, 1, 2) then 0 else 1 end,
+                   reference_review.modified_at desc,
+                   reference_review.id
+          limit 1
+        ),
+        nullif(v_target.dataset_row->>'user_id', '')::uuid,
+        v_actor,
+        v_target.table_name,
+        v_target.dataset_id,
+        v_target.dataset_version,
+        null,
+        null,
+        null
+      );
+    end if;
+
+    v_affected := v_affected || jsonb_build_array(jsonb_build_object(
+      'table', v_target.table_name,
+      'id', v_target.dataset_id,
+      'version', v_target.dataset_version,
+      'previous_state_code', v_target.state_code,
+      'state_code', case
+        when v_target.state_code < 20 then 20
+        else v_target.state_code
+      end
+    ));
+  end loop;
+  perform set_config('app.review_controlled_write', 'off', true);
+
+  insert into private.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    target_version,
+    payload
+  )
+  values (
+    'cmd_review_submit',
+    v_actor,
+    v_table,
+    p_target_id,
+    p_target_version,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'review_id', v_root_review_id,
+      'review_kind', 'root',
+      'submission_mode', 'root',
+      'affected_datasets', v_affected
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'reviewId', v_root_review_id,
+      'reviewKind', 'root',
+      'submissionMode', 'root',
+      'review', to_jsonb(v_root_review),
+      'affectedDatasets', v_affected
+    )
+  );
+exception
+  when others then
+    perform set_config('app.review_controlled_write', 'off', true);
+    if sqlerrm = 'REFERENCE_OWNER_UNRESOLVED' then
+      return jsonb_build_object(
+        'ok', false,
+        'code', sqlerrm,
+        'status', 409,
+        'message', 'Review submission could not be completed'
+      );
+    end if;
+    raise;
+end;
+$_$;
+
+ALTER FUNCTION "api"."cmd_review_submit"("p_target_table" "text", "p_target_id" "uuid", "p_target_version" "text", "p_audit" "jsonb") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."cmd_review_submit"("p_target_table" "text", "p_target_id" "uuid", "p_target_version" "text", "p_audit" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit"("p_target_table" "text", "p_target_id" "uuid", "p_target_version" "text", "p_audit" "jsonb") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit"("p_target_table" "text", "p_target_id" "uuid", "p_target_version" "text", "p_audit" "jsonb") TO "authenticated";
+
+CREATE OR REPLACE FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "sql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+  select api.cmd_review_submit_comment(
+    p_review_id,
+    p_json,
+    1,
+    p_audit
+  )
+$$;
+
+ALTER FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb") OWNER TO "postgres";
+
+CREATE OR REPLACE FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer DEFAULT 1, "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $_$
+declare
+  v_actor uuid := auth.uid();
+  v_review private.reviews%rowtype;
+  v_comment private.comments%rowtype;
+  v_ref record;
+  v_target record;
+  v_reference private.reviews%rowtype;
+  v_ref_roots jsonb := '[]'::jsonb;
+  v_checksum text;
+  v_affected jsonb := '[]'::jsonb;
+  v_reason text;
+begin
+  select review_row.*
+  into v_review
+  from private.reviews as review_row
+  where review_row.id = p_review_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_NOT_FOUND',
+      'status', 404
+    );
+  end if;
+
+  if v_review.review_kind is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'LEGACY_REVIEW_READ_ONLY',
+      'status', 409
+    );
+  end if;
+
+  if v_review.review_kind = 'reference'
+    or v_review.target_table in (
+      'contacts',
+      'sources',
+      'unitgroups',
+      'flowproperties',
+      'flows'
+    ) then
+    v_reason := coalesce(
+      p_json->'comment'->>'message',
+      p_json->>'reason'
+    );
+    return api.cmd_simple_review_submit_decision(
+      p_review_id,
+      case when p_comment_state = 1 then 'approve' else 'reject' end,
+      case when p_comment_state = -3 then v_reason else null end,
+      p_audit
+    );
+  end if;
+
+  if v_actor is null then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'AUTH_REQUIRED',
+      'status', 401
+    );
+  end if;
+
+  if v_review.review_kind <> 'root'
+    or v_review.target_table not in ('processes', 'lifecyclemodels') then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEW_METADATA_NOT_APPLICABLE',
+      'status', 400
+    );
+  end if;
+
+  if v_review.state_code <> 1
+    or p_comment_state not in (-3, 1)
+    or not coalesce(v_review.reviewer_id, '[]'::jsonb)
+      @> jsonb_build_array(v_actor::text) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'REVIEWER_REQUIRED',
+      'status', 403
+    );
+  end if;
+
+  select comment_row.*
+  into v_comment
+  from private.comments as comment_row
+  where comment_row.review_id = p_review_id
+    and comment_row.reviewer_id = v_actor
+  for update;
+
+  if found and v_comment.state_code in (-2, 2) then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'INVALID_COMMENT_STATE',
+      'status', 409
+    );
+  end if;
+
+  if p_comment_state = 1 then
+    for v_ref in
+      select *
+      from api.cmd_review_extract_refs(coalesce(p_json, '{}'::jsonb))
+    loop
+      if api.cmd_review_ref_type_to_table(v_ref.ref_type) is not null then
+        v_ref_roots := v_ref_roots || jsonb_build_array(jsonb_build_object(
+          'table', api.cmd_review_ref_type_to_table(v_ref.ref_type),
+          'id', v_ref.ref_object_id,
+          'version', v_ref.ref_version,
+          'is_root', false
+        ));
+      end if;
+    end loop;
+
+    create temporary table if not exists review_comment_v2_targets (
+      table_name text not null,
+      dataset_id uuid not null,
+      dataset_version text not null,
+      state_code integer not null,
+      reviews jsonb,
+      dataset_row jsonb not null,
+      is_root boolean not null default false,
+      primary key (table_name, dataset_id, dataset_version)
+    ) on commit drop;
+    truncate table review_comment_v2_targets;
+
+    insert into review_comment_v2_targets
+    select *
+    from api.cmd_review_collect_dataset_targets(v_ref_roots, true);
+
+    for v_target in
+      select *
+      from review_comment_v2_targets
+      order by table_name, dataset_id, dataset_version
+    loop
+      if nullif(v_target.dataset_row->>'user_id', '') is null
+        and v_target.state_code < 100 then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'REFERENCE_OWNER_UNRESOLVED',
+          'status', 409
+        );
+      end if;
+
+      if nullif(v_target.dataset_row->>'user_id', '')::uuid <> v_actor
+        and not private.review_dataset_can_read_v1(
+          v_actor,
+          v_target.table_name,
+          v_target.dataset_row
+        ) then
+        return jsonb_build_object(
+          'ok', false,
+          'code', 'REFERENCE_ACCESS_DENIED',
+          'status', 403
+        );
+      end if;
+
+      v_checksum := private.review_revision_fingerprint_v1(
+        v_target.table_name,
+        v_target.dataset_row
+      );
+      v_reference := private.review_get_or_create_reference_v1(
+        v_target.table_name,
+        v_target.dataset_row,
+        v_checksum,
+        v_actor
+      );
+
+      perform set_config('app.review_controlled_write', 'on', true);
+      execute format(
+        'update public.%I
+            set state_code = case when state_code < 20 then 20 else state_code end,
+                reviews = case when state_code < 100
+                  then api.cmd_review_append_review_ref(reviews, $1)
+                  else reviews
+                end,
+                modified_at = now()
+          where id = $2
+            and version = $3',
+        v_target.table_name
+      ) using p_review_id, v_target.dataset_id, v_target.dataset_version;
+      perform set_config('app.review_controlled_write', 'off', true);
+
+      if v_target.state_code < 20
+        and nullif(v_target.dataset_row->>'user_id', '')::uuid <> v_actor then
+        perform private.review_notify_event_v1(
+          'reference_entered_review',
+          v_reference.id,
+          nullif(v_target.dataset_row->>'user_id', '')::uuid,
+          v_actor,
+          v_target.table_name,
+          v_target.dataset_id,
+          v_target.dataset_version,
+          null,
+          null,
+          null
+        );
+      end if;
+
+      v_affected := v_affected || jsonb_build_array(jsonb_build_object(
+        'table', v_target.table_name,
+        'id', v_target.dataset_id,
+        'version', v_target.dataset_version,
+        'reference_review_id', v_reference.id
+      ));
+    end loop;
+
+  end if;
+
+  insert into private.comments (
+    review_id,
+    reviewer_id,
+    json,
+    state_code
+  )
+  values (
+    p_review_id,
+    v_actor,
+    coalesce(p_json, '{}'::jsonb)::json,
+    p_comment_state
+  )
+  on conflict (review_id, reviewer_id) do update
+  set json = excluded.json,
+      state_code = excluded.state_code,
+      modified_at = now()
+  returning * into v_comment;
+
+  update private.reviews
+  set json = api.cmd_review_append_log(
+        coalesce(json, '{}'::jsonb),
+        case when p_comment_state = 1
+          then 'submit_comments'
+          else 'reviewer_rejected'
+        end,
+        v_actor,
+        jsonb_build_object(
+          'reviewer_id', v_actor,
+          'comment_state_code', p_comment_state
+        )
+      ),
+      modified_at = now()
+  where id = p_review_id
+  returning * into v_review;
+
+  insert into private.command_audit_log (
+    command,
+    actor_user_id,
+    target_table,
+    target_id,
+    payload
+  )
+  values (
+    'cmd_review_submit_comment',
+    v_actor,
+    'reviews',
+    p_review_id,
+    coalesce(p_audit, '{}'::jsonb) || jsonb_build_object(
+      'reviewer_id', v_actor,
+      'comment_state_code', p_comment_state,
+      'affected_datasets', (
+        select coalesce(
+          jsonb_agg(affected.value - 'reference_review_id'),
+          '[]'::jsonb
+        )
+        from jsonb_array_elements(v_affected) as affected(value)
+      )
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'review', to_jsonb(v_review),
+      'comment', to_jsonb(v_comment),
+      'affected_datasets', v_affected
+    )
+  );
+exception
+  when others then
+    perform set_config('app.review_controlled_write', 'off', true);
+    raise;
+end;
+$_$;
+
+ALTER FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer, "p_audit" "jsonb") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_audit" "jsonb") TO "authenticated";
+
+REVOKE ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer, "p_audit" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer, "p_audit" "jsonb") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."cmd_review_submit_comment"("p_review_id" "uuid", "p_json" "jsonb", "p_comment_state" integer, "p_audit" "jsonb") TO "authenticated";

--- a/supabase/migrations/20260817100000_allow_approved_ownerless_review_references.sql
+++ b/supabase/migrations/20260817100000_allow_approved_ownerless_review_references.sql
@@ -1,3 +1,4 @@
+-- Allow approved references without an owner while preserving owner checks for mutable data.
 CREATE OR REPLACE FUNCTION "private"."review_get_or_create_reference_v1"("p_target_table" "text", "p_target_row" "jsonb", "p_checksum" "text", "p_actor" "uuid") RETURNS "private"."reviews"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO ''

--- a/supabase/tests/20260404_review_submit_rpc.sql
+++ b/supabase/tests/20260404_review_submit_rpc.sql
@@ -20,7 +20,7 @@ begin
 end;
 $$;
 
-select plan(15);
+select plan(20);
 
 select set_config('request.jwt.claim.role', 'authenticated', true);
 
@@ -271,7 +271,7 @@ values (
       }
     }
   }'::json,
-  '12000000-0000-0000-0000-000000000001',
+  null,
   100,
   '22000000-0000-0000-0000-000000000001',
   true
@@ -646,6 +646,25 @@ select is(
   'cmd_review_submit leaves already published references unchanged'
 );
 
+reset role;
+
+select ok(
+  exists (
+    select 1
+    from private.reviews
+    where review_kind = 'reference'
+      and target_table = 'sources'
+      and data_id = '32000000-0000-0000-0000-000000000002'
+      and btrim(data_version::text) = '01.00.000'
+      and state_code = 2
+      and target_owner_id is null
+  ),
+  'cmd_review_submit auto-approves an ownerless published reference'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000001', true);
+
 select is(
   (select count(*)::text
    from private.reviews
@@ -909,6 +928,105 @@ select is(
      and version = '01.00.000'),
   '20',
   'review submission preserves the referenced dataset under-review state'
+);
+
+reset role;
+
+insert into public.flowproperties (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  reviews
+)
+values (
+  '32000000-0000-4000-8000-000000000031',
+  '01.00.000',
+  '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Ownerless draft property"}]}}}}'::jsonb,
+  '{"flowPropertyDataSet":{"flowPropertiesInformation":{"dataSetInformation":{"common:name":[{"@xml:lang":"en","#text":"Ownerless draft property"}]}}}}'::json,
+  null,
+  0,
+  null,
+  true,
+  '[]'::jsonb
+);
+
+insert into public.flows (
+  id,
+  version,
+  json,
+  json_ordered,
+  user_id,
+  state_code,
+  team_id,
+  rule_verification,
+  reviews
+)
+values (
+  '32000000-0000-4000-8000-000000000030',
+  '01.00.000',
+  '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Ownerless draft reference root"}]}}},"flowProperties":{"flowProperty":[{"referenceToFlowPropertyDataSet":{"@type":"flow property data set","@refObjectId":"32000000-0000-4000-8000-000000000031","@version":"01.00.000"}}]}}}'::jsonb,
+  '{"flowDataSet":{"flowInformation":{"dataSetInformation":{"name":{"baseName":[{"@xml:lang":"en","#text":"Ownerless draft reference root"}]}}},"flowProperties":{"flowProperty":[{"referenceToFlowPropertyDataSet":{"@type":"flow property data set","@refObjectId":"32000000-0000-4000-8000-000000000031","@version":"01.00.000"}}]}}}'::json,
+  '12000000-0000-0000-0000-000000000001',
+  0,
+  null,
+  true,
+  '[]'::jsonb
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '12000000-0000-0000-0000-000000000001', true);
+
+select is(
+  api.cmd_review_submit(
+    'flows',
+    '32000000-0000-4000-8000-000000000030',
+    '01.00.000',
+    '{}'::jsonb
+  )->>'code',
+  'REFERENCE_OWNER_UNRESOLVED',
+  'draft references still require a resolvable owner'
+);
+
+reset role;
+
+select is(
+  (
+    select state_code
+    from public.flows
+    where id = '32000000-0000-4000-8000-000000000030'
+      and version = '01.00.000'
+  ),
+  0,
+  'ownerless draft reference rejection leaves the root draft unchanged'
+);
+
+select is(
+  (
+    select state_code
+    from public.flowproperties
+    where id = '32000000-0000-4000-8000-000000000031'
+      and version = '01.00.000'
+  ),
+  0,
+  'ownerless draft reference rejection leaves the reference draft unchanged'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from private.reviews
+    where data_id in (
+      '32000000-0000-4000-8000-000000000030',
+      '32000000-0000-4000-8000-000000000031'
+    )
+  ),
+  0,
+  'ownerless draft reference rejection creates no partial review rows'
 );
 
 select * from finish();

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260817090000'::text,
+  '20260817100000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260814090000'::text,
+  '20260817090000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260809_review_metadata_scope_basis.sql
+++ b/supabase/tests/20260809_review_metadata_scope_basis.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(21);
+select plan(22);
 
 create or replace function pg_temp.disable_trigger_if_exists(
   p_table regclass,
@@ -125,7 +125,7 @@ values (
   '01.01.000',
   '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"zh","#text":"审核员-来源"}]}}}}'::jsonb,
   '{"sourceDataSet":{"sourceInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"zh","#text":"审核员-来源"}]}}}}'::json,
-  '19800000-0000-0000-0000-000000000001',
+  null,
   100,
   null,
   true,
@@ -158,7 +158,7 @@ values (
   '01.01.000',
   '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"zh","#text":"审核员-联系人"}]}}}}'::jsonb,
   '{"contactDataSet":{"contactInformation":{"dataSetInformation":{"common:shortName":[{"@xml:lang":"zh","#text":"审核员-联系人"}]}}}}'::json,
-  '19800000-0000-0000-0000-000000000001',
+  null,
   100,
   null,
   true,
@@ -474,6 +474,22 @@ select is(
   ),
   2,
   'Source and Contact each receive a reusable Reference Review'
+);
+
+select is(
+  (
+    select count(*)::integer
+    from private.reviews
+    where review_kind = 'reference'
+      and data_id in (
+        '39800000-0000-0000-0000-000000000001',
+        '39800000-0000-0000-0000-000000000002'
+      )
+      and state_code = 2
+      and target_owner_id is null
+  ),
+  2,
+  'approved ownerless metadata references are represented by approved Reference Reviews'
 );
 
 select is(

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
 lastReviewedNote: "Restored and reviewed the exact-local workspace for the CI-authoritative public, api, private, util, and archive schemas; deterministic generation behavior is unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -20,8 +20,8 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-08-14
-lastReviewedCommit: 33b0bdcab65ef3ca5a712ac771774d5e22826378
+lastReviewedAt: 2026-08-17
+lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
 lastReviewedNote: "已恢复并复核 CI 权威的 public、api、private、util、archive 五 schema exact-local workspace；确定性生成行为不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -13491,7 +13491,8 @@ begin
     from review_submit_targets
     order by is_root desc, table_name, dataset_id, dataset_version
   loop
-    if nullif(v_target.dataset_row->>'user_id', '') is null then
+    if nullif(v_target.dataset_row->>'user_id', '') is null
+      and (v_target.is_root or v_target.state_code < 100) then
       return jsonb_build_object(
         'ok', false,
         'code', case when v_target.is_root
@@ -13863,7 +13864,8 @@ begin
       from review_comment_v2_targets
       order by table_name, dataset_id, dataset_version
     loop
-      if nullif(v_target.dataset_row->>'user_id', '') is null then
+      if nullif(v_target.dataset_row->>'user_id', '') is null
+        and v_target.state_code < 100 then
         return jsonb_build_object(
           'ok', false,
           'code', 'REFERENCE_OWNER_UNRESOLVED',
@@ -40010,7 +40012,7 @@ declare
   v_team_id uuid := nullif(p_target_row->>'team_id', '')::uuid;
   v_state integer := coalesce((p_target_row->>'state_code')::integer, 0);
 begin
-  if v_owner_id is null then
+  if v_owner_id is null and v_state < 100 then
     raise exception using
       errcode = '23502',
       message = 'REFERENCE_OWNER_UNRESOLVED';

--- a/supabase/workspace/schemas/api/functions/cmd_review_submit/definition.sql
+++ b/supabase/workspace/schemas/api/functions/cmd_review_submit/definition.sql
@@ -198,7 +198,8 @@ begin
     from review_submit_targets
     order by is_root desc, table_name, dataset_id, dataset_version
   loop
-    if nullif(v_target.dataset_row->>'user_id', '') is null then
+    if nullif(v_target.dataset_row->>'user_id', '') is null
+      and (v_target.is_root or v_target.state_code < 100) then
       return jsonb_build_object(
         'ok', false,
         'code', case when v_target.is_root

--- a/supabase/workspace/schemas/api/functions/cmd_review_submit_comment/definition.sql
+++ b/supabase/workspace/schemas/api/functions/cmd_review_submit_comment/definition.sql
@@ -149,7 +149,8 @@ begin
       from review_comment_v2_targets
       order by table_name, dataset_id, dataset_version
     loop
-      if nullif(v_target.dataset_row->>'user_id', '') is null then
+      if nullif(v_target.dataset_row->>'user_id', '') is null
+        and v_target.state_code < 100 then
         return jsonb_build_object(
           'ok', false,
           'code', 'REFERENCE_OWNER_UNRESOLVED',

--- a/supabase/workspace/schemas/private/functions/review_get_or_create_reference_v1/definition.sql
+++ b/supabase/workspace/schemas/private/functions/review_get_or_create_reference_v1/definition.sql
@@ -8,7 +8,7 @@ declare
   v_team_id uuid := nullif(p_target_row->>'team_id', '')::uuid;
   v_state integer := coalesce((p_target_row->>'state_code')::integer, 0);
 begin
-  if v_owner_id is null then
+  if v_owner_id is null and v_state < 100 then
     raise exception using
       errcode = '23502',
       message = 'REFERENCE_OWNER_UNRESOLVED';


### PR DESCRIPTION
Closes tiangong-lca/database-engine#496

## Summary
- Allow collected non-root references with state_code >= 100 to participate in review submission when user_id is null.
- Preserve owner requirements for root datasets and references with state_code < 100.
- Refresh generated workspace artifacts and add regression coverage for root and comment-derived reference collection.

## Key Decisions
- Approved ownerless references receive an automatically approved reference review with target_owner_id null.
- The exception is applied consistently in cmd_review_submit, cmd_review_submit_comment, and private.review_get_or_create_reference_v1.

## Validation
- npx --yes supabase@2.98.0 db reset --no-seed
- 216 targeted and related pgTAP assertions passed.
- npx --yes supabase@2.98.0 db lint --level warning exited 0; output contains existing analyzer warnings.
- Docpact validate-config --strict and Docpact lint passed.

## Risks / Rollback
- Rollback by reverting migration 20260817090000 and its generated artifacts; draft and root owner enforcement remains covered by tests.

## Follow-ups
- Promote database-engine dev to main through the repository release flow before root-workspace integration.

## Workspace Integration
- Workspace Integration remains Pending until the release-semantic database-engine commit reaches main and the root submodule pointer is updated separately.