### PR TITLE
Promote Scope Closure scanner r3 to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "667d627f6ce3741ef0a1573062bfaeb45f8154b4"
+lastReviewedCommit: "801a9f2c16376e20884c5269069f0847a273ab0b"
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "8c81e3fa501d708fd0bee999debbab2408c91a3c"
+lastReviewedCommit: "667d627f6ce3741ef0a1573062bfaeb45f8154b4"
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
+lastReviewedCommit: 667d627f6ce3741ef0a1573062bfaeb45f8154b4
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 667d627f6ce3741ef0a1573062bfaeb45f8154b4
+lastReviewedCommit: 801a9f2c16376e20884c5269069f0847a273ab0b
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
+lastReviewedCommit: 667d627f6ce3741ef0a1573062bfaeb45f8154b4
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md
@@ -273,7 +273,7 @@ Certificate-grade Scope Closure normalization canonicalizes omitted and supporte
 
 A passed reused Scope Closure certificate owns a new target report while retaining the direct source check's immutable numerical snapshot and Closure Bundle. Calculation admission, Worker binding, and package publication validate that single-hop source through `reused_from_check_id`; they never relabel or copy the source Bundle. The target and source must retain exact scope, policy, data-snapshot, numerical-snapshot, Bundle identity, and checksum parity. Independently, `worker_jobs.status = completed` implies canonical `progress = 1`; blocked and failed terminal states retain their actual partial progress.
 
-The current internal scanner cache identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r2`; changing it creates a distinct request fingerprint and scan execution without changing any public V1 DTO or artifact schema. The r2 revision separates exact-identity Process lineage traversal from numerical provider-universe enforcement. Historical requests retain their recorded revision for in-flight compatibility. A completed `blocked` scan has complete reusable administrative evidence but deliberately no numerical snapshot, even though its scan-execution row retains a preallocated `numerical_snapshot_id`. Reuse therefore compares that ID with the source check snapshot only for `passed` certificate evidence; all immutable scope, policy, data-snapshot, completion, and source-status fences still apply to both terminal outcomes.
+The current internal scanner cache identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r3`; changing it creates a distinct request fingerprint and scan execution without changing any public V1 DTO or artifact schema. The r2 revision separates exact-identity Process lineage traversal from numerical provider-universe enforcement; r3 additionally excludes Source `referenceToDigitalFile` attachment locators from dataset-reference scanning. Historical requests retain their recorded revision for in-flight compatibility. A completed `blocked` scan has complete reusable administrative evidence but deliberately no numerical snapshot, even though its scan-execution row retains a preallocated `numerical_snapshot_id`. Reuse therefore compares that ID with the source check snapshot only for `passed` certificate evidence; all immutable scope, policy, data-snapshot, completion, and source-status fences still apply to both terminal outcomes.
 
 ## Scope-Closure Evidence Retention
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 667d627f6ce3741ef0a1573062bfaeb45f8154b4
+lastReviewedCommit: 801a9f2c16376e20884c5269069f0847a273ab0b
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 667d627f6ce3741ef0a1573062bfaeb45f8154b4
+lastReviewedCommit: 801a9f2c16376e20884c5269069f0847a273ab0b
 lastReviewedNote: "Reviewed after validating the scope-closure scanner revision and approved ownerless-reference review handling; deterministic rebuild, generated-artifact verification, and pgTAP contracts remain the required proof."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
+lastReviewedCommit: 667d627f6ce3741ef0a1573062bfaeb45f8154b4
 lastReviewedNote: "Reviewed after validating the scope-closure scanner revision and approved ownerless-reference review handling; deterministic rebuild, generated-artifact verification, and pgTAP contracts remain the required proof."
 related:
   - ../../AGENTS.md

