### PR TITLE
fix: restore Scope Closure reuse artifact format

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "eefc003b41eee76d473b0746fb375106a3a18d0b"
+lastReviewedCommit: "29411f899b947cde8ec548f085b3354715982fa1"
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
+lastReviewedCommit: 29411f899b947cde8ec548f085b3354715982fa1
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
+lastReviewedCommit: 29411f899b947cde8ec548f085b3354715982fa1
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
+lastReviewedCommit: 29411f899b947cde8ec548f085b3354715982fa1
 lastReviewedNote: "Reviewed after validating the scope-closure scanner revision and approved ownerless-reference review handling; deterministic rebuild, generated-artifact verification, and pgTAP contracts remain the required proof."
 related:
   - ../../AGENTS.md

--- a/supabase/migrations/20260817234000_restore_scope_closure_reuse_artifact_format.sql
+++ b/supabase/migrations/20260817234000_restore_scope_closure_reuse_artifact_format.sql
@@ -1,0 +1,120 @@
+-- Restore the complete numerical evidence projection consumed by Worker when
+-- a passed Scope Closure scan is reused. The RPC already validates the stored
+-- artifact format before this response is built; return that validated fact.
+
+set lock_timeout = '5s';
+set statement_timeout = '120s';
+
+CREATE OR REPLACE FUNCTION "private"."svc_lcia_scope_closure_reuse_completed_scan"("p_closure_check_id" "uuid", "p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_completed_check_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'private', 'api', 'public', 'util', 'extensions', 'pg_temp'
+    AS $$
+declare
+  v_target private.lcia_scope_closure_checks%rowtype;
+  v_source private.lcia_scope_closure_checks%rowtype;
+  v_execution private.lcia_scope_closure_scan_executions%rowtype;
+  v_job private.worker_jobs%rowtype;
+  v_snapshot private.lca_network_snapshots%rowtype;
+  v_artifact private.lca_snapshot_artifacts%rowtype;
+  v_bundle private.worker_job_artifacts%rowtype;
+begin
+  if not coalesce(util.is_service_request(), false) then
+    return api.lcia_scope_closure_error('service_role_required', 403, 'Service role is required');
+  end if;
+  select * into v_target from private.lcia_scope_closure_checks where id = p_closure_check_id for update;
+  select * into v_source
+  from private.lcia_scope_closure_checks
+  where id = p_completed_check_id
+  for share;
+  select * into v_job from private.worker_jobs where id = p_worker_job_id for update;
+  if v_target.id is null or v_source.id is null
+     or v_target.worker_job_id <> p_worker_job_id
+     or v_target.status not in ('queued', 'running') then
+    return api.lcia_scope_closure_error('closure_check_not_found', 404, 'Closure check not found');
+  end if;
+  if v_job.status <> 'running'
+     or v_job.lease_token is distinct from p_lease_token
+     or v_job.lease_expires_at < now() then
+    return api.lcia_scope_closure_error('worker_job_lease_invalid', 409, 'Worker job lease is no longer valid');
+  end if;
+  select * into v_execution
+  from private.lcia_scope_closure_scan_executions
+  where id = v_target.scan_execution_id
+  for update;
+  if v_execution.id is null
+     or v_execution.status <> 'completed'
+     or v_execution.completed_check_id <> v_source.id
+     or (
+       v_source.status = 'passed'
+       and v_execution.numerical_snapshot_id is distinct from v_source.snapshot_id
+     )
+     or v_source.status not in ('passed', 'blocked')
+     or v_source.scan_completeness <> 'complete'
+     or v_source.requested_scope_hash <> v_target.requested_scope_hash
+     or v_source.policy_fingerprint <> v_target.policy_fingerprint
+     or v_source.data_snapshot_token <> v_target.data_snapshot_token then
+    return api.lcia_scope_closure_error('scan_execution_not_reusable', 409, 'Completed scan evidence does not match this closure run');
+  end if;
+  if v_source.status = 'passed' then
+    select * into v_snapshot from private.lca_network_snapshots where id = v_source.snapshot_id;
+    select * into v_artifact from private.lca_snapshot_artifacts where id = v_source.snapshot_artifact_id;
+    select * into v_bundle from private.worker_job_artifacts where id = v_source.closure_bundle_artifact_id;
+    if v_source.certificate_status <> 'valid'
+       or v_source.certificate_schema_version <> 'lcia.scope-closure-certificate.v2'
+       or (
+         v_source.requested_scope_manifest->>'certificateFreshnessPolicy' = 'current-membership-required-v1'
+         and not private.lcia_scope_closure_current_release_matches(v_source.data_snapshot_token)
+       )
+       or v_snapshot.id is null
+       or v_snapshot.status <> 'ready'
+       or v_artifact.id is null
+       or v_artifact.snapshot_id <> v_snapshot.id
+       or v_artifact.status <> 'ready'
+       or v_artifact.artifact_format <> 'snapshot-hdf5:v1'
+       or v_artifact.artifact_sha256 <> v_source.snapshot_hash
+       or v_artifact.snapshot_index_sha256 <> v_source.snapshot_index_sha256
+       or v_artifact.snapshot_build_contract_hash <> v_source.snapshot_build_contract_hash
+       or v_artifact.effective_scope_hash <> v_source.effective_scope_hash
+       or v_artifact.data_snapshot_token <> v_source.data_snapshot_token
+       or v_artifact.closure_bundle_hash <> v_source.closure_bundle_hash
+       or v_bundle.id is null
+       or v_bundle.job_id <> v_source.worker_job_id
+       or v_bundle.artifact_type <> 'closure_bundle'
+       or v_bundle.checksum_sha256 <> v_source.closure_bundle_hash
+       or coalesce(v_bundle.metadata->>'closureCheckId', '') <> v_source.id::text then
+      return api.lcia_scope_closure_error('scan_execution_not_reusable', 409, 'Source numerical snapshot certificate is not reusable');
+    end if;
+  end if;
+  return jsonb_build_object('ok', true, 'data', jsonb_build_object(
+    'reuseAvailable', true,
+    'closureCheckId', v_target.id,
+    'workerJobId', v_job.id,
+    'completedCheckId', v_source.id,
+    'status', v_source.status,
+    'scanCompleteness', v_source.scan_completeness,
+    'evidence', jsonb_strip_nulls(jsonb_build_object(
+      'schemaVersion', 'lcia.scope-closure-evidence.v2',
+      'sourceFingerprint', v_source.source_fingerprint,
+      'resolutionMapHash', v_source.resolution_map_hash,
+      'closureBundleHash', v_source.closure_bundle_hash,
+      'closureBundleArtifactId', v_source.closure_bundle_artifact_id,
+      'snapshotId', v_source.snapshot_id,
+      'snapshotHash', v_source.snapshot_hash,
+      'snapshotArtifactId', v_source.snapshot_artifact_id,
+      'snapshotIndexSha256', v_source.snapshot_index_sha256,
+      'snapshotBuildContractHash', v_source.snapshot_build_contract_hash,
+      'artifactFormat', v_artifact.artifact_format,
+      'evidenceHash', v_source.evidence_hash
+    )),
+    'blockerCodes', to_jsonb(v_source.blocker_codes)
+  ));
+end;
+$$;
+
+ALTER FUNCTION "private"."svc_lcia_scope_closure_reuse_completed_scan"("p_closure_check_id" "uuid", "p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_completed_check_id" "uuid") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "private"."svc_lcia_scope_closure_reuse_completed_scan"("p_closure_check_id" "uuid", "p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_completed_check_id" "uuid") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "private"."svc_lcia_scope_closure_reuse_completed_scan"("p_closure_check_id" "uuid", "p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_completed_check_id" "uuid") TO "service_role";
+
+GRANT ALL ON FUNCTION "private"."svc_lcia_scope_closure_reuse_completed_scan"("p_closure_check_id" "uuid", "p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_completed_check_id" "uuid") TO "api_internal_executor";

--- a/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
+++ b/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
@@ -184,12 +184,16 @@ update private.worker_jobs set status='running', lease_token='c7220000-0000-4000
 where id=(select worker_job_id from private.lcia_scope_closure_checks where request_idempotency_token='closure-e2e-b');
 insert into private.worker_job_artifacts(id,job_id,artifact_type,storage_bucket,storage_path,content_type,byte_size,checksum_sha256)
 values ('c7220000-0000-4000-8000-000000000202',(select worker_job_id from private.lcia_scope_closure_checks where request_idempotency_token='closure-e2e-b'),'closure_report_xlsx','test','reports/b.xlsx','application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',11,repeat('b',64));
-select is(private.svc_lcia_scope_closure_reuse_completed_scan(
+create temporary table closure_e2e_reuse_response(result jsonb);
+insert into closure_e2e_reuse_response
+select private.svc_lcia_scope_closure_reuse_completed_scan(
   (select id from private.lcia_scope_closure_checks where request_idempotency_token='closure-e2e-b'),
   (select worker_job_id from private.lcia_scope_closure_checks where request_idempotency_token='closure-e2e-b'),
   'c7220000-0000-4000-8000-000000000102',
   (select id from private.lcia_scope_closure_checks where request_idempotency_token='closure-e2e-a')
-)->'data'->>'reuseAvailable','true','second run can reuse completed scan facts');
+);
+select is((select result->'data'->>'reuseAvailable' from closure_e2e_reuse_response),'true','second run can reuse completed scan facts');
+select is((select result->'data'->'evidence'->>'artifactFormat' from closure_e2e_reuse_response),'snapshot-hdf5:v1','passed reuse returns the validated snapshot artifact format required by Worker');
 select is(private.svc_lcia_scope_closure_finalize_reused_scan(
   (select id from private.lcia_scope_closure_checks where request_idempotency_token='closure-e2e-b'),
   (select worker_job_id from private.lcia_scope_closure_checks where request_idempotency_token='closure-e2e-b'),


### PR DESCRIPTION
Closes tiangong-lca/database-engine#509

## Summary
- Return the validated snapshot artifact format from passed Scope Closure reuse so Worker can accept complete cached numerical evidence.
- Add a regression assertion against the real database RPC response while preserving blocked reuse without numerical artifact fields.

## Key Decisions
- Source artifactFormat from v_artifact.artifact_format after the existing snapshot-hdf5:v1 reuse fence, rather than trusting caller or copied JSON evidence.
- Ship as an additive production main hotfix; do not invalidate or purge valid completed scans.

## Validation
- supabase db reset --no-seed
- /opt/homebrew/bin/psql postgresql://postgres:postgres@127.0.0.1:55322/postgres -X -v ON_ERROR_STOP=1 -f supabase/tests/20260722_scope_closure_release_binding_e2e.sql (85 assertions passed)
- /opt/homebrew/bin/psql ... -f supabase/tests/20260801_scope_closure_cutoff_main_hotfix.sql
- /opt/homebrew/bin/psql ... -f supabase/tests/20260724_initial_candidate_scope_closure_e2e.sql
- /opt/homebrew/bin/psql ... -f supabase/tests/20260722_data_product_scope_closure_and_task_feed.sql
- supabase migration list --local
- supabase db lint --level warning (existing repository-wide dynamic-temp-table and volatility findings only; no finding for the changed RPC)
- scripts/docpact validate-config --root . --strict; staged and pre-push docpact lint passed

## Risks / Rollback
- Low and backward-compatible: the migration only adds one already-validated key to an internal JSON evidence object. Roll back with a follow-up CREATE OR REPLACE FUNCTION migration if a consumer regression appears.

## Follow-ups
- After merge, confirm the production Supabase GitHub integration applies migration 20260817234000, retry the failed passed-reuse check, then back-merge main into dev.

## Workspace Integration
- Workspace integration remains pending until database-engine/main is back-merged to dev as required and the eligible release commit is pinned in lca-workspace.