### PR TITLE
chore: advance Scope Closure scanner cache to r4

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "801a9f2c16376e20884c5269069f0847a273ab0b"
+lastReviewedCommit: "eefc003b41eee76d473b0746fb375106a3a18d0b"
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 801a9f2c16376e20884c5269069f0847a273ab0b
+lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 801a9f2c16376e20884c5269069f0847a273ab0b
+lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md
@@ -273,7 +273,7 @@ Certificate-grade Scope Closure normalization canonicalizes omitted and supporte
 
 A passed reused Scope Closure certificate owns a new target report while retaining the direct source check's immutable numerical snapshot and Closure Bundle. Calculation admission, Worker binding, and package publication validate that single-hop source through `reused_from_check_id`; they never relabel or copy the source Bundle. The target and source must retain exact scope, policy, data-snapshot, numerical-snapshot, Bundle identity, and checksum parity. Independently, `worker_jobs.status = completed` implies canonical `progress = 1`; blocked and failed terminal states retain their actual partial progress.
 
-The current internal scanner cache identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r3`; changing it creates a distinct request fingerprint and scan execution without changing any public V1 DTO or artifact schema. The r2 revision separates exact-identity Process lineage traversal from numerical provider-universe enforcement; r3 additionally excludes Source `referenceToDigitalFile` attachment locators from dataset-reference scanning. Historical requests retain their recorded revision for in-flight compatibility. A completed `blocked` scan has complete reusable administrative evidence but deliberately no numerical snapshot, even though its scan-execution row retains a preallocated `numerical_snapshot_id`. Reuse therefore compares that ID with the source check snapshot only for `passed` certificate evidence; all immutable scope, policy, data-snapshot, completion, and source-status fences still apply to both terminal outcomes.
+The current internal scanner cache identity is `scope-closure-validator-scanner.v1+cutoff-readiness-r4`; changing it creates a distinct request fingerprint and scan execution without changing any public V1 DTO or artifact schema. The r2 revision separates exact-identity Process lineage traversal from numerical provider-universe enforcement; r3 excludes Source `referenceToDigitalFile` attachment locators from dataset-reference scanning; r4 prevents reuse of an r3 completed blocked scan after Worker changes certificate-grade medium singular risk from blocker to warning. The database does not interpret readiness severity. Historical requests retain their recorded revision for in-flight compatibility. A completed `blocked` scan has complete reusable administrative evidence but deliberately no numerical snapshot, even though its scan-execution row retains a preallocated `numerical_snapshot_id`. Reuse therefore compares that ID with the source check snapshot only for `passed` certificate evidence; all immutable scope, policy, data-snapshot, completion, and source-status fences still apply to both terminal outcomes.
 
 ## Scope-Closure Evidence Retention
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 801a9f2c16376e20884c5269069f0847a273ab0b
+lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
 lastReviewedNote: "Reviewed after validating the scope-closure scanner revision and approved ownerless-reference review handling; deterministic rebuild, generated-artifact verification, and pgTAP contracts remain the required proof."
 related:
   - ../../AGENTS.md

--- a/supabase/migrations/20260817170000_advance_scope_closure_medium_singular_warning_scanner_revision.sql
+++ b/supabase/migrations/20260817170000_advance_scope_closure_medium_singular_warning_scanner_revision.sql
@@ -1,0 +1,19 @@
+-- Advance the internal scanner cache identity after certificate-grade Scope
+-- Closure retains medium singular risk as a non-blocking warning. Historical
+-- requests keep their recorded fingerprint; new requests must not reuse an r3
+-- completed blocked scan whose verdict used the former readiness policy.
+
+set lock_timeout = '5s';
+set statement_timeout = '120s';
+
+insert into private.lcia_scope_closure_config (
+  singleton,
+  expected_validator_scanner_fingerprint
+)
+values (
+  true,
+  'scope-closure-validator-scanner.v1+cutoff-readiness-r4'
+)
+on conflict (singleton) do update
+set expected_validator_scanner_fingerprint = excluded.expected_validator_scanner_fingerprint,
+    updated_at = statement_timestamp();

--- a/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
+++ b/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
@@ -8,8 +8,8 @@ select is(
   (select expected_validator_scanner_fingerprint
    from private.lcia_scope_closure_config
    where singleton),
-  'scope-closure-validator-scanner.v1+cutoff-readiness-r3',
-  'new closure requests use the digital-file-aware scanner cache revision'
+  'scope-closure-validator-scanner.v1+cutoff-readiness-r4',
+  'new closure requests use the medium-singular-warning scanner cache revision'
 );
 
 -- A minimal immutable current release.  The closure request must use this
@@ -265,7 +265,7 @@ select is((select status from private.lcia_scope_closure_scan_executions limit 1
 -- rollout may still have old requests in flight, but new requests must not
 -- select their completed evidence after the configured revision changes.
 update private.lcia_scope_closure_config
-set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r2',
+set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r3',
     updated_at=now()
 where singleton;
 select set_config('request.jwt.claim.role','authenticated',true);
@@ -274,18 +274,18 @@ select is(api.cmd_lcia_scope_closure_check_request_v2(
   'closure-e2e-old-scanner','{}'
 )->>'ok','true','previous scanner revision request fixture is accepted by the database command');
 update private.lcia_scope_closure_config
-set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r3',
+set expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r4',
     updated_at=now()
 where singleton;
 select is(api.cmd_lcia_scope_closure_check_request_v2(
   '{"coverageMode":"subset","processes":[{"id":"c7220000-0000-4000-8000-000000000020","version":"01.00.000"}],"lciaMethods":[{"id":"c7220000-0000-4000-8000-000000000021","version":"01.00.000"}]}'::jsonb,
   'closure-e2e-new-scanner','{}'
-)->>'ok','true','digital-file-aware scanner request fixture is accepted');
+)->>'ok','true','medium-singular-warning scanner request fixture is accepted');
 select ok((
   select old_scan.scan_execution_id <> new_scan.scan_execution_id
      and old_scan.request_fingerprint <> new_scan.request_fingerprint
-     and old_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r2'
-     and new_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r3'
+     and old_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r3'
+     and new_scan.expected_validator_scanner_fingerprint='scope-closure-validator-scanner.v1+cutoff-readiness-r4'
   from private.lcia_scope_closure_checks old_scan
   join private.lcia_scope_closure_checks new_scan on true
   where old_scan.request_idempotency_token='closure-e2e-old-scanner'

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260817140000'::text,
+  '20260817170000'::text,
   'service-only schema readback reports the exact migration head'
 );
 


### PR DESCRIPTION
Closes tiangong-lca/database-engine#504

## Summary
- Advance new Scope Closure requests from scanner fingerprint r3 to r4 so completed r3 blocked scans are not reused after the Worker readiness policy changes.

## Key Decisions
- Keep readiness severity semantics out of Database Engine; this migration changes cache identity only.

## Validation
- supabase db reset
- supabase test db supabase/tests/20260722_scope_closure_release_binding_e2e.sql (84 tests)
- supabase test db supabase/tests/20260801_scope_closure_cutoff_main_hotfix.sql supabase/tests/20260724_initial_candidate_scope_closure_e2e.sql supabase/tests/20260722_data_product_scope_closure_and_task_feed.sql (130 tests)
- supabase migration list --local
- docpact lint and strict config validation

## Risks / Rollback
- Low schema risk: one singleton config value changes. Deploy only after the matching Worker version is available; rollback is a later migration restoring the previous fingerprint.

## Follow-ups
- Promote database-engine dev to main after persistent-Dev validation, then perform the workspace submodule integration tracked by tiangong-lca/workspace#593.

## Workspace Integration
- Requires later database-engine dev-to-main promotion and root workspace submodule bump. The cross-repo cache-version ownership redesign remains tracked separately in tiangong-lca/workspace#590.