### PR TITLE
chore: promote ResultSet database contract to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "3dade01ce537ee948f565f2881668c6e5c8554a7"
+lastReviewedCommit: "6ac7ed66"
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-17"
-lastReviewedCommit: "eefc003b41eee76d473b0746fb375106a3a18d0b"
+lastReviewedCommit: "3dade01ce537ee948f565f2881668c6e5c8554a7"
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; routing and ownership rules remain unchanged."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
+lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
+lastReviewedCommit: 6ac7ed66
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; repository ownership, bootstrap guidance, and cross-repository boundaries remain unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
+lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -28,7 +28,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
+lastReviewedCommit: 6ac7ed66
 lastReviewedNote: "Reviewed after integrating the scope-closure scanner revision and approved ownerless-reference review handling; schema ownership, API boundaries, and migration source-of-truth rules remain unchanged."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: eefc003b41eee76d473b0746fb375106a3a18d0b
+lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
 lastReviewedNote: "Reviewed after validating the scope-closure scanner revision and approved ownerless-reference review handling; deterministic rebuild, generated-artifact verification, and pgTAP contracts remain the required proof."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
+lastReviewedCommit: 6ac7ed66
 lastReviewedNote: "Reviewed after validating the scope-closure scanner revision and approved ownerless-reference review handling; deterministic rebuild, generated-artifact verification, and pgTAP contracts remain the required proof."
 related:
   - ../../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
+lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
 lastReviewedNote: "Reviewed after an exact CI-equivalent five-schema workspace rebuild; the script catalog and invocation contract remain unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
+lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
 lastReviewedNote: "已按 CI 的五 schema 参数完成等价重建复核；脚本目录及调用契约无需改变。"
 related:
   - ../AGENTS.md

--- a/supabase/migrations/20260817190000_add_persistent_lcia_result_sets.sql
+++ b/supabase/migrations/20260817190000_add_persistent_lcia_result_sets.sql
@@ -1,0 +1,497 @@
+begin;
+
+create table private.lcia_result_sets (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamptz not null default now(),
+  constraint lcia_result_sets_name_check check (length(btrim(name)) > 0)
+);
+
+alter table private.lcia_result_sets enable row level security;
+
+revoke all on table private.lcia_result_sets
+  from public, anon, authenticated, service_role;
+
+alter table private.lcia_scope_closure_checks
+  add column result_set_id uuid;
+
+alter table private.lcia_scope_closure_checks
+  add constraint lcia_scope_closure_checks_result_set_id_fkey
+  foreign key (result_set_id)
+  references private.lcia_result_sets(id)
+  on delete restrict;
+
+create index lcia_scope_closure_checks_result_set_idx
+  on private.lcia_scope_closure_checks (result_set_id)
+  where result_set_id is not null;
+
+create index lcia_result_sets_created_idx
+  on private.lcia_result_sets (created_at desc, id desc);
+
+create or replace function api.cmd_lcia_result_set_create(p_name text)
+returns jsonb
+language plpgsql
+security definer
+set search_path = api, private, public, util, extensions, pg_temp
+as $function$
+declare
+  v_actor uuid := auth.uid();
+  v_result_set private.lcia_result_sets%rowtype;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+  if coalesce(length(btrim(p_name)), 0) = 0 then
+    return api.lcia_scope_closure_error(
+      'invalid_result_set_name', 400, 'Result set name is required'
+    );
+  end if;
+
+  insert into private.lcia_result_sets (name)
+  values (btrim(p_name))
+  returning * into v_result_set;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'schemaVersion', 'lcia.result-set.v1',
+      'resultSetId', v_result_set.id,
+      'name', v_result_set.name,
+      'createdAt', v_result_set.created_at
+    )
+  );
+end;
+$function$;
+
+create or replace function api.list_lcia_result_sets(
+  p_limit integer default 100
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = api, private, public, util, extensions, pg_temp
+as $function$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_limit, 100), 200));
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'items', coalesce((
+        select jsonb_agg(
+          jsonb_build_object(
+            'schemaVersion', 'lcia.result-set.v1',
+            'resultSetId', result_set.id,
+            'name', result_set.name,
+            'createdAt', result_set.created_at
+          )
+          order by result_set.created_at desc, result_set.id desc
+        )
+        from (
+          select id, name, created_at
+          from private.lcia_result_sets
+          order by created_at desc, id desc
+          limit v_limit
+        ) result_set
+      ), '[]'::jsonb)
+    )
+  );
+end;
+$function$;
+
+create or replace function api.get_lcia_result_set(p_result_set_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = api, private, public, util, extensions, pg_temp
+as $function$
+declare
+  v_actor uuid := auth.uid();
+  v_result_set private.lcia_result_sets%rowtype;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  select *
+  into v_result_set
+  from private.lcia_result_sets
+  where id = p_result_set_id;
+
+  if v_result_set.id is null then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'schemaVersion', 'lcia.result-set.v1',
+      'resultSetId', v_result_set.id,
+      'name', v_result_set.name,
+      'createdAt', v_result_set.created_at
+    )
+  );
+end;
+$function$;
+
+create or replace function api.cmd_lcia_scope_closure_check_request_v3(
+  p_result_set_id uuid,
+  p_requested_scope jsonb,
+  p_request_idempotency_token text,
+  p_audit jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = api, private, public, util, extensions, pg_temp
+set statement_timeout = '60s'
+as $function$
+declare
+  v_actor uuid := auth.uid();
+  v_result jsonb;
+  v_closure_check_id uuid;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+  if not exists (
+    select 1 from private.lcia_result_sets where id = p_result_set_id
+  ) then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  v_result := api.cmd_lcia_scope_closure_check_request_v2(
+    p_requested_scope,
+    p_request_idempotency_token,
+    coalesce(p_audit, '{}'::jsonb)
+      || jsonb_build_object('resultSetId', p_result_set_id)
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    return v_result;
+  end if;
+
+  v_closure_check_id := nullif(
+    v_result->'data'->>'closureCheckId', ''
+  )::uuid;
+
+  update private.lcia_scope_closure_checks
+  set result_set_id = p_result_set_id,
+      updated_at = now()
+  where id = v_closure_check_id
+    and requested_by = v_actor
+    and (result_set_id is null or result_set_id = p_result_set_id);
+
+  if not found then
+    return api.lcia_scope_closure_error(
+      'closure_check_result_set_conflict', 409,
+      'Closure check is already bound to another result set'
+    );
+  end if;
+
+  return jsonb_set(
+    v_result,
+    '{data,resultSetId}',
+    to_jsonb(p_result_set_id),
+    true
+  );
+end;
+$function$;
+
+create or replace function private.get_task_summary_v2_feed_unversioned(
+  p_category text default null,
+  p_job_kinds text[] default null,
+  p_statuses text[] default null,
+  p_updated_since timestamptz default null,
+  p_cursor_updated_at timestamptz default null,
+  p_cursor_job_id uuid default null,
+  p_limit integer default 50,
+  p_root_only boolean default false
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = private, api, public, util, extensions, pg_temp
+as $function$
+declare
+  a uuid := auth.uid();
+  lim integer := greatest(1, least(coalesce(p_limit, 50), 200));
+  mgr boolean;
+begin
+  if a is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if (p_cursor_updated_at is null) <> (p_cursor_job_id is null) then
+    return api.lcia_scope_closure_error(
+      'invalid_task_cursor', 400,
+      'Task cursor fields must be supplied together'
+    );
+  end if;
+  mgr := api.lcia_scope_closure_is_manager();
+
+  return jsonb_build_object(
+    'ok', true,
+    'serverTime', now(),
+    'data', coalesce((
+      with x as (
+        select
+          j.*,
+          k.task_center_category,
+          p.id as package_id,
+          coalesce(cd.id, cp.id, ck.id) as closure_id,
+          coalesce(cd.status, cp.status, ck.status) as closure_status,
+          coalesce(
+            cd.certificate_status,
+            cp.certificate_status,
+            ck.certificate_status
+          ) as certificate_status,
+          result_set.id as result_set_id,
+          result_set.name as result_set_name,
+          greatest(
+            j.updated_at,
+            coalesce(cd.updated_at, '-infinity'::timestamptz),
+            coalesce(cp.updated_at, '-infinity'::timestamptz),
+            coalesce(ck.updated_at, '-infinity'::timestamptz),
+            coalesce(p.updated_at, '-infinity'::timestamptz)
+          ) as pu
+        from private.worker_jobs j
+        join private.worker_job_kinds k on k.job_kind = j.job_kind
+        left join private.lcia_scope_closure_checks cd
+          on cd.worker_job_id = j.id
+        left join private.lcia_result_packages p
+          on p.build_worker_job_id = j.id
+        left join private.lcia_scope_closure_checks cp
+          on cp.id = case
+            when (j.payload_json->>'closure_check_id')
+              ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              then (j.payload_json->>'closure_check_id')::uuid
+            else null
+          end
+        left join private.lcia_scope_closure_checks ck
+          on ck.id = p.closure_check_id
+        left join private.lcia_result_sets result_set
+          on result_set.id = coalesce(
+            cd.result_set_id,
+            cp.result_set_id,
+            ck.result_set_id
+          )
+        where j.requested_by = a
+          and (
+            j.visibility = 'user'
+            or (
+              mgr
+              and j.visibility = 'operator'
+              and j.job_kind = any(array[
+                'lcia.scope_closure_check',
+                'lcia_result.package_build'
+              ])
+            )
+          )
+          and (p_category is null or k.task_center_category = p_category)
+          and (p_job_kinds is null or j.job_kind = any(p_job_kinds))
+          and (p_statuses is null or j.status = any(p_statuses))
+          and (
+            p_updated_since is null
+            or greatest(
+              j.updated_at,
+              coalesce(cd.updated_at, '-infinity'::timestamptz),
+              coalesce(cp.updated_at, '-infinity'::timestamptz),
+              coalesce(ck.updated_at, '-infinity'::timestamptz),
+              coalesce(p.updated_at, '-infinity'::timestamptz)
+            ) >= p_updated_since
+          )
+          and (
+            not p_root_only
+            or j.root_job_id is null
+            or j.root_job_id = j.id
+          )
+      ), pg as (
+        select *
+        from x
+        where p_cursor_updated_at is null
+          or (pu, id) < (p_cursor_updated_at, p_cursor_job_id)
+        order by pu desc, id desc
+        limit lim + 1
+      ), sh as (
+        select * from pg order by pu desc, id desc limit lim
+      )
+      select jsonb_build_object(
+        'items', coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
+          'jobId', id,
+          'jobKind', job_kind,
+          'category', task_center_category,
+          'requestedBy', requested_by,
+          'workerStatus', status,
+          'phase', phase,
+          'progressFraction', case
+            when progress is null then null
+            else greatest(0::numeric, least(progress, 1::numeric))
+          end,
+          'progressCounters', diagnostics->'progressCounters',
+          'domainStatus', coalesce(closure_status, result_json->>'status'),
+          'domainValidity', certificate_status,
+          'projectionUpdatedAt', pu,
+          'title', coalesce(result_set_name, payload_json->>'name', job_kind),
+          'blockerCodes', blocker_codes,
+          'errorSummary', error_code,
+          'capabilities', jsonb_build_object(
+            'canCancel', status in ('queued', 'running', 'waiting'),
+            'canDownloadReport', closure_id is not null
+              and closure_status in ('passed', 'blocked'),
+            'canOpenWorkbench', task_center_category = 'data_product',
+            'canPreviewResult', package_id is not null
+          ),
+          'deepLink', case
+            when package_id is not null then jsonb_build_object(
+              'routeKey', 'data_product.package',
+              'params', jsonb_strip_nulls(jsonb_build_object(
+                'packageId', package_id,
+                'closureCheckId', closure_id,
+                'resultSetId', result_set_id
+              ))
+            )
+            when closure_id is not null then jsonb_build_object(
+              'routeKey', 'data_product.closure_check',
+              'params', jsonb_strip_nulls(jsonb_build_object(
+                'closureCheckId', closure_id,
+                'resultSetId', result_set_id
+              ))
+            )
+          end,
+          'closureCheckId', closure_id,
+          'resultPackageId', package_id,
+          'resultSetId', result_set_id,
+          'resultSetName', result_set_name
+        )) order by pu desc, id desc), '[]'::jsonb),
+        'nextCursor', case
+          when exists(select 1 from pg offset lim) then (
+            select jsonb_build_object('updatedAt', pu, 'jobId', id)
+            from sh
+            order by pu asc, id asc
+            limit 1
+          )
+          else null
+        end
+      )
+      from sh
+    ), jsonb_build_object('items', '[]'::jsonb, 'nextCursor', null))
+  );
+end;
+$function$;
+
+alter function api.cmd_lcia_result_set_create(text) owner to postgres;
+alter function api.list_lcia_result_sets(integer) owner to postgres;
+alter function api.get_lcia_result_set(uuid) owner to postgres;
+alter function api.cmd_lcia_scope_closure_check_request_v3(
+  uuid, jsonb, text, jsonb
+) owner to postgres;
+alter function private.get_task_summary_v2_feed_unversioned(
+  text, text[], text[], timestamptz, timestamptz, uuid, integer, boolean
+) owner to postgres;
+
+revoke all on function api.cmd_lcia_result_set_create(text) from public;
+revoke all on function api.list_lcia_result_sets(integer) from public;
+revoke all on function api.get_lcia_result_set(uuid) from public;
+revoke all on function api.cmd_lcia_scope_closure_check_request_v3(
+  uuid, jsonb, text, jsonb
+) from public;
+revoke all on function private.get_task_summary_v2_feed_unversioned(
+  text, text[], text[], timestamptz, timestamptz, uuid, integer, boolean
+) from public, anon, authenticated, service_role;
+
+grant execute on function api.cmd_lcia_result_set_create(text)
+  to api_internal_executor, authenticated;
+grant execute on function api.list_lcia_result_sets(integer)
+  to api_internal_executor, authenticated;
+grant execute on function api.get_lcia_result_set(uuid)
+  to api_internal_executor, authenticated;
+grant execute on function api.cmd_lcia_scope_closure_check_request_v3(
+  uuid, jsonb, text, jsonb
+) to api_internal_executor, authenticated;
+grant execute on function private.get_task_summary_v2_feed_unversioned(
+  text, text[], text[], timestamptz, timestamptz, uuid, integer, boolean
+) to api_internal_executor;
+
+insert into private.api_capability_grants (
+  routine_identity,
+  capability_id,
+  allow_anon,
+  allow_authenticated,
+  allow_service_role
+)
+values
+  (
+    'api.cmd_lcia_result_set_create(text)',
+    'EDGE-DATA-PRODUCT-01', false, true, false
+  ),
+  (
+    'api.list_lcia_result_sets(integer)',
+    'EDGE-DATA-PRODUCT-01', false, true, false
+  ),
+  (
+    'api.get_lcia_result_set(uuid)',
+    'EDGE-DATA-PRODUCT-01', false, true, false
+  ),
+  (
+    'api.cmd_lcia_scope_closure_check_request_v3(uuid, jsonb, text, jsonb)',
+    'EDGE-DATA-PRODUCT-01', false, true, false
+  )
+on conflict (routine_identity) do update
+set capability_id = excluded.capability_id,
+    allow_anon = excluded.allow_anon,
+    allow_authenticated = excluded.allow_authenticated,
+    allow_service_role = excluded.allow_service_role;
+
+comment on table private.lcia_result_sets is
+  'Named persistent containers for resuming the Data Processing workflow.';
+comment on column private.lcia_scope_closure_checks.result_set_id is
+  'Optional ResultSet container binding. NULL preserves legacy closure checks.';
+comment on function api.cmd_lcia_scope_closure_check_request_v3(
+  uuid, jsonb, text, jsonb
+) is
+  'Creates or reuses a Scope Closure check and atomically binds it to one persistent ResultSet.';
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
+++ b/supabase/tests/20260722_scope_closure_release_binding_e2e.sql
@@ -39,14 +39,82 @@ set local role authenticated;
 select set_config('request.jwt.claim.role','authenticated',true);
 select set_config('request.jwt.claim.sub','c7220000-0000-4000-8000-000000000001',true);
 