--- a/supabase/migrations/20260817140000_advance_scope_closure_digital_file_scanner_revision.sql
+++ b/supabase/migrations/20260817140000_advance_scope_closure_digital_file_scanner_revision.sql
@@ -1,0 +1,19 @@
+-- Advance the internal scanner cache identity after Worker scope-closure
+-- semantics stop treating Source digital-file locators as dataset references.
+-- Historical requests retain their recorded fingerprint and remain readable;
+-- new requests receive a distinct request and scan-execution identity.
+
+set lock_timeout = '5s';
+set statement_timeout = '120s';
+
+insert into private.lcia_scope_closure_config (
+  singleton,
+  expected_validator_scanner_fingerprint
+)
+values (
+  true,
+  'scope-closure-validator-scanner.v1+cutoff-readiness-r3'
+)
+on conflict (singleton) do update
+set expected_validator_scanner_fingerprint = excluded.expected_validator_scanner_fingerprint,
+    updated_at = statement_timestamp();

--- a/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
+++ b/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
@@ -8,8 +8,8 @@ select is(
   (select expected_validator_scanner_fingerprint
    from private.lcia_scope_closure_config
    where singleton),
-  'scope-closure-validator-scanner.v1+cutoff-readiness-r2',
-  'new closure requests use the lineage-aware scanner cache revision'
+  'scope-closure-validator-scanner.v1+cutoff-readiness-r3',
+  'new closure requests use the digital-file-aware scanner cache revision'
 );
 
 -- A minimal immutable current release.  The closure request must use this
@@ -265,7 +265,7 @@ select is((select status from private.lcia_scope_closure_scan_executions limit 1
 -- rollout may still have old requests in flight, but new requests must not
 -- select their completed evidence after the configured revision changes.
 update private.lcia_scope_closure_config
-set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r1',
+set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r2',
     updated_at=now()
 where singleton;
 select set_config('request.jwt.claim.role','authenticated',true);
@@ -274,18 +274,18 @@ select is(api.cmd_lcia_scope_closure_check_request_v2(
   'closure-e2e-old-scanner','{}'
 )->>'ok','true','previous scanner revision request fixture is accepted by the database command');
 update private.lcia_scope_closure_config
-set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r2',
+set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r3',
     updated_at=now()
 where singleton;
 select is(api.cmd_lcia_scope_closure_check_request_v2(
   '{"coverageMode":"subset","processes":[{"id":"c7220000-0000-4000-8000-000000000020","version":"01.00.000"}],"lciaMethods":[{"id":"c7220000-0000-4000-8000-000000000021","version":"01.00.000"}]}'::jsonb,
   'closure-e2e-new-scanner','{}'
-)->>'ok','true','lineage-aware scanner request fixture is accepted');
+)->>'ok','true','digital-file-aware scanner request fixture is accepted');
 select ok((
   select old_scan.scan_execution_id <> new_scan.scan_execution_id
      and old_scan.request_fingerprint <> new_scan.request_fingerprint
-     and old_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r1'
-     and new_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r2'
+     and old_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r2'
+     and new_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r3'
   from private.lcia_scope_closure_checks old_scan
   join private.lcia_scope_closure_checks new_scan on true
   where old_scan.request_idempotency_token='closure-e2e-old-scanner'

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260817100000'::text,
+  '20260817140000'::text,
   'service-only schema readback reports the exact migration head'
 );
 


### PR DESCRIPTION
## Summary

- Promote the Scope Closure scanner cache revision r3 from `dev` to `main`.
- Carry the exact Database Engine change already reviewed and merged in #502.
- Ensure new release-semantic requests cannot reuse r2 evidence after Worker digital-file traversal semantics change.

## Scope

The `main...dev` tree diff contains only the seven files delivered by #502: the r3 config migration, its Scope Closure/API contract assertions, and governed review metadata.

## Validation

- #502 clean local database rebuild passed.
- Four Scope Closure pgTAP suites passed: 214 assertions.
- API contract suite passed: 49 assertions.
- #502 GitHub rebuild/contract CI, Gitleaks, and Supabase Preview all passed.

## Rollout

- Worker support is already merged to `linancn/tiangong-lca-worker@main` in #262.
- After this promote merges, the Database Engine commit is eligible for root `main` integration.

Closes #501