+create temporary table closure_result_set_response(result jsonb);
+insert into closure_result_set_response
+values (api.cmd_lcia_result_set_create('Closure E2E result set'));
+
 create temporary table closure_e2e_responses(result jsonb);
 insert into closure_e2e_responses values
-(api.cmd_lcia_scope_closure_check_request_v2('{"coverageMode":"subset","processes":[{"id":"c7220000-0000-4000-8000-000000000020","version":"01.00.000"}],"lciaMethods":[{"id":"c7220000-0000-4000-8000-000000000021","version":"01.00.000"}]}'::jsonb,'closure-e2e-a','{}')),
+(api.cmd_lcia_scope_closure_check_request_v3(
+  (select (result->'data'->>'resultSetId')::uuid from closure_result_set_response),
+  '{"coverageMode":"subset","processes":[{"id":"c7220000-0000-4000-8000-000000000020","version":"01.00.000"}],"lciaMethods":[{"id":"c7220000-0000-4000-8000-000000000021","version":"01.00.000"}]}'::jsonb,
+  'closure-e2e-a',
+  '{}'
+)),
 (api.cmd_lcia_scope_closure_check_request_v2('{"coverageMode":"subset","processes":[{"id":"c7220000-0000-4000-8000-000000000020","version":"01.00.000"}],"lciaMethods":[{"id":"c7220000-0000-4000-8000-000000000021","version":"01.00.000"}]}'::jsonb,'closure-e2e-b','{}'));
+
+create temporary table closure_result_set_task_feed(result jsonb);
+insert into closure_result_set_task_feed
+values (api.get_task_summary_v2_feed(
+  p_category => 'data_product',
+  p_limit => 50
+));
 
 reset role;
 
 select is((select count(*) from closure_e2e_responses where result->>'ok'='true'),2::bigint,'two explicit runs are accepted against the release');
+select is(
+  (
+    select result_set_id
+    from private.lcia_scope_closure_checks
+    where request_idempotency_token = 'closure-e2e-a'
+  ),
+  (
+    select (result->'data'->>'resultSetId')::uuid
+    from closure_result_set_response
+  ),
+  'ResultSet-aware closure request persists the container binding'
+);
+select is(
+  (
+    select result_set_id
+    from private.lcia_scope_closure_checks
+    where request_idempotency_token = 'closure-e2e-b'
+  ),
+  null::uuid,
+  'legacy closure requests remain valid without a ResultSet binding'
+);
+select is(
+  (
+    select item->>'resultSetName'
+    from closure_result_set_task_feed,
+      lateral jsonb_array_elements(result->'data'->'items') item
+    where item->>'closureCheckId' = (
+      select id::text
+      from private.lcia_scope_closure_checks
+      where request_idempotency_token = 'closure-e2e-a'
+    )
+  ),
+  'Closure E2E result set',
+  'TaskSummary projects the ResultSet name for recovery'
+);
+select is(
+  (
+    select item->'deepLink'->'params'->>'resultSetId'
+    from closure_result_set_task_feed,
+      lateral jsonb_array_elements(result->'data'->'items') item
+    where item->>'closureCheckId' = (
+      select id::text
+      from private.lcia_scope_closure_checks
+      where request_idempotency_token = 'closure-e2e-a'
+    )
+  ),
+  (
+    select result->'data'->>'resultSetId'
+    from closure_result_set_response
+  ),
+  'TaskSummary deep link carries the stable ResultSet identity'
+);
 select is((select count(distinct scan_execution_id) from private.lcia_scope_closure_checks where request_idempotency_token in ('closure-e2e-a','closure-e2e-b')),1::bigint,'two runs share one release-bound scan execution');
 select is((select count(distinct data_snapshot_token) from private.lcia_scope_closure_checks where request_idempotency_token in ('closure-e2e-a','closure-e2e-b')),1::bigint,'two runs freeze the same exact release snapshot');
 select is((select provider_matching_rule from private.lca_network_snapshots where id=(select numerical_snapshot_id from private.lcia_scope_closure_scan_executions limit 1)),'split_by_process_volume','preallocated snapshot records the actual fixed closure builder provider rule');

--- a/supabase/tests/20260805_full_schema_cutover.sql
+++ b/supabase/tests/20260805_full_schema_cutover.sql
@@ -68,7 +68,7 @@ select is(
     where namespace.nspname = 'api'
       and routine.prokind = 'f'
   ),
-  260::bigint,
+  264::bigint,
   'api contains the cutover functions, reviewed consumer facades, and Database A Search RPCs'
 );
 
@@ -136,7 +136,7 @@ select is(
       'util'::regnamespace
     )
   ),
-  457::bigint,
+  460::bigint,
   'all application constraints remain present'
 );
 
@@ -165,7 +165,7 @@ select is(
       and class.relkind in ('r', 'p')
       and class.relrowsecurity
   ),
-  55::bigint,
+  56::bigint,
   'RLS enablement is preserved across moved tables'
 );
 

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -475,7 +475,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260817170000'::text,
+  '20260817190000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260817_result_set_workflow.sql
+++ b/supabase/tests/20260817_result_set_workflow.sql
@@ -1,0 +1,261 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, auth;
+select no_plan();
+
+select has_table(
+  'private', 'lcia_result_sets',
+  'ResultSet containers are persisted in the private schema'
+);
+select col_is_pk(
+  'private', 'lcia_result_sets', 'id',
+  'ResultSet identity is a UUID primary key'
+);
+select has_column(
+  'private', 'lcia_result_sets', 'name',
+  'ResultSet persists its user-facing name'
+);
+select has_column(
+  'private', 'lcia_result_sets', 'created_at',
+  'ResultSet persists its creation time'
+);
+select has_column(
+  'private', 'lcia_scope_closure_checks', 'result_set_id',
+  'Scope Closure optionally binds to a ResultSet'
+);
+select fk_ok(
+  'private', 'lcia_scope_closure_checks', 'result_set_id',
+  'private', 'lcia_result_sets', 'id',
+  'Scope Closure ResultSet binding is referentially constrained'
+);
+select ok(
+  (
+    select is_nullable = 'YES'
+    from information_schema.columns
+    where table_schema = 'private'
+      and table_name = 'lcia_scope_closure_checks'
+      and column_name = 'result_set_id'
+  ),
+  'legacy Scope Closure rows may remain unbound'
+);
+select ok(
+  (
+    select relrowsecurity
+    from pg_catalog.pg_class
+    where oid = 'private.lcia_result_sets'::regclass
+  ),
+  'ResultSet table enables RLS'
+);
+select ok(
+  not has_table_privilege(
+    'authenticated', 'private.lcia_result_sets', 'select'
+  ),
+  'authenticated callers cannot read ResultSet rows directly'
+);
+select ok(
+  not has_table_privilege(
+    'authenticated', 'private.lcia_result_sets', 'insert'
+  ),
+  'authenticated callers cannot create ResultSet rows directly'
+);
+select ok(
+  exists (
+    select 1
+    from pg_catalog.pg_indexes
+    where schemaname = 'private'
+      and indexname = 'lcia_scope_closure_checks_result_set_idx'
+  ),
+  'ResultSet foreign-key lookups have a supporting index'
+);
+
+select has_function(
+  'api', 'cmd_lcia_result_set_create', array['text'],
+  'ResultSet create command exists'
+);
+select has_function(
+  'api', 'list_lcia_result_sets', array['integer'],
+  'bounded ResultSet list query exists'
+);
+select has_function(
+  'api', 'get_lcia_result_set', array['uuid'],
+  'ResultSet read query exists'
+);
+select has_function(
+  'api', 'cmd_lcia_scope_closure_check_request_v3',
+  array['uuid', 'jsonb', 'text', 'jsonb'],
+  'ResultSet-aware Scope Closure command exists'
+);
+select has_function(
+  'api', 'cmd_lcia_scope_closure_check_request_v2',
+  array['jsonb', 'text', 'jsonb'],
+  'legacy nullable Scope Closure command remains available'
+);
+select ok(
+  has_function_privilege(
+    'authenticated', 'api.cmd_lcia_result_set_create(text)', 'execute'
+  )
+  and has_function_privilege(
+    'authenticated', 'api.list_lcia_result_sets(integer)', 'execute'
+  )
+  and has_function_privilege(
+    'authenticated', 'api.get_lcia_result_set(uuid)', 'execute'
+  )
+  and has_function_privilege(
+    'authenticated',
+    'api.cmd_lcia_scope_closure_check_request_v3(uuid,jsonb,text,jsonb)',
+    'execute'
+  ),
+  'authenticated callers use only role-gated ResultSet RPCs'
+);
+select ok(
+  pg_catalog.strpos(
+    pg_catalog.pg_get_functiondef(
+      'api.cmd_lcia_scope_closure_check_request_v3(uuid,jsonb,text,jsonb)'
+        ::regprocedure
+    ),
+    'result_set_id = p_result_set_id'
+  ) > 0,
+  'ResultSet-aware Scope Closure command persists the binding'
+);
+select ok(
+  pg_catalog.strpos(
+    pg_catalog.pg_get_functiondef(
+      'private.get_task_summary_v2_feed_unversioned(text,text[],text[],timestamp with time zone,timestamp with time zone,uuid,integer,boolean)'
+        ::regprocedure
+    ),
+    '''resultSetId'''
+  ) > 0
+  and pg_catalog.strpos(
+    pg_catalog.pg_get_functiondef(
+      'private.get_task_summary_v2_feed_unversioned(text,text[],text[],timestamp with time zone,timestamp with time zone,uuid,integer,boolean)'
+        ::regprocedure
+    ),
+    '''resultSetName'''
+  ) > 0,
+  'TaskSummary safely projects ResultSet identity and name'
+);
+select ok(
+  exists (
+    select 1
+    from private.api_capability_grants
+    where routine_identity = 'api.cmd_lcia_result_set_create(text)'
+      and allow_authenticated
+      and not allow_anon
+      and not allow_service_role
+  )
+  and exists (
+    select 1
+    from private.api_capability_grants
+    where routine_identity =
+      'api.cmd_lcia_scope_closure_check_request_v3(uuid, jsonb, text, jsonb)'
+      and allow_authenticated
+      and not allow_anon
+      and not allow_service_role
+  ),
+  'ResultSet RPCs are recorded in the exact capability manifest'
+);
+
+insert into auth.users (
+  instance_id, id, aud, role, email, encrypted_password,
+  email_confirmed_at, raw_app_meta_data, raw_user_meta_data,
+  created_at, updated_at, is_sso_user, is_anonymous
+) values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '51700000-0000-4000-8000-000000000001',
+    'authenticated', 'authenticated', 'result-set-manager@example.com',
+    'x', now(), '{}', '{}', now(), now(), false, false
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '51700000-0000-4000-8000-000000000002',
+    'authenticated', 'authenticated', 'result-set-member@example.com',
+    'x', now(), '{}', '{}', now(), now(), false, false
+  );
+
+insert into private.users(id, raw_user_meta_data, contact) values
+  ('51700000-0000-4000-8000-000000000001', '{}', null),
+  ('51700000-0000-4000-8000-000000000002', '{}', null);
+insert into private.teams(id, json, rank, is_public)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  '{"name":"System"}', 0, false
+)
+on conflict (id) do nothing;
+insert into private.roles(user_id, team_id, role)
+values (
+  '51700000-0000-4000-8000-000000000001',
+  '00000000-0000-0000-0000-000000000000',
+  'data_product_manager'
+);
+
+create temporary table result_set_test_context (
+  result_set_id uuid primary key
+) on commit drop;
+grant select, insert on result_set_test_context to authenticated;
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '51700000-0000-4000-8000-000000000002',
+  true
+);
+
+select is(
+  api.cmd_lcia_result_set_create('member result')->>'code',
+  'not_data_product_manager',
+  'ordinary users cannot create ResultSets'
+);
+select is(
+  api.list_lcia_result_sets()->>'code',
+  'not_data_product_manager',
+  'ordinary users cannot list ResultSets'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '51700000-0000-4000-8000-000000000001',
+  true
+);
+
+select is(
+  api.cmd_lcia_result_set_create('   ')->>'code',
+  'invalid_result_set_name',
+  'blank ResultSet names are rejected'
+);
+
+insert into result_set_test_context(result_set_id)
+select (
+  api.cmd_lcia_result_set_create('  test  ')->'data'->>'resultSetId'
+)::uuid;
+
+select is(
+  api.get_lcia_result_set(
+    (select result_set_id from result_set_test_context)
+  )->'data'->>'name',
+  'test',
+  'ResultSet create trims and persists the display name'
+);
+select is(
+  api.list_lcia_result_sets()->'data'->'items'->0->>'resultSetId',
+  (select result_set_id::text from result_set_test_context),
+  'ResultSet list returns the newest persistent container'
+);
+select is(
+  api.list_lcia_result_sets()->'data'->'items'->0->>'schemaVersion',
+  'lcia.result-set.v1',
+  'ResultSet list items carry the stable DTO version'
+);
+
+reset role;
+
+select is(
+  (select name from private.lcia_result_sets limit 1),
+  'test',
+  'ResultSet table stores only the approved minimal user data'
+);
+
+select * from finish();
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
+lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
 lastReviewedNote: "Restored and reviewed the exact-local workspace for the CI-authoritative public, api, private, util, and archive schemas; deterministic generation behavior is unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-17
-lastReviewedCommit: 8c81e3fa501d708fd0bee999debbab2408c91a3c
+lastReviewedCommit: 3dade01ce537ee948f565f2881668c6e5c8554a7
 lastReviewedNote: "已恢复并复核 CI 权威的 public、api、private、util、archive 五 schema exact-local workspace；确定性生成行为不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/database.types.ts
+++ b/supabase/workspace/database.types.ts
@@ -353,11 +353,21 @@ export type Database = {
         Args: { p_audit?: Json; p_publication_id: string; p_reason?: string }
         Returns: Json
       }
+      cmd_lcia_result_set_create: { Args: { p_name: string }; Returns: Json }
       cmd_lcia_scope_closure_check_request_v2: {
         Args: {
           p_audit?: Json
           p_request_idempotency_token: string
           p_requested_scope: Json
+        }
+        Returns: Json
+      }
+      cmd_lcia_scope_closure_check_request_v3: {
+        Args: {
+          p_audit?: Json
+          p_request_idempotency_token: string
+          p_requested_scope: Json
+          p_result_set_id: string
         }
         Returns: Json
       }
@@ -858,6 +868,7 @@ export type Database = {
         Args: { p_package_id: string }
         Returns: Json
       }
+      get_lcia_result_set: { Args: { p_result_set_id: string }; Returns: Json }
       get_lcia_scope_closure_check: {
         Args: { p_closure_check_id: string }
         Returns: Json
@@ -1275,6 +1286,7 @@ export type Database = {
         Args: { proc: Database["public"]["Tables"]["lifecyclemodels"]["Row"] }
         Returns: string
       }
+      list_lcia_result_sets: { Args: { p_limit?: number }; Returns: Json }
       list_lcia_scope_closure_issues: {
         Args: {
           p_after_issue_id?: string

--- a/supabase/workspace/global/other/0168e05013.sql
+++ b/supabase/workspace/global/other/0168e05013.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN "private"."lcia_scope_closure_checks"."result_set_id" IS 'Optional ResultSet container binding. NULL preserves legacy closure checks.';

--- a/supabase/workspace/global/other/dd062aedf1.sql
+++ b/supabase/workspace/global/other/dd062aedf1.sql
@@ -1,0 +1,1 @@
+COMMENT ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") IS 'Creates or reuses a Scope Closure check and atomically binds it to one persistent ResultSet.';

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -9720,6 +9720,51 @@ $$;
 ALTER FUNCTION "api"."cmd_lcia_result_publication_unpublish"("p_publication_id" "uuid", "p_reason" "text", "p_audit" "jsonb") OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_result_set private.lcia_result_sets%rowtype;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+  if coalesce(length(btrim(p_name)), 0) = 0 then
+    return api.lcia_scope_closure_error(
+      'invalid_result_set_name', 400, 'Result set name is required'
+    );
+  end if;
+
+  insert into private.lcia_result_sets (name)
+  values (btrim(p_name))
+  returning * into v_result_set;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'schemaVersion', 'lcia.result-set.v1',
+      'resultSetId', v_result_set.id,
+      'name', v_result_set.name,
+      'createdAt', v_result_set.created_at
+    )
+  );
+end;
+$$;
+
+
+ALTER FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "api"."cmd_lcia_scope_closure_check_request_v2"("p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
@@ -10089,6 +10134,80 @@ ALTER FUNCTION "api"."cmd_lcia_scope_closure_check_request_v2"("p_requested_scop
 
 
 COMMENT ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v2"("p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") IS 'Creates a release-bound closure preflight when a formal release exists, or a deterministic candidate-public-state preflight for initial release bootstrap.';
+
+
+
+CREATE OR REPLACE FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_result jsonb;
+  v_closure_check_id uuid;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+  if not exists (
+    select 1 from private.lcia_result_sets where id = p_result_set_id
+  ) then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  v_result := api.cmd_lcia_scope_closure_check_request_v2(
+    p_requested_scope,
+    p_request_idempotency_token,
+    coalesce(p_audit, '{}'::jsonb)
+      || jsonb_build_object('resultSetId', p_result_set_id)
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    return v_result;
+  end if;
+
+  v_closure_check_id := nullif(
+    v_result->'data'->>'closureCheckId', ''
+  )::uuid;
+
+  update private.lcia_scope_closure_checks
+  set result_set_id = p_result_set_id,
+      updated_at = now()
+  where id = v_closure_check_id
+    and requested_by = v_actor
+    and (result_set_id is null or result_set_id = p_result_set_id);
+
+  if not found then
+    return api.lcia_scope_closure_error(
+      'closure_check_result_set_conflict', 409,
+      'Closure check is already bound to another result set'
+    );
+  end if;
+
+  return jsonb_set(
+    v_result,
+    '{data,resultSetId}',
+    to_jsonb(p_result_set_id),
+    true
+  );
+end;
+$$;
+
+
+ALTER FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") OWNER TO "postgres";
+
+
+COMMENT ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") IS 'Creates or reuses a Scope Closure check and atomically binds it to one persistent ResultSet.';
 
 
 
@@ -16895,6 +17014,52 @@ $$;
 ALTER FUNCTION "api"."get_lcia_result_package_preview"("p_package_id" "uuid") OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_result_set private.lcia_result_sets%rowtype;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  select *
+  into v_result_set
+  from private.lcia_result_sets
+  where id = p_result_set_id;
+
+  if v_result_set.id is null then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'schemaVersion', 'lcia.result-set.v1',
+      'resultSetId', v_result_set.id,
+      'name', v_result_set.name,
+      'createdAt', v_result_set.created_at
+    )
+  );
+end;
+$$;
+
+
+ALTER FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "api"."get_lcia_scope_closure_check"("p_closure_check_id" "uuid") RETURNS "jsonb"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
@@ -18004,6 +18169,55 @@ $$;
 
 
 ALTER FUNCTION "api"."lifecyclemodels_embedding_ft_input"("proc" "public"."lifecyclemodels") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "api"."list_lcia_result_sets"("p_limit" integer DEFAULT 100) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_limit, 100), 200));
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'items', coalesce((
+        select jsonb_agg(
+          jsonb_build_object(
+            'schemaVersion', 'lcia.result-set.v1',
+            'resultSetId', result_set.id,
+            'name', result_set.name,
+            'createdAt', result_set.created_at
+          )
+          order by result_set.created_at desc, result_set.id desc
+        )
+        from (
+          select id, name, created_at
+          from private.lcia_result_sets
+          order by created_at desc, id desc
+          limit v_limit
+        ) result_set
+      ), '[]'::jsonb)
+    )
+  );
+end;
+$$;
+
+
+ALTER FUNCTION "api"."list_lcia_result_sets"("p_limit" integer) OWNER TO "postgres";
 
 
 CREATE OR REPLACE FUNCTION "api"."list_lcia_scope_closure_issues"("p_closure_check_id" "uuid", "p_after_issue_id" "uuid" DEFAULT NULL::"uuid", "p_limit" integer DEFAULT 100) RETURNS "jsonb"
@@ -36839,21 +37053,171 @@ CREATE OR REPLACE FUNCTION "private"."get_task_summary_v2_feed_unversioned"("p_c
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO 'private', 'api', 'public', 'util', 'extensions', 'pg_temp'
     AS $_$
-declare a uuid:=auth.uid(); lim integer:=greatest(1,least(coalesce(p_limit,50),200)); mgr boolean;
+declare
+  a uuid := auth.uid();
+  lim integer := greatest(1, least(coalesce(p_limit, 50), 200));
+  mgr boolean;
 begin
-  if a is null then return api.lcia_scope_closure_error('auth_required',401,'Authentication required'); end if;
-  if (p_cursor_updated_at is null)<>(p_cursor_job_id is null) then return api.lcia_scope_closure_error('invalid_task_cursor',400,'Task cursor fields must be supplied together'); end if;
-  mgr:=api.lcia_scope_closure_is_manager();
-  return jsonb_build_object('ok',true,'serverTime',now(),'data',coalesce((with x as (
-    select j.*,k.task_center_category,p.id package_id,coalesce(cd.id,cp.id,ck.id) closure_id,coalesce(cd.status,cp.status,ck.status) closure_status,coalesce(cd.certificate_status,cp.certificate_status,ck.certificate_status) certificate_status,greatest(j.updated_at,coalesce(cd.updated_at,'-infinity'::timestamptz),coalesce(cp.updated_at,'-infinity'::timestamptz),coalesce(ck.updated_at,'-infinity'::timestamptz),coalesce(p.updated_at,'-infinity'::timestamptz)) pu
-    from private.worker_jobs j join private.worker_job_kinds k on k.job_kind=j.job_kind
-      left join private.lcia_scope_closure_checks cd on cd.worker_job_id=j.id
-      left join private.lcia_result_packages p on p.build_worker_job_id=j.id
-      left join private.lcia_scope_closure_checks cp on cp.id=case when (j.payload_json->>'closure_check_id')~'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$' then (j.payload_json->>'closure_check_id')::uuid else null end
-      left join private.lcia_scope_closure_checks ck on ck.id=p.closure_check_id
-    where j.requested_by=a and (j.visibility='user' or (mgr and j.visibility='operator' and j.job_kind=any(array['lcia.scope_closure_check','lcia_result.package_build']))) and (p_category is null or k.task_center_category=p_category) and (p_job_kinds is null or j.job_kind=any(p_job_kinds)) and (p_statuses is null or j.status=any(p_statuses)) and (p_updated_since is null or greatest(j.updated_at,coalesce(cd.updated_at,'-infinity'::timestamptz),coalesce(cp.updated_at,'-infinity'::timestamptz),coalesce(ck.updated_at,'-infinity'::timestamptz),coalesce(p.updated_at,'-infinity'::timestamptz))>=p_updated_since) and (not p_root_only or j.root_job_id is null or j.root_job_id=j.id)
-  ), pg as (select * from x where p_cursor_updated_at is null or (pu,id)<(p_cursor_updated_at,p_cursor_job_id) order by pu desc,id desc limit lim+1), sh as (select * from pg order by pu desc,id desc limit lim)
-  select jsonb_build_object('items',coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object('jobId',id,'jobKind',job_kind,'category',task_center_category,'requestedBy',requested_by,'workerStatus',status,'phase',phase,'progressFraction',case when progress is null then null else greatest(0::numeric,least(progress,1::numeric)) end,'progressCounters',diagnostics->'progressCounters','domainStatus',coalesce(closure_status,result_json->>'status'),'domainValidity',certificate_status,'projectionUpdatedAt',pu,'title',coalesce(payload_json->>'name',job_kind),'blockerCodes',blocker_codes,'errorSummary',error_code,'capabilities',jsonb_build_object('canCancel',status in ('queued','running','waiting'),'canDownloadReport',closure_id is not null and closure_status in ('passed','blocked'),'canOpenWorkbench',task_center_category='data_product','canPreviewResult',package_id is not null),'deepLink',case when package_id is not null then jsonb_build_object('routeKey','data_product.package','params',jsonb_strip_nulls(jsonb_build_object('packageId',package_id,'closureCheckId',closure_id))) when closure_id is not null then jsonb_build_object('routeKey','data_product.closure_check','params',jsonb_build_object('closureCheckId',closure_id)) end,'closureCheckId',closure_id,'resultPackageId',package_id)) order by pu desc,id desc),'[]'::jsonb),'nextCursor',case when exists(select 1 from pg offset lim) then (select jsonb_build_object('updatedAt',pu,'jobId',id) from sh order by pu asc,id asc limit 1) else null end) from sh),jsonb_build_object('items','[]'::jsonb,'nextCursor',null)));
+  if a is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if (p_cursor_updated_at is null) <> (p_cursor_job_id is null) then
+    return api.lcia_scope_closure_error(
+      'invalid_task_cursor', 400,
+      'Task cursor fields must be supplied together'
+    );
+  end if;
+  mgr := api.lcia_scope_closure_is_manager();
+
+  return jsonb_build_object(
+    'ok', true,
+    'serverTime', now(),
+    'data', coalesce((
+      with x as (
+        select
+          j.*,
+          k.task_center_category,
+          p.id as package_id,
+          coalesce(cd.id, cp.id, ck.id) as closure_id,
+          coalesce(cd.status, cp.status, ck.status) as closure_status,
+          coalesce(
+            cd.certificate_status,
+            cp.certificate_status,
+            ck.certificate_status
+          ) as certificate_status,
+          result_set.id as result_set_id,
+          result_set.name as result_set_name,
+          greatest(
+            j.updated_at,
+            coalesce(cd.updated_at, '-infinity'::timestamptz),
+            coalesce(cp.updated_at, '-infinity'::timestamptz),
+            coalesce(ck.updated_at, '-infinity'::timestamptz),
+            coalesce(p.updated_at, '-infinity'::timestamptz)
+          ) as pu
+        from private.worker_jobs j
+        join private.worker_job_kinds k on k.job_kind = j.job_kind
+        left join private.lcia_scope_closure_checks cd
+          on cd.worker_job_id = j.id
+        left join private.lcia_result_packages p
+          on p.build_worker_job_id = j.id
+        left join private.lcia_scope_closure_checks cp
+          on cp.id = case
+            when (j.payload_json->>'closure_check_id')
+              ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              then (j.payload_json->>'closure_check_id')::uuid
+            else null
+          end
+        left join private.lcia_scope_closure_checks ck
+          on ck.id = p.closure_check_id
+        left join private.lcia_result_sets result_set
+          on result_set.id = coalesce(
+            cd.result_set_id,
+            cp.result_set_id,
+            ck.result_set_id
+          )
+        where j.requested_by = a
+          and (
+            j.visibility = 'user'
+            or (
+              mgr
+              and j.visibility = 'operator'
+              and j.job_kind = any(array[
+                'lcia.scope_closure_check',
+                'lcia_result.package_build'
+              ])
+            )
+          )
+          and (p_category is null or k.task_center_category = p_category)
+          and (p_job_kinds is null or j.job_kind = any(p_job_kinds))
+          and (p_statuses is null or j.status = any(p_statuses))
+          and (
+            p_updated_since is null
+            or greatest(
+              j.updated_at,
+              coalesce(cd.updated_at, '-infinity'::timestamptz),
+              coalesce(cp.updated_at, '-infinity'::timestamptz),
+              coalesce(ck.updated_at, '-infinity'::timestamptz),
+              coalesce(p.updated_at, '-infinity'::timestamptz)
+            ) >= p_updated_since
+          )
+          and (
+            not p_root_only
+            or j.root_job_id is null
+            or j.root_job_id = j.id
+          )
+      ), pg as (
+        select *
+        from x
+        where p_cursor_updated_at is null
+          or (pu, id) < (p_cursor_updated_at, p_cursor_job_id)
+        order by pu desc, id desc
+        limit lim + 1
+      ), sh as (
+        select * from pg order by pu desc, id desc limit lim
+      )
+      select jsonb_build_object(
+        'items', coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
+          'jobId', id,
+          'jobKind', job_kind,
+          'category', task_center_category,
+          'requestedBy', requested_by,
+          'workerStatus', status,
+          'phase', phase,
+          'progressFraction', case
+            when progress is null then null
+            else greatest(0::numeric, least(progress, 1::numeric))
+          end,
+          'progressCounters', diagnostics->'progressCounters',
+          'domainStatus', coalesce(closure_status, result_json->>'status'),
+          'domainValidity', certificate_status,
+          'projectionUpdatedAt', pu,
+          'title', coalesce(result_set_name, payload_json->>'name', job_kind),
+          'blockerCodes', blocker_codes,
+          'errorSummary', error_code,
+          'capabilities', jsonb_build_object(
+            'canCancel', status in ('queued', 'running', 'waiting'),
+            'canDownloadReport', closure_id is not null
+              and closure_status in ('passed', 'blocked'),
+            'canOpenWorkbench', task_center_category = 'data_product',
+            'canPreviewResult', package_id is not null
+          ),
+          'deepLink', case
+            when package_id is not null then jsonb_build_object(
+              'routeKey', 'data_product.package',
+              'params', jsonb_strip_nulls(jsonb_build_object(
+                'packageId', package_id,
+                'closureCheckId', closure_id,
+                'resultSetId', result_set_id
+              ))
+            )
+            when closure_id is not null then jsonb_build_object(
+              'routeKey', 'data_product.closure_check',
+              'params', jsonb_strip_nulls(jsonb_build_object(
+                'closureCheckId', closure_id,
+                'resultSetId', result_set_id
+              ))
+            )
+          end,
+          'closureCheckId', closure_id,
+          'resultPackageId', package_id,
+          'resultSetId', result_set_id,
+          'resultSetName', result_set_name
+        )) order by pu desc, id desc), '[]'::jsonb),
+        'nextCursor', case
+          when exists(select 1 from pg offset lim) then (
+            select jsonb_build_object('updatedAt', pu, 'jobId', id)
+            from sh
+            order by pu asc, id asc
+            limit 1
+          )
+          else null
+        end
+      )
+      from sh
+    ), jsonb_build_object('items', '[]'::jsonb, 'nextCursor', null))
+  );
 end;
 $_$;
 
@@ -38382,6 +38746,7 @@ CREATE TABLE IF NOT EXISTS "private"."lcia_scope_closure_checks" (
     "snapshot_build_contract_hash" "text",
     "complete_machine_result_artifact_id" "uuid",
     "valid_until" timestamp with time zone,
+    "result_set_id" "uuid",
     CONSTRAINT "lcia_scope_closure_checks_certificate_check" CHECK (("certificate_status" = ANY (ARRAY['pending'::"text", 'valid'::"text", 'stale'::"text", 'revoked'::"text", 'unavailable'::"text"]))),
     CONSTRAINT "lcia_scope_closure_checks_completeness_check" CHECK ((("scan_completeness" IS NULL) OR ("scan_completeness" = ANY (ARRAY['complete'::"text", 'incomplete'::"text", 'unknown'::"text"])))),
     CONSTRAINT "lcia_scope_closure_checks_effective_scope_manifest_check" CHECK ((("effective_scope_manifest" IS NULL) OR ("jsonb_typeof"("effective_scope_manifest") = 'object'::"text"))),
@@ -38409,6 +38774,10 @@ COMMENT ON COLUMN "private"."lcia_scope_closure_checks"."complete_machine_result
 
 
 COMMENT ON COLUMN "private"."lcia_scope_closure_checks"."valid_until" IS 'Certificate admission deadline, bounded by every required closure evidence artifact.';
+
+
+
+COMMENT ON COLUMN "private"."lcia_scope_closure_checks"."result_set_id" IS 'Optional ResultSet container binding. NULL preserves legacy closure checks.';
 
 
 
@@ -56282,6 +56651,21 @@ CREATE TABLE IF NOT EXISTS "private"."lcia_result_publications" (
 ALTER TABLE "private"."lcia_result_publications" OWNER TO "postgres";
 
 
+CREATE TABLE IF NOT EXISTS "private"."lcia_result_sets" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "name" "text" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lcia_result_sets_name_check" CHECK (("length"("btrim"("name")) > 0))
+);
+
+
+ALTER TABLE "private"."lcia_result_sets" OWNER TO "postgres";
+
+
+COMMENT ON TABLE "private"."lcia_result_sets" IS 'Named persistent containers for resuming the Data Processing workflow.';
+
+
+
 CREATE TABLE IF NOT EXISTS "private"."lcia_scope_closure_artifact_write_set_batches" (
     "write_set_id" "uuid" NOT NULL,
     "batch_id" "uuid" NOT NULL,
@@ -57915,6 +58299,11 @@ ALTER TABLE ONLY "private"."lcia_result_publications"
 
 
 
+ALTER TABLE ONLY "private"."lcia_result_sets"
+    ADD CONSTRAINT "lcia_result_sets_pkey" PRIMARY KEY ("id");
+
+
+
 ALTER TABLE ONLY "private"."lcia_scope_closure_artifact_write_set_batches"
     ADD CONSTRAINT "lcia_scope_closure_artifact_write_set_batches_pkey" PRIMARY KEY ("write_set_id", "batch_id");
 
@@ -58714,6 +59103,10 @@ CREATE INDEX "lcia_result_publications_package_idx" ON "private"."lcia_result_pu
 
 
 
+CREATE INDEX "lcia_result_sets_created_idx" ON "private"."lcia_result_sets" USING "btree" ("created_at" DESC, "id" DESC);
+
+
+
 CREATE INDEX "lcia_scope_closure_artifact_write_set_batches_range_idx" ON "private"."lcia_scope_closure_artifact_write_set_batches" USING "btree" ("write_set_id", "first_ordinal", "last_ordinal", "batch_id");
 
 
@@ -58755,6 +59148,10 @@ CREATE UNIQUE INDEX "lcia_scope_closure_checks_request_key_uidx" ON "private"."l
 
 
 CREATE INDEX "lcia_scope_closure_checks_requested_updated_idx" ON "private"."lcia_scope_closure_checks" USING "btree" ("requested_by", "updated_at" DESC, "id" DESC);
+
+
+
+CREATE INDEX "lcia_scope_closure_checks_result_set_idx" ON "private"."lcia_scope_closure_checks" USING "btree" ("result_set_id") WHERE ("result_set_id" IS NOT NULL);
 
 
 
@@ -60126,6 +60523,11 @@ ALTER TABLE ONLY "private"."lcia_scope_closure_checks"
 
 
 ALTER TABLE ONLY "private"."lcia_scope_closure_checks"
+    ADD CONSTRAINT "lcia_scope_closure_checks_result_set_id_fkey" FOREIGN KEY ("result_set_id") REFERENCES "private"."lcia_result_sets"("id") ON DELETE RESTRICT;
+
+
+
+ALTER TABLE ONLY "private"."lcia_scope_closure_checks"
     ADD CONSTRAINT "lcia_scope_closure_checks_reused_from_check_id_fkey" FOREIGN KEY ("reused_from_check_id") REFERENCES "private"."lcia_scope_closure_checks"("id") ON DELETE RESTRICT;
 
 
@@ -60463,6 +60865,9 @@ ALTER TABLE "private"."lcia_result_packages" ENABLE ROW LEVEL SECURITY;
 
 
 ALTER TABLE "private"."lcia_result_publications" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "private"."lcia_result_sets" ENABLE ROW LEVEL SECURITY;
 
 
 ALTER TABLE "private"."lcia_scope_closure_artifact_write_set_batches" ENABLE ROW LEVEL SECURITY;
@@ -61065,9 +61470,21 @@ GRANT ALL ON FUNCTION "api"."cmd_lcia_result_publication_unpublish"("p_publicati
 
 
 
+REVOKE ALL ON FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") FROM PUBLIC;
+GRANT ALL ON FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") TO "api_internal_executor";
+GRANT ALL ON FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") TO "authenticated";
+
+
+
 REVOKE ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v2"("p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v2"("p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") TO "api_internal_executor";
 GRANT ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v2"("p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") TO "authenticated";
+
+
+
+REVOKE ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") FROM PUBLIC;
+GRANT ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") TO "api_internal_executor";
+GRANT ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") TO "authenticated";
 
 
 
@@ -61502,6 +61919,12 @@ GRANT ALL ON FUNCTION "api"."get_lcia_result_package_preview"("p_package_id" "uu
 
 
 
+REVOKE ALL ON FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") FROM PUBLIC;
+GRANT ALL ON FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") TO "api_internal_executor";
+GRANT ALL ON FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") TO "authenticated";
+
+
+
 REVOKE ALL ON FUNCTION "api"."get_lcia_scope_closure_check"("p_closure_check_id" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."get_lcia_scope_closure_check"("p_closure_check_id" "uuid") TO "api_internal_executor";
 GRANT ALL ON FUNCTION "api"."get_lcia_scope_closure_check"("p_closure_check_id" "uuid") TO "authenticated";
@@ -61671,6 +62094,12 @@ GRANT SELECT ON TABLE "public"."lifecyclemodels" TO "api_internal_executor";
 
 REVOKE ALL ON FUNCTION "api"."lifecyclemodels_embedding_ft_input"("proc" "public"."lifecyclemodels") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."lifecyclemodels_embedding_ft_input"("proc" "public"."lifecyclemodels") TO "api_internal_executor";
+
+
+
+REVOKE ALL ON FUNCTION "api"."list_lcia_result_sets"("p_limit" integer) FROM PUBLIC;
+GRANT ALL ON FUNCTION "api"."list_lcia_result_sets"("p_limit" integer) TO "api_internal_executor";
+GRANT ALL ON FUNCTION "api"."list_lcia_result_sets"("p_limit" integer) TO "authenticated";
 
 
 

--- a/supabase/workspace/schemas/api/functions/cmd_lcia_result_set_create/definition.sql
+++ b/supabase/workspace/schemas/api/functions/cmd_lcia_result_set_create/definition.sql
@@ -1,0 +1,48 @@
+CREATE OR REPLACE FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_result_set private.lcia_result_sets%rowtype;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+  if coalesce(length(btrim(p_name)), 0) = 0 then
+    return api.lcia_scope_closure_error(
+      'invalid_result_set_name', 400, 'Result set name is required'
+    );
+  end if;
+
+  insert into private.lcia_result_sets (name)
+  values (btrim(p_name))
+  returning * into v_result_set;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'schemaVersion', 'lcia.result-set.v1',
+      'resultSetId', v_result_set.id,
+      'name', v_result_set.name,
+      'createdAt', v_result_set.created_at
+    )
+  );
+end;
+$$;
+
+ALTER FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."cmd_lcia_result_set_create"("p_name" "text") TO "authenticated";

--- a/supabase/workspace/schemas/api/functions/cmd_lcia_scope_closure_check_request_v3/definition.sql
+++ b/supabase/workspace/schemas/api/functions/cmd_lcia_scope_closure_check_request_v3/definition.sql
@@ -1,0 +1,73 @@
+CREATE OR REPLACE FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb" DEFAULT '{}'::"jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    SET "statement_timeout" TO '60s'
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_result jsonb;
+  v_closure_check_id uuid;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+  if not exists (
+    select 1 from private.lcia_result_sets where id = p_result_set_id
+  ) then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  v_result := api.cmd_lcia_scope_closure_check_request_v2(
+    p_requested_scope,
+    p_request_idempotency_token,
+    coalesce(p_audit, '{}'::jsonb)
+      || jsonb_build_object('resultSetId', p_result_set_id)
+  );
+  if coalesce((v_result->>'ok')::boolean, false) is not true then
+    return v_result;
+  end if;
+
+  v_closure_check_id := nullif(
+    v_result->'data'->>'closureCheckId', ''
+  )::uuid;
+
+  update private.lcia_scope_closure_checks
+  set result_set_id = p_result_set_id,
+      updated_at = now()
+  where id = v_closure_check_id
+    and requested_by = v_actor
+    and (result_set_id is null or result_set_id = p_result_set_id);
+
+  if not found then
+    return api.lcia_scope_closure_error(
+      'closure_check_result_set_conflict', 409,
+      'Closure check is already bound to another result set'
+    );
+  end if;
+
+  return jsonb_set(
+    v_result,
+    '{data,resultSetId}',
+    to_jsonb(p_result_set_id),
+    true
+  );
+end;
+$$;
+
+ALTER FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."cmd_lcia_scope_closure_check_request_v3"("p_result_set_id" "uuid", "p_requested_scope" "jsonb", "p_request_idempotency_token" "text", "p_audit" "jsonb") TO "authenticated";

--- a/supabase/workspace/schemas/api/functions/get_lcia_result_set/definition.sql
+++ b/supabase/workspace/schemas/api/functions/get_lcia_result_set/definition.sql
@@ -1,0 +1,49 @@
+CREATE OR REPLACE FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_result_set private.lcia_result_sets%rowtype;
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  select *
+  into v_result_set
+  from private.lcia_result_sets
+  where id = p_result_set_id;
+
+  if v_result_set.id is null then
+    return api.lcia_scope_closure_error(
+      'result_set_not_found', 404, 'Result set not found'
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'schemaVersion', 'lcia.result-set.v1',
+      'resultSetId', v_result_set.id,
+      'name', v_result_set.name,
+      'createdAt', v_result_set.created_at
+    )
+  );
+end;
+$$;
+
+ALTER FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."get_lcia_result_set"("p_result_set_id" "uuid") TO "authenticated";

--- a/supabase/workspace/schemas/api/functions/list_lcia_result_sets/definition.sql
+++ b/supabase/workspace/schemas/api/functions/list_lcia_result_sets/definition.sql
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION "api"."list_lcia_result_sets"("p_limit" integer DEFAULT 100) RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'api', 'private', 'public', 'util', 'extensions', 'pg_temp'
+    AS $$
+declare
+  v_actor uuid := auth.uid();
+  v_limit integer := greatest(1, least(coalesce(p_limit, 100), 200));
+begin
+  if v_actor is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if not api.lcia_scope_closure_is_manager() then
+    return api.lcia_scope_closure_error(
+      'not_data_product_manager', 403,
+      'Data product manager role is required'
+    );
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'data', jsonb_build_object(
+      'items', coalesce((
+        select jsonb_agg(
+          jsonb_build_object(
+            'schemaVersion', 'lcia.result-set.v1',
+            'resultSetId', result_set.id,
+            'name', result_set.name,
+            'createdAt', result_set.created_at
+          )
+          order by result_set.created_at desc, result_set.id desc
+        )
+        from (
+          select id, name, created_at
+          from private.lcia_result_sets
+          order by created_at desc, id desc
+          limit v_limit
+        ) result_set
+      ), '[]'::jsonb)
+    )
+  );
+end;
+$$;
+
+ALTER FUNCTION "api"."list_lcia_result_sets"("p_limit" integer) OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."list_lcia_result_sets"("p_limit" integer) FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."list_lcia_result_sets"("p_limit" integer) TO "api_internal_executor";
+
+GRANT ALL ON FUNCTION "api"."list_lcia_result_sets"("p_limit" integer) TO "authenticated";

--- a/supabase/workspace/schemas/private/functions/get_task_summary_v2_feed_unversioned/definition.sql
+++ b/supabase/workspace/schemas/private/functions/get_task_summary_v2_feed_unversioned/definition.sql
@@ -2,21 +2,171 @@ CREATE OR REPLACE FUNCTION "private"."get_task_summary_v2_feed_unversioned"("p_c
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO 'private', 'api', 'public', 'util', 'extensions', 'pg_temp'
     AS $_$
-declare a uuid:=auth.uid(); lim integer:=greatest(1,least(coalesce(p_limit,50),200)); mgr boolean;
+declare
+  a uuid := auth.uid();
+  lim integer := greatest(1, least(coalesce(p_limit, 50), 200));
+  mgr boolean;
 begin
-  if a is null then return api.lcia_scope_closure_error('auth_required',401,'Authentication required'); end if;
-  if (p_cursor_updated_at is null)<>(p_cursor_job_id is null) then return api.lcia_scope_closure_error('invalid_task_cursor',400,'Task cursor fields must be supplied together'); end if;
-  mgr:=api.lcia_scope_closure_is_manager();
-  return jsonb_build_object('ok',true,'serverTime',now(),'data',coalesce((with x as (
-    select j.*,k.task_center_category,p.id package_id,coalesce(cd.id,cp.id,ck.id) closure_id,coalesce(cd.status,cp.status,ck.status) closure_status,coalesce(cd.certificate_status,cp.certificate_status,ck.certificate_status) certificate_status,greatest(j.updated_at,coalesce(cd.updated_at,'-infinity'::timestamptz),coalesce(cp.updated_at,'-infinity'::timestamptz),coalesce(ck.updated_at,'-infinity'::timestamptz),coalesce(p.updated_at,'-infinity'::timestamptz)) pu
-    from private.worker_jobs j join private.worker_job_kinds k on k.job_kind=j.job_kind
-      left join private.lcia_scope_closure_checks cd on cd.worker_job_id=j.id
-      left join private.lcia_result_packages p on p.build_worker_job_id=j.id
-      left join private.lcia_scope_closure_checks cp on cp.id=case when (j.payload_json->>'closure_check_id')~'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$' then (j.payload_json->>'closure_check_id')::uuid else null end
-      left join private.lcia_scope_closure_checks ck on ck.id=p.closure_check_id
-    where j.requested_by=a and (j.visibility='user' or (mgr and j.visibility='operator' and j.job_kind=any(array['lcia.scope_closure_check','lcia_result.package_build']))) and (p_category is null or k.task_center_category=p_category) and (p_job_kinds is null or j.job_kind=any(p_job_kinds)) and (p_statuses is null or j.status=any(p_statuses)) and (p_updated_since is null or greatest(j.updated_at,coalesce(cd.updated_at,'-infinity'::timestamptz),coalesce(cp.updated_at,'-infinity'::timestamptz),coalesce(ck.updated_at,'-infinity'::timestamptz),coalesce(p.updated_at,'-infinity'::timestamptz))>=p_updated_since) and (not p_root_only or j.root_job_id is null or j.root_job_id=j.id)
-  ), pg as (select * from x where p_cursor_updated_at is null or (pu,id)<(p_cursor_updated_at,p_cursor_job_id) order by pu desc,id desc limit lim+1), sh as (select * from pg order by pu desc,id desc limit lim)
-  select jsonb_build_object('items',coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object('jobId',id,'jobKind',job_kind,'category',task_center_category,'requestedBy',requested_by,'workerStatus',status,'phase',phase,'progressFraction',case when progress is null then null else greatest(0::numeric,least(progress,1::numeric)) end,'progressCounters',diagnostics->'progressCounters','domainStatus',coalesce(closure_status,result_json->>'status'),'domainValidity',certificate_status,'projectionUpdatedAt',pu,'title',coalesce(payload_json->>'name',job_kind),'blockerCodes',blocker_codes,'errorSummary',error_code,'capabilities',jsonb_build_object('canCancel',status in ('queued','running','waiting'),'canDownloadReport',closure_id is not null and closure_status in ('passed','blocked'),'canOpenWorkbench',task_center_category='data_product','canPreviewResult',package_id is not null),'deepLink',case when package_id is not null then jsonb_build_object('routeKey','data_product.package','params',jsonb_strip_nulls(jsonb_build_object('packageId',package_id,'closureCheckId',closure_id))) when closure_id is not null then jsonb_build_object('routeKey','data_product.closure_check','params',jsonb_build_object('closureCheckId',closure_id)) end,'closureCheckId',closure_id,'resultPackageId',package_id)) order by pu desc,id desc),'[]'::jsonb),'nextCursor',case when exists(select 1 from pg offset lim) then (select jsonb_build_object('updatedAt',pu,'jobId',id) from sh order by pu asc,id asc limit 1) else null end) from sh),jsonb_build_object('items','[]'::jsonb,'nextCursor',null)));
+  if a is null then
+    return api.lcia_scope_closure_error(
+      'auth_required', 401, 'Authentication required'
+    );
+  end if;
+  if (p_cursor_updated_at is null) <> (p_cursor_job_id is null) then
+    return api.lcia_scope_closure_error(
+      'invalid_task_cursor', 400,
+      'Task cursor fields must be supplied together'
+    );
+  end if;
+  mgr := api.lcia_scope_closure_is_manager();
+
+  return jsonb_build_object(
+    'ok', true,
+    'serverTime', now(),
+    'data', coalesce((
+      with x as (
+        select
+          j.*,
+          k.task_center_category,
+          p.id as package_id,
+          coalesce(cd.id, cp.id, ck.id) as closure_id,
+          coalesce(cd.status, cp.status, ck.status) as closure_status,
+          coalesce(
+            cd.certificate_status,
+            cp.certificate_status,
+            ck.certificate_status
+          ) as certificate_status,
+          result_set.id as result_set_id,
+          result_set.name as result_set_name,
+          greatest(
+            j.updated_at,
+            coalesce(cd.updated_at, '-infinity'::timestamptz),
+            coalesce(cp.updated_at, '-infinity'::timestamptz),
+            coalesce(ck.updated_at, '-infinity'::timestamptz),
+            coalesce(p.updated_at, '-infinity'::timestamptz)
+          ) as pu
+        from private.worker_jobs j
+        join private.worker_job_kinds k on k.job_kind = j.job_kind
+        left join private.lcia_scope_closure_checks cd
+          on cd.worker_job_id = j.id
+        left join private.lcia_result_packages p
+          on p.build_worker_job_id = j.id
+        left join private.lcia_scope_closure_checks cp
+          on cp.id = case
+            when (j.payload_json->>'closure_check_id')
+              ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+              then (j.payload_json->>'closure_check_id')::uuid
+            else null
+          end
+        left join private.lcia_scope_closure_checks ck
+          on ck.id = p.closure_check_id
+        left join private.lcia_result_sets result_set
+          on result_set.id = coalesce(
+            cd.result_set_id,
+            cp.result_set_id,
+            ck.result_set_id
+          )
+        where j.requested_by = a
+          and (
+            j.visibility = 'user'
+            or (
+              mgr
+              and j.visibility = 'operator'
+              and j.job_kind = any(array[
+                'lcia.scope_closure_check',
+                'lcia_result.package_build'
+              ])
+            )
+          )
+          and (p_category is null or k.task_center_category = p_category)
+          and (p_job_kinds is null or j.job_kind = any(p_job_kinds))
+          and (p_statuses is null or j.status = any(p_statuses))
+          and (
+            p_updated_since is null
+            or greatest(
+              j.updated_at,
+              coalesce(cd.updated_at, '-infinity'::timestamptz),
+              coalesce(cp.updated_at, '-infinity'::timestamptz),
+              coalesce(ck.updated_at, '-infinity'::timestamptz),
+              coalesce(p.updated_at, '-infinity'::timestamptz)
+            ) >= p_updated_since
+          )
+          and (
+            not p_root_only
+            or j.root_job_id is null
+            or j.root_job_id = j.id
+          )
+      ), pg as (
+        select *
+        from x
+        where p_cursor_updated_at is null
+          or (pu, id) < (p_cursor_updated_at, p_cursor_job_id)
+        order by pu desc, id desc
+        limit lim + 1
+      ), sh as (
+        select * from pg order by pu desc, id desc limit lim
+      )
+      select jsonb_build_object(
+        'items', coalesce(jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
+          'jobId', id,
+          'jobKind', job_kind,
+          'category', task_center_category,
+          'requestedBy', requested_by,
+          'workerStatus', status,
+          'phase', phase,
+          'progressFraction', case
+            when progress is null then null
+            else greatest(0::numeric, least(progress, 1::numeric))
+          end,
+          'progressCounters', diagnostics->'progressCounters',
+          'domainStatus', coalesce(closure_status, result_json->>'status'),
+          'domainValidity', certificate_status,
+          'projectionUpdatedAt', pu,
+          'title', coalesce(result_set_name, payload_json->>'name', job_kind),
+          'blockerCodes', blocker_codes,
+          'errorSummary', error_code,
+          'capabilities', jsonb_build_object(
+            'canCancel', status in ('queued', 'running', 'waiting'),
+            'canDownloadReport', closure_id is not null
+              and closure_status in ('passed', 'blocked'),
+            'canOpenWorkbench', task_center_category = 'data_product',
+            'canPreviewResult', package_id is not null
+          ),
+          'deepLink', case
+            when package_id is not null then jsonb_build_object(
+              'routeKey', 'data_product.package',
+              'params', jsonb_strip_nulls(jsonb_build_object(
+                'packageId', package_id,
+                'closureCheckId', closure_id,
+                'resultSetId', result_set_id
+              ))
+            )
+            when closure_id is not null then jsonb_build_object(
+              'routeKey', 'data_product.closure_check',
+              'params', jsonb_strip_nulls(jsonb_build_object(
+                'closureCheckId', closure_id,
+                'resultSetId', result_set_id
+              ))
+            )
+          end,
+          'closureCheckId', closure_id,
+          'resultPackageId', package_id,
+          'resultSetId', result_set_id,
+          'resultSetName', result_set_name
+        )) order by pu desc, id desc), '[]'::jsonb),
+        'nextCursor', case
+          when exists(select 1 from pg offset lim) then (
+            select jsonb_build_object('updatedAt', pu, 'jobId', id)
+            from sh
+            order by pu asc, id asc
+            limit 1
+          )
+          else null
+        end
+      )
+      from sh
+    ), jsonb_build_object('items', '[]'::jsonb, 'nextCursor', null))
+  );
 end;
 $_$;
 

--- a/supabase/workspace/schemas/private/tables/lcia_result_sets/indexes/lcia_result_sets_created_idx.sql
+++ b/supabase/workspace/schemas/private/tables/lcia_result_sets/indexes/lcia_result_sets_created_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "lcia_result_sets_created_idx" ON "private"."lcia_result_sets" USING "btree" ("created_at" DESC, "id" DESC);

--- a/supabase/workspace/schemas/private/tables/lcia_result_sets/table.sql
+++ b/supabase/workspace/schemas/private/tables/lcia_result_sets/table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "private"."lcia_result_sets" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "name" "text" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "lcia_result_sets_name_check" CHECK (("length"("btrim"("name")) > 0))
+);
+
+ALTER TABLE "private"."lcia_result_sets" OWNER TO "postgres";
+
+COMMENT ON TABLE "private"."lcia_result_sets" IS 'Named persistent containers for resuming the Data Processing workflow.';
+
+ALTER TABLE ONLY "private"."lcia_result_sets"
+    ADD CONSTRAINT "lcia_result_sets_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE "private"."lcia_result_sets" ENABLE ROW LEVEL SECURITY;

--- a/supabase/workspace/schemas/private/tables/lcia_scope_closure_checks/indexes/lcia_scope_closure_checks_result_set_idx.sql
+++ b/supabase/workspace/schemas/private/tables/lcia_scope_closure_checks/indexes/lcia_scope_closure_checks_result_set_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "lcia_scope_closure_checks_result_set_idx" ON "private"."lcia_scope_closure_checks" USING "btree" ("result_set_id") WHERE ("result_set_id" IS NOT NULL);

--- a/supabase/workspace/schemas/private/tables/lcia_scope_closure_checks/table.sql
+++ b/supabase/workspace/schemas/private/tables/lcia_scope_closure_checks/table.sql
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS "private"."lcia_scope_closure_checks" (
     "snapshot_build_contract_hash" "text",
     "complete_machine_result_artifact_id" "uuid",
     "valid_until" timestamp with time zone,
+    "result_set_id" "uuid",
     CONSTRAINT "lcia_scope_closure_checks_certificate_check" CHECK (("certificate_status" = ANY (ARRAY['pending'::"text", 'valid'::"text", 'stale'::"text", 'revoked'::"text", 'unavailable'::"text"]))),
     CONSTRAINT "lcia_scope_closure_checks_completeness_check" CHECK ((("scan_completeness" IS NULL) OR ("scan_completeness" = ANY (ARRAY['complete'::"text", 'incomplete'::"text", 'unknown'::"text"])))),
     CONSTRAINT "lcia_scope_closure_checks_effective_scope_manifest_check" CHECK ((("effective_scope_manifest" IS NULL) OR ("jsonb_typeof"("effective_scope_manifest") = 'object'::"text"))),
@@ -67,6 +68,9 @@ ALTER TABLE ONLY "private"."lcia_scope_closure_checks"
 
 ALTER TABLE ONLY "private"."lcia_scope_closure_checks"
     ADD CONSTRAINT "lcia_scope_closure_checks_report_artifact_id_fkey" FOREIGN KEY ("report_artifact_id") REFERENCES "private"."worker_job_artifacts"("id") ON DELETE RESTRICT;
+
+ALTER TABLE ONLY "private"."lcia_scope_closure_checks"
+    ADD CONSTRAINT "lcia_scope_closure_checks_result_set_id_fkey" FOREIGN KEY ("result_set_id") REFERENCES "private"."lcia_result_sets"("id") ON DELETE RESTRICT;
 
 ALTER TABLE ONLY "private"."lcia_scope_closure_checks"
     ADD CONSTRAINT "lcia_scope_closure_checks_reused_from_check_id_fkey" FOREIGN KEY ("reused_from_check_id") REFERENCES "private"."lcia_scope_closure_checks"("id") ON DELETE RESTRICT;


### PR DESCRIPTION
## Promotion Contract

- Base branch: `main`
- Source branch: `dev`
- Validated environment before promotion: local and PR Preview contract
- Root workspace integration expected: Yes, after the release commit reaches `main`

- [x] This PR promotes `dev` into `main`.
- [x] The `main...dev` delivery range contains only Database Engine Issue #507 / PR #508.
- [x] The integrated database contract was verified in `dev).
- [x] No Edge Function deployment is performed by this repository.

## Release Summary

Promote persistent ResultSet containers, role-gated create/list/get RPCs, ResultSet-aware Closure V3 admission, and safe task-feed recovery projections.

## Validation

- PR #508 merged into `dev` at `901e039bb407bb3aafb7c07ab97bc17435b55618`
- Rebuild and verify database contract: passed
- Gitleaks: passed
- focused ResultSet and full-schema pgTAP suites: passed
- generated five-schema workspace and Data API types: verified

## Integration / Follow-up

After merge, confirm the production Supabase GitHub integration applies the migration, then update the root workspace pointer together with Edge and Next release commits.

Refs #507
Refs tiangong-lca/workspace#599