### PR TITLE
Fix Portal search timeouts at Dev cardinality

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-27"
-lastReviewedCommit: "09ca0d6"
+lastReviewedCommit: "e46e205"
 lastReviewedNote: "Reviewed for the Portal projection recovery document catalog, coverage, routing intents, derivation-contract rule, and exact-head validation evidence."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -473,6 +473,10 @@ rules:
         kind: database-migration
       - path: supabase/migrations/20260826080403_portal_projection_facets.sql
         kind: database-migration
+      - path: supabase/migrations/20260827010000_portal_flow_embedding_eligibility_index.sql
+        kind: database-migration
+      - path: supabase/migrations/20260827010003_portal_flow_embedding_eligibility_guard.sql
+        kind: database-migration
       - path: supabase/tests/20260826_portal_candidate_first_search.sql
         kind: database-contract-test
       - path: supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-27"
-lastReviewedCommit: "d4c2976"
+lastReviewedCommit: "09ca0d6"
 lastReviewedNote: "Reviewed for the Portal projection recovery document catalog, coverage, routing intents, derivation-contract rule, and exact-head validation evidence."
 
 # Keep deterministic governance facts here.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-27"
-lastReviewedCommit: "450c04e"
+lastReviewedCommit: "d4c2976"
 lastReviewedNote: "Reviewed for the Portal projection recovery document catalog, coverage, routing intents, derivation-contract rule, and exact-head validation evidence."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 09ca0d6
+lastReviewedCommit: e46e205
 lastReviewedNote: "Reviewed for the immutable Portal projection manifest, sparse performance gates, and recovery contract; repository ownership and delivery boundaries are unchanged."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: d4c2976
+lastReviewedCommit: 09ca0d6
 lastReviewedNote: "Reviewed for the immutable Portal projection manifest, sparse performance gates, and recovery contract; repository ownership and delivery boundaries are unchanged."
 related:
   - .docpact/config.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 450c04e
+lastReviewedCommit: d4c2976
 lastReviewedNote: "Reviewed for the immutable Portal projection manifest, sparse performance gates, and recovery contract; repository ownership and delivery boundaries are unchanged."
 related:
   - .docpact/config.yaml

--- a/docs/agents/portal-projection-migration-recovery.md
+++ b/docs/agents/portal-projection-migration-recovery.md
@@ -1,6 +1,6 @@
 ---
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 450c04e
+lastReviewedCommit: d4c2976
 lastReviewedNote: "Reviewed for immutable v1 manifest diagnosis, fail-closed drift handling, and the required shadow-v2 semantic-change path."
 title: Portal Projection Migration Recovery
 docType: runbook

--- a/docs/agents/portal-projection-migration-recovery.md
+++ b/docs/agents/portal-projection-migration-recovery.md
@@ -1,6 +1,6 @@
 ---
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: d4c2976
+lastReviewedCommit: 09ca0d6
 lastReviewedNote: "Reviewed for immutable v1 manifest diagnosis, fail-closed drift handling, and the required shadow-v2 semantic-change path."
 title: Portal Projection Migration Recovery
 docType: runbook

--- a/docs/agents/portal-projection-migration-recovery.md
+++ b/docs/agents/portal-projection-migration-recovery.md
@@ -63,13 +63,13 @@ The rollout has five observable boundaries:
    existing Process/Flow source HNSW indexes and precede the
    transactional Search/Hybrid cutover at `20260826080400` and the transactional
    Facets cutover at `20260826080403`.
-5. `20260827010000` adds one narrow concurrent Flow source B-tree over
-   `(id, version)` only for state-100/200 rows with a non-null embedding.
+5. `20260827010000` adds one narrow concurrent Flow source B-tree on
+   `state_code`, restricted to state-100/200 rows with a non-null embedding.
    `20260827010003` transactionally verifies its exact table, keys, opclasses,
    predicate, owner, validity, and lack of INCLUDE/expression/options drift.
-   This post-cutover index accelerates the exact 0..199 embedding-universe
-   probe; it does not store vectors, rank semantic candidates, or alter API
-   semantics.
+   This low-selectivity membership index accelerates the exact 0..199
+   embedding-universe probe without becoming a covering id/version join path;
+   it does not store vectors, rank semantic candidates, or alter API semantics.
 
 The expand, reconcile, Search/Hybrid cutover, and Facets cutover files are
 explicit transactions. A statement or guard failure rolls back the entire

--- a/docs/agents/portal-projection-migration-recovery.md
+++ b/docs/agents/portal-projection-migration-recovery.md
@@ -27,6 +27,8 @@ checkPaths:
   - supabase/migrations/20260826080351_portal_projection_flow_pgroonga.sql
   - supabase/migrations/20260826080400_portal_projection_candidate_cutover.sql
   - supabase/migrations/20260826080403_portal_projection_facets.sql
+  - supabase/migrations/20260827010000_portal_flow_embedding_eligibility_index.sql
+  - supabase/migrations/20260827010003_portal_flow_embedding_eligibility_guard.sql
 related:
   - ../../AGENTS.md
   - repo-validation.md
@@ -43,7 +45,7 @@ branch controls before any hosted action.
 
 ## Safe rollout states
 
-The rollout has four observable boundaries:
+The rollout has five observable boundaries:
 
 1. `20260826060422` installs the immutable v1 derivation-contract registry,
    private projection, dormant projection Hybrid kernel, and source-table sync
@@ -61,6 +63,13 @@ The rollout has four observable boundaries:
    existing Process/Flow source HNSW indexes and precede the
    transactional Search/Hybrid cutover at `20260826080400` and the transactional
    Facets cutover at `20260826080403`.
+5. `20260827010000` adds one narrow concurrent Flow source B-tree over
+   `(id, version)` only for state-100/200 rows with a non-null embedding.
+   `20260827010003` transactionally verifies its exact table, keys, opclasses,
+   predicate, owner, validity, and lack of INCLUDE/expression/options drift.
+   This post-cutover index accelerates the exact 0..199 embedding-universe
+   probe; it does not store vectors, rank semantic candidates, or alter API
+   semantics.
 
 The expand, reconcile, Search/Hybrid cutover, and Facets cutover files are
 explicit transactions. A statement or guard failure rolls back the entire
@@ -82,7 +91,7 @@ error alone.
 ```sql
 select version
 from supabase_migrations.schema_migrations
-where version between '20260826060422' and '20260826080403'
+where version between '20260826060422' and '20260827010003'
 order by version;
 
 select contract_version,
@@ -123,7 +132,8 @@ where (
     namespace.nspname = 'public'
     and index_relation.relname in (
       'processes_embedding_ft_hnsw_idx',
-      'flows_embedding_ft_hnsw_idx'
+      'flows_embedding_ft_hnsw_idx',
+      'flows_portal_embedding_eligible_v1_idx'
     )
   )
 order by index_relation.relname;
@@ -230,6 +240,22 @@ migration command. The following cutover guard verifies the exact access
 method, indexed column, `extensions` opclass, partial predicate, validity state,
 and PGroonga options before any wrapper changes.
 
+The post-cutover Flow eligibility index uses the same controlled pattern, but
+its preconditions are different: `20260827010000` and `20260827010003` must both
+be absent, while the cutover and Facets migrations must already be recorded and
+their runtime probes healthy. Removing an unrecorded invalid, definition-drifted,
+or canonical-valid commit-gap copy restores only the pre-hotfix slow sparse
+probe; it does not revert API semantics. Run only this standalone cleanup:
+
+```sql
+drop index concurrently if exists
+  public.flows_portal_embedding_eligible_v1_idx;
+```
+
+Then rerun the normal migration command. Never drop the index when either
+post-cutover migration is recorded; diagnose or repair that state as separately
+tracked work.
+
 ## Uncertain expand commit
 
 The expand migration is transactional, so ordinary SQL failure leaves no Issue
@@ -293,7 +319,7 @@ Issue 531 Supabase project. It resets that local project and must never target a
 shared checkout, Preview, persistent Dev, or production.
 
 Formal recovery evidence requires clean HEAD, the reviewed Supabase CLI
-`2.109.1`, and byte equality plus one aggregate SHA-256 across all 257 migration
+`2.109.1`, and byte equality plus one aggregate SHA-256 across all 259 migration
 files in the repository and isolated project. Comparing only Issue 531 files is
 not sufficient because an earlier baseline change can alter recovery behavior.
 
@@ -310,7 +336,8 @@ races. Embedding-only changes remain source-HNSW owned and the final fence fills
 any independently missing card row. The regression also proves reconcile
 lock-timeout rollback, reconcile COMMIT/history retry, wrong and canonical-valid
 same-name index cleanup without history edits, cutover guard rollback,
-successful retry, and no-op repeat without rebuilding recorded indexes.
+post-cutover Flow eligibility build/guard recovery, successful retry, and no-op
+repeat without rebuilding recorded indexes.
 
 The pre-cutover raw-source
 `private.portal_public_hybrid_search_v1_impl(...)` is a rollback asset only

--- a/docs/agents/portal-projection-migration-recovery.md
+++ b/docs/agents/portal-projection-migration-recovery.md
@@ -1,6 +1,6 @@
 ---
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 09ca0d6
+lastReviewedCommit: e46e205
 lastReviewedNote: "Reviewed for immutable v1 manifest diagnosis, fail-closed drift handling, and the required shadow-v2 semantic-change path."
 title: Portal Projection Migration Recovery
 docType: runbook

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 09ca0d6
+lastReviewedCommit: e46e205
 lastReviewedNote: "Reviewed for the synchronized Portal candidate projection, versioned ANN semantics, immutable derivation manifest, and sparse fallback gates."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: d4c2976
+lastReviewedCommit: 09ca0d6
 lastReviewedNote: "Reviewed for the synchronized Portal candidate projection, versioned ANN semantics, immutable derivation manifest, and sparse fallback gates."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 450c04e
+lastReviewedCommit: d4c2976
 lastReviewedNote: "Reviewed for the synchronized Portal candidate projection, versioned ANN semantics, immutable derivation manifest, and sparse fallback gates."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -88,6 +88,13 @@ For Exchange support types whose TIDAS schemas do not carry a Process-style lice
 
 The Portal executor is NOLOGIN/NOBYPASSRLS and receives only the minimum object privileges required by the façades. External wrapper ACLs are revoked from `PUBLIC` and classified by exact signature in `private.api_capability_grants`; raw core tables receive no new anon policy.
 
+Flow semantic sparse-cardinality detection uses one narrow source-side partial
+B-tree on `(id, version)` for state-100/200 rows whose `embedding_ft` is non-null.
+It exists only to prove an exact 0..199 embedding universe without scanning the
+wide Flow heap. It contains no vector payload, does not replace the source HNSW
+ranking index, does not change projection semantics, and has no speculative
+Process counterpart because hosted Process evidence already meets budget.
+
 Edge consumers must obtain Data Product publication, package, and worker
 metadata through bounded `api.svc_data_product_*` projections rather than
 reading private relations. TIDAS package reads and import admission likewise

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -89,11 +89,12 @@ For Exchange support types whose TIDAS schemas do not carry a Process-style lice
 The Portal executor is NOLOGIN/NOBYPASSRLS and receives only the minimum object privileges required by the façades. External wrapper ACLs are revoked from `PUBLIC` and classified by exact signature in `private.api_capability_grants`; raw core tables receive no new anon policy.
 
 Flow semantic sparse-cardinality detection uses one narrow source-side partial
-B-tree on `(id, version)` for state-100/200 rows whose `embedding_ft` is non-null.
+B-tree on `state_code` for state-100/200 rows whose `embedding_ft` is non-null.
 It exists only to prove an exact 0..199 embedding universe without scanning the
-wide Flow heap. It contains no vector payload, does not replace the source HNSW
-ranking index, does not change projection semantics, and has no speculative
-Process counterpart because hosted Process evidence already meets budget.
+wide Flow heap. Its low-selectivity key avoids a covering id/version exact-join
+path. It contains no vector payload, does not replace the source HNSW ranking
+index, does not change projection semantics, and has no speculative Process
+counterpart because hosted Process evidence already meets budget.
 
 Edge consumers must obtain Data Product publication, package, and worker
 metadata through bounded `api.svc_data_product_*` projections rather than

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,7 +32,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 450c04e
+lastReviewedCommit: d4c2976
 lastReviewedNote: "Reviewed for the complete Portal request-shape, sparse semantic, immutable manifest, recovery, and promotion proof matrix."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,7 +32,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: d4c2976
+lastReviewedCommit: 09ca0d6
 lastReviewedNote: "Reviewed for the complete Portal request-shape, sparse semantic, immutable manifest, recovery, and promotion proof matrix."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,7 +32,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 09ca0d6
+lastReviewedCommit: e46e205
 lastReviewedNote: "Reviewed for the complete Portal request-shape, sparse semantic, immutable manifest, recovery, and promotion proof matrix."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -102,6 +102,18 @@ need Git provenance still check out full history (`fetch-depth: 0`).
 | `supabase/workspace/**` | prove whether the touched file is generated or stable | if stable manual overlay files changed, explain how they feed migration generation | Generated files alone are not sufficient evidence of a durable schema change. |
 | repo docs only | `scripts/docpact lint --root . --files "<csv>" --mode enforce` | `scripts/docpact validate-config --root . --strict` when `.docpact/config.yaml` changes | Refresh review metadata even when prose stays unchanged. |
 
+For the Portal Flow embedding-eligibility hotfix, sparse-zero and sparse-199
+profiles must naturally name `flows_portal_embedding_eligible_v1_idx` for the
+exact `state_code IN (100,200) AND embedding_ft IS NOT NULL LIMIT 200` universe
+probe, expose parseable buffers/execution, and show no Flow heap Seq Scan or
+temp/disk spill. The release profile records the natural full-vector plan and
+keeps existing writer/ANN/exact budgets. After persistent Dev deploy, a
+zero-embedding Flow probe plus at least five anonymous Hybrid samples must show
+p95 <= 6 seconds, every call < 8 seconds, and no `portal hybrid unavailable`;
+record index validity/size, database size before/after when available, and both
+advisor classes. Process remains index-free unless separate hosted evidence
+justifies shared write amplification.
+
 ## SQL And Offline Node Contract Notes
 
 The repo stores SQL assertions and narrow offline Node contracts under `supabase/tests/**`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 09ca0d6
+lastReviewedCommit: e46e205
 lastReviewedNote: "Reviewed for the Portal projection manifest checker and named release/sparse benchmark profiles; schema-workspace helper behavior is unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: d4c2976
+lastReviewedCommit: 09ca0d6
 lastReviewedNote: "Reviewed for the Portal projection manifest checker and named release/sparse benchmark profiles; schema-workspace helper behavior is unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 450c04e
+lastReviewedCommit: d4c2976
 lastReviewedNote: "Reviewed for the Portal projection manifest checker and named release/sparse benchmark profiles; schema-workspace helper behavior is unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -134,7 +134,9 @@ Both lexical probes require the exact needle fixture identity and no spill.
 Every profile also records the exact Flow embedding-universe probe. Sparse
 profiles must naturally use the narrow partial eligibility B-tree and may not
 scan the wide Flow heap; release records the natural full-vector plan without
-forcing that index.
+forcing that index. Only release must name both source HNSW indexes; sparse
+source probes may choose an eligibility/empty-set plan but still require
+buffers, execution time, and no temp/disk spill.
 
 ### `check_portal_projection_manifest.py`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,11 +90,12 @@ attested, isolated local Supabase project. It uses live concurrent connections
 to prove valid-update, delete, state-invalidation, key-change, and
 embedding-only races; forces reconcile lock-timeout and cutover-guard failures;
 and verifies same-history retry, controlled same-name concurrent-index cleanup,
-and no-op repeat without index rebuild. See
+post-cutover Flow eligibility guard rollback, and no-op repeat without index
+rebuild. See
 `docs/agents/portal-projection-migration-recovery.md` for the required
 environment and recovery boundaries. Formal evidence additionally requires
 clean HEAD, Supabase CLI `2.109.1`, and byte equality plus aggregate SHA-256 for
-the complete 257-file migration tree.
+the complete 259-file migration tree.
 
 ### `run_portal_projection_benchmark.sh`
 
@@ -130,13 +131,18 @@ the smaller Process cardinality records its natural-cost plan without forcing
 one index, while the migration catalog guard proves its PGroonga index and the
 named timings independently cover Process performance, ordering, and cursors.
 Both lexical probes require the exact needle fixture identity and no spill.
+Every profile also records the exact Flow embedding-universe probe. Sparse
+profiles must naturally use the narrow partial eligibility B-tree and may not
+scan the wide Flow heap; release records the natural full-vector plan without
+forcing that index.
 
 ### `check_portal_projection_manifest.py`
 
 Checks that the committed Portal projection-v1 digest and exact eleven-function
 closure remain present, that no later migration creates, replaces, drops, or
 alters a v1 closure/control function, and that reconcile/Search-Hybrid/Facets
-retain their required runtime guards.
+retain their required runtime guards. It also binds the post-cutover Flow
+eligibility index and its exact catalog guard without changing the v1 digest.
 
 ```bash
 python3 scripts/check_portal_projection_manifest.py

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: d4c2976
+lastReviewedCommit: 09ca0d6
 lastReviewedNote: "已复核 Portal projection manifest 检查器与命名 release/sparse benchmark profile；schema-workspace helper 行为不变。"
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 450c04e
+lastReviewedCommit: d4c2976
 lastReviewedNote: "已复核 Portal projection manifest 检查器与命名 release/sparse benchmark profile；schema-workspace helper 行为不变。"
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 09ca0d6
+lastReviewedCommit: e46e205
 lastReviewedNote: "已复核 Portal projection manifest 检查器与命名 release/sparse benchmark profile；schema-workspace helper 行为不变。"
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -117,7 +117,9 @@ temp/disk spill。每次运行必须使用新的 mode-0700 输出目录。正式
 必须满足精确 needle fixture identity 且无 spill。
 每个 profile 还会记录精确的 Flow embedding universe probe。sparse profile 必须
 自然命中窄 partial eligibility B-tree，且不得扫描宽 Flow heap；release profile
-记录全量 vector 的自然计划，不强制使用该索引。
+记录全量 vector 的自然计划，不强制使用该索引。只有 release 必须命名两个 source
+HNSW index；sparse source probe 可以选择 eligibility/empty-set plan，但仍必须提供
+buffers、execution time 且没有 temp/disk spill。
 
 ### `check_portal_projection_manifest.py`
 

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -82,9 +82,9 @@ scripts/test_search_text_array_upgrade.sh
 上线。脚本使用真实并发连接覆盖有效更新、删除、状态失效、主键变更以及仅 embedding
 更新竞态；主动制造 reconcile 锁超时与 cutover guard 失败；并证明相同 migration
 history 下可重试、同名 concurrent index 可受控清理，以及已记录迁移重复执行不会重建
-索引。所需环境变量与恢复边界见
+索引，并覆盖 cutover 后 Flow eligibility guard 回滚。所需环境变量与恢复边界见
 `docs/agents/portal-projection-migration-recovery.md`。正式证据还要求干净 HEAD、
-Supabase CLI `2.109.1`，以及完整 257-file migration tree 的逐字相等和 aggregate
+Supabase CLI `2.109.1`，以及完整 259-file migration tree 的逐字相等和 aggregate
 SHA-256。
 
 ### `run_portal_projection_benchmark.sh`
@@ -115,12 +115,16 @@ temp/disk spill。每次运行必须使用新的 mode-0700 输出目录。正式
 因此记录自然成本计划而不强制某个索引，迁移期 catalog guard 负责证明其 PGroonga
 索引，命名 timing 独立覆盖 Process 性能、排序和 cursor。两类 lexical probe 都
 必须满足精确 needle fixture identity 且无 spill。
+每个 profile 还会记录精确的 Flow embedding universe probe。sparse profile 必须
+自然命中窄 partial eligibility B-tree，且不得扫描宽 Flow heap；release profile
+记录全量 vector 的自然计划，不强制使用该索引。
 
 ### `check_portal_projection_manifest.py`
 
 验证已提交的 Portal projection-v1 digest 与十一函数闭包仍完整，禁止后续
 migration 创建、替换、删除或修改 v1 闭包/控制函数，并确认 reconcile、
-Search/Hybrid 与 Facets 保留所需 runtime guard。
+Search/Hybrid 与 Facets 保留所需 runtime guard。它还绑定 cutover 后的 Flow
+eligibility index 及其精确 catalog guard，同时保持 v1 digest 不变。
 
 ```bash
 python3 scripts/check_portal_projection_manifest.py

--- a/scripts/check_portal_projection_manifest.py
+++ b/scripts/check_portal_projection_manifest.py
@@ -11,6 +11,12 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MIGRATIONS_DIR = REPO_ROOT / "supabase" / "migrations"
 ANCHOR_NAME = "20260826060422_portal_candidate_first_search.sql"
+FLOW_ELIGIBILITY_INDEX_NAME = (
+    "20260827010000_portal_flow_embedding_eligibility_index.sql"
+)
+FLOW_ELIGIBILITY_GUARD_NAME = (
+    "20260827010003_portal_flow_embedding_eligibility_guard.sql"
+)
 MANIFEST_SHA256 = (
     "b5e0aff9abbffcc8d2dacaf559a5d1a8c993c20b647d0c70f0e4fa18eb06d2dc"
 )
@@ -149,6 +155,64 @@ def main() -> int:
         if not backfill_timeout_pattern.search(executable_sql):
             violations.append(
                 f"{migration.name}: missing outer 5s lock / 120s statement timeout"
+            )
+
+    eligibility_index = MIGRATIONS_DIR / FLOW_ELIGIBILITY_INDEX_NAME
+    if not eligibility_index.is_file():
+        violations.append(
+            f"missing Flow embedding eligibility migration: {FLOW_ELIGIBILITY_INDEX_NAME}"
+        )
+    else:
+        eligibility_sql = sql_without_comments(
+            eligibility_index.read_text(encoding="utf-8")
+        )
+        eligibility_pattern = re.compile(
+            r"\s*create\s+index\s+concurrently\s+"
+            r"flows_portal_embedding_eligible_v1_idx\s+"
+            r"on\s+public[.]flows\s+using\s+btree\s*"
+            r"[(]\s*id\s*,\s*version\s*[)]\s*"
+            r"where\s+state_code\s+in\s*[(]\s*100\s*,\s*200\s*[)]\s*"
+            r"and\s+embedding_ft\s+is\s+not\s+null\s*;\s*",
+            flags=re.IGNORECASE,
+        )
+        if not eligibility_pattern.fullmatch(eligibility_sql):
+            violations.append(
+                f"{FLOW_ELIGIBILITY_INDEX_NAME}: must be one exact concurrent "
+                "partial btree statement without IF NOT EXISTS"
+            )
+
+    eligibility_guard = MIGRATIONS_DIR / FLOW_ELIGIBILITY_GUARD_NAME
+    if not eligibility_guard.is_file():
+        violations.append(
+            f"missing Flow embedding eligibility guard: {FLOW_ELIGIBILITY_GUARD_NAME}"
+        )
+    else:
+        guard_sql = sql_without_comments(
+            eligibility_guard.read_text(encoding="utf-8")
+        ).lower()
+        required_guard_tokens = (
+            "set local lock_timeout = '5s'",
+            "set local statement_timeout = '8s'",
+            "flows_portal_embedding_eligible_v1_idx",
+            "index_catalog.indisvalid",
+            "index_catalog.indisready",
+            "index_catalog.indislive",
+            "index_catalog.indnkeyatts = 2",
+            "index_catalog.indnatts = 2",
+            "first_key.attname = 'id'",
+            "second_key.attname = 'version'",
+            "first_opclass.opcname = 'uuid_ops'",
+            "second_opclass.opcname = 'bpchar_ops'",
+            "((state_code=any(array[100,200]))and(embedding_ftisnotnull))",
+            "portal flow embedding eligibility index drifted",
+        )
+        missing_guard_tokens = [
+            token for token in required_guard_tokens if token not in guard_sql
+        ]
+        if missing_guard_tokens:
+            violations.append(
+                f"{FLOW_ELIGIBILITY_GUARD_NAME}: missing guard tokens "
+                + ", ".join(missing_guard_tokens)
             )
 
     if violations:

--- a/scripts/check_portal_projection_manifest.py
+++ b/scripts/check_portal_projection_manifest.py
@@ -201,8 +201,12 @@ def main() -> int:
             "index_catalog.indnatts = 2",
             "first_key.attname = 'id'",
             "second_key.attname = 'version'",
+            "first_opclass_namespace.nspname = 'pg_catalog'",
+            "second_opclass_namespace.nspname = 'pg_catalog'",
             "first_opclass.opcname = 'uuid_ops'",
             "second_opclass.opcname = 'bpchar_ops'",
+            "first_opclass.opcintype = 'pg_catalog.uuid'::pg_catalog.regtype",
+            "second_opclass.opcintype = 'pg_catalog.bpchar'::pg_catalog.regtype",
             "((state_code=any(array[100,200]))and(embedding_ftisnotnull))",
             "portal flow embedding eligibility index drifted",
         )

--- a/scripts/check_portal_projection_manifest.py
+++ b/scripts/check_portal_projection_manifest.py
@@ -170,7 +170,7 @@ def main() -> int:
             r"\s*create\s+index\s+concurrently\s+"
             r"flows_portal_embedding_eligible_v1_idx\s+"
             r"on\s+public[.]flows\s+using\s+btree\s*"
-            r"[(]\s*id\s*,\s*version\s*[)]\s*"
+            r"[(]\s*state_code\s*[)]\s*"
             r"where\s+state_code\s+in\s*[(]\s*100\s*,\s*200\s*[)]\s*"
             r"and\s+embedding_ft\s+is\s+not\s+null\s*;\s*",
             flags=re.IGNORECASE,
@@ -197,16 +197,12 @@ def main() -> int:
             "index_catalog.indisvalid",
             "index_catalog.indisready",
             "index_catalog.indislive",
-            "index_catalog.indnkeyatts = 2",
-            "index_catalog.indnatts = 2",
-            "first_key.attname = 'id'",
-            "second_key.attname = 'version'",
+            "index_catalog.indnkeyatts = 1",
+            "index_catalog.indnatts = 1",
+            "first_key.attname = 'state_code'",
             "first_opclass_namespace.nspname = 'pg_catalog'",
-            "second_opclass_namespace.nspname = 'pg_catalog'",
-            "first_opclass.opcname = 'uuid_ops'",
-            "second_opclass.opcname = 'bpchar_ops'",
-            "first_opclass.opcintype = 'pg_catalog.uuid'::pg_catalog.regtype",
-            "second_opclass.opcintype = 'pg_catalog.bpchar'::pg_catalog.regtype",
+            "first_opclass.opcname = 'int4_ops'",
+            "first_opclass.opcintype = 'pg_catalog.int4'::pg_catalog.regtype",
             "((state_code=any(array[100,200]))and(embedding_ftisnotnull))",
             "portal flow embedding eligibility index drifted",
         )

--- a/scripts/run_portal_projection_benchmark.sh
+++ b/scripts/run_portal_projection_benchmark.sh
@@ -312,19 +312,29 @@ fi
 docker cp "$container_name:$container_explain" "$explain_log" >/dev/null
 chmod 600 "$explain_log"
 
-# The ~17k-row Process lexical leaf has two valid natural-cost plans.  SQL
-# records and bounds whichever the planner selects; the fresh migration guard
-# separately validates its PGroonga catalog.  Flow must name PGroonga here.
-for expected_index in \
-  portal_catalog_search_flow_document_v1_pgroonga \
-  processes_embedding_ft_hnsw_idx \
-  flows_embedding_ft_hnsw_idx
-do
+# The ~17k-row Process lexical leaf has two valid natural-cost plans. SQL
+# records and bounds whichever the planner selects; Flow must name PGroonga.
+for expected_index in portal_catalog_search_flow_document_v1_pgroonga; do
   if ! grep -q "$expected_index" "$explain_log"; then
     echo "missing representative plan index: $expected_index" >&2
     exit 1
   fi
 done
+
+# Empty/sparse source universes may naturally use an eligibility/empty-set
+# plan. The full-vector release profile must still exercise both source HNSW
+# indexes; sparse profiles separately require the Flow eligibility B-tree.
+if [[ "$release_profile" == "true" ]]; then
+  for expected_index in \
+    processes_embedding_ft_hnsw_idx \
+    flows_embedding_ft_hnsw_idx
+  do
+    if ! grep -q "$expected_index" "$explain_log"; then
+      echo "release profile missed source HNSW index: $expected_index" >&2
+      exit 1
+    fi
+  done
+fi
 
 if [[ "$sparse_profile" == "true" ]] \
    && ! grep -q "flows_portal_embedding_eligible_v1_idx" "$explain_log"; then

--- a/scripts/run_portal_projection_benchmark.sh
+++ b/scripts/run_portal_projection_benchmark.sh
@@ -51,9 +51,9 @@ fi
 shopt -s nullglob
 repo_migrations=("$repo_root"/supabase/migrations/*.sql)
 test_migrations=("$test_workdir"/supabase/migrations/*.sql)
-if [[ "${#repo_migrations[@]}" -ne 257 \
-   || "${#test_migrations[@]}" -ne 257 ]]; then
-  echo "complete migration tree must contain exactly 257 files" >&2
+if [[ "${#repo_migrations[@]}" -ne 259 \
+   || "${#test_migrations[@]}" -ne 259 ]]; then
+  echo "complete migration tree must contain exactly 259 files" >&2
   exit 2
 fi
 migration_manifest_payload=""
@@ -265,7 +265,7 @@ echo "Supabase CLI: $supabase_cli_version" | tee "$results_log"
 echo "Benchmark target: $project_id" | tee -a "$results_log"
 echo "Benchmark profile: $profile_name" | tee -a "$results_log"
 echo "Repository HEAD: $repository_head" | tee -a "$results_log"
-echo "Migration tree SHA-256 (257 files): $migration_tree_sha256" \
+echo "Migration tree SHA-256 (259 files): $migration_tree_sha256" \
   | tee -a "$results_log"
 echo "Benchmark SQL SHA-256: $benchmark_sql_sha256" | tee -a "$results_log"
 echo "Benchmark runner SHA-256: $benchmark_runner_sha256" \
@@ -325,6 +325,12 @@ do
     exit 1
   fi
 done
+
+if [[ "$sparse_profile" == "true" ]] \
+   && ! grep -q "flows_portal_embedding_eligible_v1_idx" "$explain_log"; then
+  echo "sparse profile missed Flow embedding eligibility btree" >&2
+  exit 1
+fi
 
 docker exec "$container_name" rm -f "$container_explain" >/dev/null
 "$supabase_cli" --workdir "$test_workdir" \

--- a/scripts/test_portal_projection_upgrade_recovery.sh
+++ b/scripts/test_portal_projection_upgrade_recovery.sh
@@ -780,7 +780,9 @@ apply_pending
 reset_to 20260826080403
 run_psql <<'SQL'
 create index flows_portal_embedding_eligible_v1_idx
-on public.flows (id);
+on public.flows (id, version)
+where state_code in (100, 200)
+  and embedding_ft is not null;
 SQL
 
 eligibility_name_log_since="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"

--- a/scripts/test_portal_projection_upgrade_recovery.sh
+++ b/scripts/test_portal_projection_upgrade_recovery.sh
@@ -26,9 +26,9 @@ fi
 shopt -s nullglob
 repo_migrations=("$repo_root"/supabase/migrations/*.sql)
 test_migrations=("$test_workdir"/supabase/migrations/*.sql)
-if [[ "${#repo_migrations[@]}" -ne 257 \
-   || "${#test_migrations[@]}" -ne 257 ]]; then
-  echo "complete migration tree must contain exactly 257 files" >&2
+if [[ "${#repo_migrations[@]}" -ne 259 \
+   || "${#test_migrations[@]}" -ne 259 ]]; then
+  echo "complete migration tree must contain exactly 259 files" >&2
   exit 2
 fi
 migration_manifest_payload=""
@@ -211,7 +211,7 @@ fi
 echo "Supabase CLI: $supabase_cli_version"
 echo "Recovery target: $project_id"
 echo "Repository HEAD: $repository_head"
-echo "Migration tree SHA-256 (257 files): $migration_tree_sha256"
+echo "Migration tree SHA-256 (259 files): $migration_tree_sha256"
 
 # Breakpoint 1: expand plus every bounded backfill is recorded, while old API
 # wrappers remain authoritative. Exercise all five write/snapshot races before
@@ -772,6 +772,118 @@ rename to portal_catalog_search_process_document_v1_pgroonga;
 SQL
 apply_pending
 
+# Breakpoint 4: the post-cutover sparse-Flow eligibility index is an online,
+# single-statement migration with a separate transactional catalog guard.
+# Wrong-name collisions and a canonical COMMIT/history gap must require the
+# same explicit standalone cleanup before unchanged-ledger retry. A guard
+# failure must not record its migration or disturb the already-cut-over API.
+reset_to 20260826080403
+run_psql <<'SQL'
+create index flows_portal_embedding_eligible_v1_idx
+on public.flows (id);
+SQL
+
+eligibility_name_log_since="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+if apply_pending >"$race_log_dir/expected-eligibility-name-failure.log" 2>&1; then
+  echo "eligibility migration unexpectedly replaced a same-name index" >&2
+  exit 1
+fi
+docker logs --since "$eligibility_name_log_since" "$container_name" \
+  >>"$race_log_dir/expected-eligibility-name-failure.log" 2>&1
+assert_log_contains \
+  "$race_log_dir/expected-eligibility-name-failure.log" \
+  '42P07|already exists|duplicate_table' \
+  'Flow eligibility same-name failure'
+assert_sql "
+  not exists (
+    select 1 from supabase_migrations.schema_migrations
+    where version in ('20260827010000', '20260827010003')
+  )
+" "failed eligibility build unexpectedly advanced migration history"
+run_psql <<'SQL'
+drop index concurrently if exists
+  public.flows_portal_embedding_eligible_v1_idx;
+SQL
+apply_pending
+
+assert_sql "
+  exists (
+    select 1 from supabase_migrations.schema_migrations
+    where version = '20260827010000'
+  )
+  and exists (
+    select 1 from supabase_migrations.schema_migrations
+    where version = '20260827010003'
+  )
+  and (select access_method.amname = 'btree'
+       from pg_catalog.pg_class as index_relation
+       join pg_catalog.pg_am as access_method
+         on access_method.oid = index_relation.relam
+       where index_relation.oid =
+         'public.flows_portal_embedding_eligible_v1_idx'::regclass)
+" "same-name eligibility recovery did not install and guard the btree"
+
+reset_to 20260826080403
+apply_sql_file \
+  "$repo_root/supabase/migrations/20260827010000_portal_flow_embedding_eligibility_index.sql" \
+  >"$race_log_dir/eligibility-canonical-commit-gap.log" 2>&1
+assert_sql "
+  not exists (
+    select 1 from supabase_migrations.schema_migrations
+    where version = '20260827010000'
+  )
+  and (select index_catalog.indisvalid
+         and index_catalog.indisready
+         and index_catalog.indislive
+       from pg_catalog.pg_index as index_catalog
+       where index_catalog.indexrelid =
+         'public.flows_portal_embedding_eligible_v1_idx'::regclass)
+" "canonical eligibility commit-gap fixture is not exact"
+eligibility_commit_log_since="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+if apply_pending >"$race_log_dir/expected-eligibility-commit-gap-failure.log" 2>&1; then
+  echo "canonical unrecorded eligibility index unexpectedly advanced" >&2
+  exit 1
+fi
+docker logs --since "$eligibility_commit_log_since" "$container_name" \
+  >>"$race_log_dir/expected-eligibility-commit-gap-failure.log" 2>&1
+assert_log_contains \
+  "$race_log_dir/expected-eligibility-commit-gap-failure.log" \
+  '42P07|already exists|duplicate_table' \
+  'Flow eligibility canonical history-gap failure'
+run_psql <<'SQL'
+drop index concurrently if exists
+  public.flows_portal_embedding_eligible_v1_idx;
+SQL
+apply_pending
+
+reset_to 20260827010000
+run_psql <<'SQL'
+alter index public.flows_portal_embedding_eligible_v1_idx
+rename to flows_portal_embedding_eligible_v1_idx_held;
+SQL
+eligibility_guard_log_since="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+if apply_pending >"$race_log_dir/expected-eligibility-guard-failure.log" 2>&1; then
+  echo "eligibility guard unexpectedly accepted a missing canonical index" >&2
+  exit 1
+fi
+docker logs --since "$eligibility_guard_log_since" "$container_name" \
+  >>"$race_log_dir/expected-eligibility-guard-failure.log" 2>&1
+assert_log_contains \
+  "$race_log_dir/expected-eligibility-guard-failure.log" \
+  'Portal Flow embedding eligibility index drifted|55000|P0001' \
+  'Flow eligibility catalog-guard failure'
+assert_sql "
+  not exists (
+    select 1 from supabase_migrations.schema_migrations
+    where version = '20260827010003'
+  )
+" "failed eligibility guard unexpectedly advanced migration history"
+run_psql <<'SQL'
+alter index public.flows_portal_embedding_eligible_v1_idx_held
+rename to flows_portal_embedding_eligible_v1_idx;
+SQL
+apply_pending
+
 run_psql <<'SQL'
 grant api_internal_executor to postgres;
 set role api_internal_executor;
@@ -822,7 +934,8 @@ index_oids_before="$(scalar_sql "
       namespace.nspname = 'public'
       and index_relation.relname in (
         'processes_embedding_ft_hnsw_idx',
-        'flows_embedding_ft_hnsw_idx'
+        'flows_embedding_ft_hnsw_idx',
+        'flows_portal_embedding_eligible_v1_idx'
       )
     )
 ")"
@@ -841,12 +954,13 @@ index_count_before="$(scalar_sql "
       namespace.nspname = 'public'
       and index_relation.relname in (
         'processes_embedding_ft_hnsw_idx',
-        'flows_embedding_ft_hnsw_idx'
+        'flows_embedding_ft_hnsw_idx',
+        'flows_portal_embedding_eligible_v1_idx'
       )
     )
 ")"
-if [[ "$index_count_before" != "4" \
-   || ! "$index_oids_before" =~ ^[0-9]+,[0-9]+,[0-9]+,[0-9]+$ ]]; then
+if [[ "$index_count_before" != "5" \
+   || ! "$index_oids_before" =~ ^[0-9]+,[0-9]+,[0-9]+,[0-9]+,[0-9]+$ ]]; then
   echo "post-cutover index identity evidence is incomplete" >&2
   exit 1
 fi
@@ -866,7 +980,8 @@ index_oids_after="$(scalar_sql "
       namespace.nspname = 'public'
       and index_relation.relname in (
         'processes_embedding_ft_hnsw_idx',
-        'flows_embedding_ft_hnsw_idx'
+        'flows_embedding_ft_hnsw_idx',
+        'flows_portal_embedding_eligible_v1_idx'
       )
     )
 ")"

--- a/supabase/migrations/20260827010000_portal_flow_embedding_eligibility_index.sql
+++ b/supabase/migrations/20260827010000_portal_flow_embedding_eligibility_index.sql
@@ -1,0 +1,4 @@
+create index concurrently flows_portal_embedding_eligible_v1_idx
+on public.flows using btree (id, version)
+where state_code in (100, 200)
+  and embedding_ft is not null;

--- a/supabase/migrations/20260827010000_portal_flow_embedding_eligibility_index.sql
+++ b/supabase/migrations/20260827010000_portal_flow_embedding_eligibility_index.sql
@@ -1,4 +1,4 @@
 create index concurrently flows_portal_embedding_eligible_v1_idx
-on public.flows using btree (id, version)
+on public.flows using btree (state_code)
 where state_code in (100, 200)
   and embedding_ft is not null;

--- a/supabase/migrations/20260827010003_portal_flow_embedding_eligibility_guard.sql
+++ b/supabase/migrations/20260827010003_portal_flow_embedding_eligibility_guard.sql
@@ -1,0 +1,69 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '8s';
+
+do $portal_flow_embedding_eligibility_guard$
+declare
+  v_index regclass := pg_catalog.to_regclass(
+    'public.flows_portal_embedding_eligible_v1_idx'
+  );
+begin
+  if v_index is null
+     or not exists (
+       select 1
+       from pg_catalog.pg_index as index_catalog
+       join pg_catalog.pg_class as index_relation
+         on index_relation.oid = index_catalog.indexrelid
+       join pg_catalog.pg_class as source_relation
+         on source_relation.oid = index_catalog.indrelid
+       join pg_catalog.pg_namespace as source_namespace
+         on source_namespace.oid = source_relation.relnamespace
+       join pg_catalog.pg_am as access_method
+         on access_method.oid = index_relation.relam
+       join pg_catalog.pg_attribute as first_key
+         on first_key.attrelid = source_relation.oid
+        and first_key.attnum = index_catalog.indkey[0]
+       join pg_catalog.pg_attribute as second_key
+         on second_key.attrelid = source_relation.oid
+        and second_key.attnum = index_catalog.indkey[1]
+       join pg_catalog.pg_opclass as first_opclass
+         on first_opclass.oid = index_catalog.indclass[0]
+       join pg_catalog.pg_opclass as second_opclass
+         on second_opclass.oid = index_catalog.indclass[1]
+       where index_catalog.indexrelid = v_index
+         and source_namespace.nspname = 'public'
+         and source_relation.relname = 'flows'
+         and access_method.amname = 'btree'
+         and index_catalog.indisvalid
+         and index_catalog.indisready
+         and index_catalog.indislive
+         and not index_catalog.indisunique
+         and index_catalog.indnkeyatts = 2
+         and index_catalog.indnatts = 2
+         and index_catalog.indexprs is null
+         and first_key.attname = 'id'
+         and second_key.attname = 'version'
+         and first_opclass.opcname = 'uuid_ops'
+         and second_opclass.opcname = 'bpchar_ops'
+         and pg_catalog.regexp_replace(
+           pg_catalog.lower(pg_catalog.pg_get_expr(
+             index_catalog.indpred,
+             index_catalog.indrelid
+           )),
+           '[[:space:]]',
+           '',
+           'g'
+         ) = '((state_code=any(array[100,200]))and(embedding_ftisnotnull))'
+         and index_relation.relowner = source_relation.relowner
+         and index_relation.reloptions is null
+         and index_relation.relacl is null
+     ) then
+    raise exception using
+      errcode = '55000',
+      message = 'Portal Flow embedding eligibility index drifted';
+  end if;
+end
+$portal_flow_embedding_eligibility_guard$;
+
+commit;

--- a/supabase/migrations/20260827010003_portal_flow_embedding_eligibility_guard.sql
+++ b/supabase/migrations/20260827010003_portal_flow_embedding_eligibility_guard.sql
@@ -29,8 +29,12 @@ begin
         and second_key.attnum = index_catalog.indkey[1]
        join pg_catalog.pg_opclass as first_opclass
          on first_opclass.oid = index_catalog.indclass[0]
+       join pg_catalog.pg_namespace as first_opclass_namespace
+         on first_opclass_namespace.oid = first_opclass.opcnamespace
        join pg_catalog.pg_opclass as second_opclass
          on second_opclass.oid = index_catalog.indclass[1]
+       join pg_catalog.pg_namespace as second_opclass_namespace
+         on second_opclass_namespace.oid = second_opclass.opcnamespace
        where index_catalog.indexrelid = v_index
          and source_namespace.nspname = 'public'
          and source_relation.relname = 'flows'
@@ -44,8 +48,12 @@ begin
          and index_catalog.indexprs is null
          and first_key.attname = 'id'
          and second_key.attname = 'version'
+         and first_opclass_namespace.nspname = 'pg_catalog'
+         and second_opclass_namespace.nspname = 'pg_catalog'
          and first_opclass.opcname = 'uuid_ops'
          and second_opclass.opcname = 'bpchar_ops'
+         and first_opclass.opcintype = 'pg_catalog.uuid'::pg_catalog.regtype
+         and second_opclass.opcintype = 'pg_catalog.bpchar'::pg_catalog.regtype
          and pg_catalog.regexp_replace(
            pg_catalog.lower(pg_catalog.pg_get_expr(
              index_catalog.indpred,

--- a/supabase/migrations/20260827010003_portal_flow_embedding_eligibility_guard.sql
+++ b/supabase/migrations/20260827010003_portal_flow_embedding_eligibility_guard.sql
@@ -24,17 +24,10 @@ begin
        join pg_catalog.pg_attribute as first_key
          on first_key.attrelid = source_relation.oid
         and first_key.attnum = index_catalog.indkey[0]
-       join pg_catalog.pg_attribute as second_key
-         on second_key.attrelid = source_relation.oid
-        and second_key.attnum = index_catalog.indkey[1]
        join pg_catalog.pg_opclass as first_opclass
          on first_opclass.oid = index_catalog.indclass[0]
        join pg_catalog.pg_namespace as first_opclass_namespace
          on first_opclass_namespace.oid = first_opclass.opcnamespace
-       join pg_catalog.pg_opclass as second_opclass
-         on second_opclass.oid = index_catalog.indclass[1]
-       join pg_catalog.pg_namespace as second_opclass_namespace
-         on second_opclass_namespace.oid = second_opclass.opcnamespace
        where index_catalog.indexrelid = v_index
          and source_namespace.nspname = 'public'
          and source_relation.relname = 'flows'
@@ -43,17 +36,13 @@ begin
          and index_catalog.indisready
          and index_catalog.indislive
          and not index_catalog.indisunique
-         and index_catalog.indnkeyatts = 2
-         and index_catalog.indnatts = 2
+         and index_catalog.indnkeyatts = 1
+         and index_catalog.indnatts = 1
          and index_catalog.indexprs is null
-         and first_key.attname = 'id'
-         and second_key.attname = 'version'
+         and first_key.attname = 'state_code'
          and first_opclass_namespace.nspname = 'pg_catalog'
-         and second_opclass_namespace.nspname = 'pg_catalog'
-         and first_opclass.opcname = 'uuid_ops'
-         and second_opclass.opcname = 'bpchar_ops'
-         and first_opclass.opcintype = 'pg_catalog.uuid'::pg_catalog.regtype
-         and second_opclass.opcintype = 'pg_catalog.bpchar'::pg_catalog.regtype
+         and first_opclass.opcname = 'int4_ops'
+         and first_opclass.opcintype = 'pg_catalog.int4'::pg_catalog.regtype
          and pg_catalog.regexp_replace(
            pg_catalog.lower(pg_catalog.pg_get_expr(
              index_catalog.indpred,

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -445,7 +445,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260826080403'::text,
+  '20260827010003'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260826_portal_candidate_first_search.sql
+++ b/supabase/tests/20260826_portal_candidate_first_search.sql
@@ -602,8 +602,12 @@ select extensions.ok(
       and index_catalog.indexprs is null
       and first_key.attname = 'id'
       and second_key.attname = 'version'
+      and first_opclass_namespace.nspname = 'pg_catalog'
+      and second_opclass_namespace.nspname = 'pg_catalog'
       and first_opclass.opcname = 'uuid_ops'
       and second_opclass.opcname = 'bpchar_ops'
+      and first_opclass.opcintype = 'pg_catalog.uuid'::pg_catalog.regtype
+      and second_opclass.opcintype = 'pg_catalog.bpchar'::pg_catalog.regtype
       and pg_catalog.regexp_replace(
         pg_catalog.lower(pg_catalog.pg_get_expr(
           index_catalog.indpred,
@@ -633,8 +637,12 @@ select extensions.ok(
      and second_key.attnum = index_catalog.indkey[1]
     join pg_catalog.pg_opclass as first_opclass
       on first_opclass.oid = index_catalog.indclass[0]
+    join pg_catalog.pg_namespace as first_opclass_namespace
+      on first_opclass_namespace.oid = first_opclass.opcnamespace
     join pg_catalog.pg_opclass as second_opclass
       on second_opclass.oid = index_catalog.indclass[1]
+    join pg_catalog.pg_namespace as second_opclass_namespace
+      on second_opclass_namespace.oid = second_opclass.opcnamespace
     where index_catalog.indexrelid =
       'public.flows_portal_embedding_eligible_v1_idx'::regclass
   ),

--- a/supabase/tests/20260826_portal_candidate_first_search.sql
+++ b/supabase/tests/20260826_portal_candidate_first_search.sql
@@ -588,6 +588,66 @@ select extensions.ok(
   'semantic helpers reuse source HNSW under isolated planner settings without copying vectors'
 );
 
+select extensions.ok(
+  (
+    select source_namespace.nspname = 'public'
+      and source_relation.relname = 'flows'
+      and access_method.amname = 'btree'
+      and index_catalog.indisvalid
+      and index_catalog.indisready
+      and index_catalog.indislive
+      and not index_catalog.indisunique
+      and index_catalog.indnkeyatts = 2
+      and index_catalog.indnatts = 2
+      and index_catalog.indexprs is null
+      and first_key.attname = 'id'
+      and second_key.attname = 'version'
+      and first_opclass.opcname = 'uuid_ops'
+      and second_opclass.opcname = 'bpchar_ops'
+      and pg_catalog.regexp_replace(
+        pg_catalog.lower(pg_catalog.pg_get_expr(
+          index_catalog.indpred,
+          index_catalog.indrelid
+        )),
+        '[[:space:]]',
+        '',
+        'g'
+      ) = '((state_code=any(array[100,200]))and(embedding_ftisnotnull))'
+      and index_relation.relowner = source_relation.relowner
+      and index_relation.reloptions is null
+      and index_relation.relacl is null
+    from pg_catalog.pg_index as index_catalog
+    join pg_catalog.pg_class as index_relation
+      on index_relation.oid = index_catalog.indexrelid
+    join pg_catalog.pg_class as source_relation
+      on source_relation.oid = index_catalog.indrelid
+    join pg_catalog.pg_namespace as source_namespace
+      on source_namespace.oid = source_relation.relnamespace
+    join pg_catalog.pg_am as access_method
+      on access_method.oid = index_relation.relam
+    join pg_catalog.pg_attribute as first_key
+      on first_key.attrelid = source_relation.oid
+     and first_key.attnum = index_catalog.indkey[0]
+    join pg_catalog.pg_attribute as second_key
+      on second_key.attrelid = source_relation.oid
+     and second_key.attnum = index_catalog.indkey[1]
+    join pg_catalog.pg_opclass as first_opclass
+      on first_opclass.oid = index_catalog.indclass[0]
+    join pg_catalog.pg_opclass as second_opclass
+      on second_opclass.oid = index_catalog.indclass[1]
+    where index_catalog.indexrelid =
+      'public.flows_portal_embedding_eligible_v1_idx'::regclass
+  ),
+  'Flow sparse semantic universe uses one exact narrow eligibility btree'
+);
+
+select extensions.ok(
+  pg_catalog.to_regclass(
+    'public.processes_portal_embedding_eligible_v1_idx'
+  ) is null,
+  'the Hosted hotfix adds no speculative Process eligibility index'
+);
+
 select extensions.is(
   (
     with expected(

--- a/supabase/tests/20260826_portal_candidate_first_search.sql
+++ b/supabase/tests/20260826_portal_candidate_first_search.sql
@@ -597,17 +597,13 @@ select extensions.ok(
       and index_catalog.indisready
       and index_catalog.indislive
       and not index_catalog.indisunique
-      and index_catalog.indnkeyatts = 2
-      and index_catalog.indnatts = 2
+      and index_catalog.indnkeyatts = 1
+      and index_catalog.indnatts = 1
       and index_catalog.indexprs is null
-      and first_key.attname = 'id'
-      and second_key.attname = 'version'
+      and first_key.attname = 'state_code'
       and first_opclass_namespace.nspname = 'pg_catalog'
-      and second_opclass_namespace.nspname = 'pg_catalog'
-      and first_opclass.opcname = 'uuid_ops'
-      and second_opclass.opcname = 'bpchar_ops'
-      and first_opclass.opcintype = 'pg_catalog.uuid'::pg_catalog.regtype
-      and second_opclass.opcintype = 'pg_catalog.bpchar'::pg_catalog.regtype
+      and first_opclass.opcname = 'int4_ops'
+      and first_opclass.opcintype = 'pg_catalog.int4'::pg_catalog.regtype
       and pg_catalog.regexp_replace(
         pg_catalog.lower(pg_catalog.pg_get_expr(
           index_catalog.indpred,
@@ -632,17 +628,10 @@ select extensions.ok(
     join pg_catalog.pg_attribute as first_key
       on first_key.attrelid = source_relation.oid
      and first_key.attnum = index_catalog.indkey[0]
-    join pg_catalog.pg_attribute as second_key
-      on second_key.attrelid = source_relation.oid
-     and second_key.attnum = index_catalog.indkey[1]
     join pg_catalog.pg_opclass as first_opclass
       on first_opclass.oid = index_catalog.indclass[0]
     join pg_catalog.pg_namespace as first_opclass_namespace
       on first_opclass_namespace.oid = first_opclass.opcnamespace
-    join pg_catalog.pg_opclass as second_opclass
-      on second_opclass.oid = index_catalog.indclass[1]
-    join pg_catalog.pg_namespace as second_opclass_namespace
-      on second_opclass_namespace.oid = second_opclass.opcnamespace
     where index_catalog.indexrelid =
       'public.flows_portal_embedding_eligible_v1_idx'::regclass
   ),

--- a/supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql
+++ b/supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql
@@ -1135,7 +1135,7 @@ set local enable_seqscan = on;
 set local enable_indexscan = on;
 set local enable_indexonlyscan = on;
 set local enable_bitmapscan = on;
-set local enable_sort = off;
+set local enable_sort = on;
 set local plan_cache_mode = force_custom_plan;
 set local jit = off;
 set local row_security = on;
@@ -1188,7 +1188,10 @@ set local enable_seqscan = on;
 set local enable_indexscan = on;
 set local enable_indexonlyscan = on;
 set local enable_bitmapscan = on;
-set local enable_sort = on;
+set local enable_sort = off;
+set local plan_cache_mode = force_custom_plan;
+set local jit = off;
+set local row_security = on;
 
 \qecho profile=flow-source-embedding-eligibility
 explain (analyze, buffers, settings, wal, summary, format json)

--- a/supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql
+++ b/supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql
@@ -1181,6 +1181,37 @@ revoke portal_public_executor from postgres;
 grant api_internal_executor to postgres;
 set local role api_internal_executor;
 
+set local enable_seqscan = on;
+set local enable_indexscan = on;
+set local enable_indexonlyscan = on;
+set local enable_bitmapscan = on;
+set local enable_sort = on;
+
+\qecho profile=flow-source-embedding-eligibility
+explain (analyze, buffers, settings, wal, summary, format json)
+select flow.id,
+  flow.version::text as version,
+  flow.embedding_ft operator(extensions.<=>) pg_temp.portal_bench_vector(1)
+    as semantic_distance
+from public.flows as flow
+where flow.state_code in (100, 200)
+  and flow.embedding_ft is not null
+limit 200;
+
+select pg_temp.capture_portal_benchmark_plan(
+  'flow_embedding_eligibility',
+  $query$
+    select flow.id,
+      flow.version::text as version,
+      flow.embedding_ft operator(extensions.<=>) pg_temp.portal_bench_vector(1)
+        as semantic_distance
+    from public.flows as flow
+    where flow.state_code in (100, 200)
+      and flow.embedding_ft is not null
+    limit 200
+  $query$
+);
+
 set local enable_sort = off;
 set local hnsw.iterative_scan = relaxed_order;
 set local hnsw.ef_search = 1000;
@@ -1587,13 +1618,13 @@ insert into pg_temp.portal_benchmark_failures (
 select
   'plan_index_guard',
   'P0001',
-  'representative plan missed required Flow PGroonga/full-source-HNSW evidence or malformed the Process lexical probe',
+  'representative plan missed required Flow lexical/semantic eligibility or source-HNSW evidence',
   0
 where (:'process_rows'::integer >= 10000
     and :'flow_rows'::integer >= 100000)
   and (
     (select count(*) from pg_temp.portal_benchmark_plans) <> case
-      when :'benchmark_semantic_plan_profile'::boolean then 8 else 4
+      when :'benchmark_semantic_plan_profile'::boolean then 9 else 5
     end
    or not coalesce((
      select plan_text ~ 'Buffers: shared'
@@ -1617,6 +1648,23 @@ where (:'process_rows'::integer >= 10000
        and plan_text !~ 'external merge'
      from pg_temp.portal_benchmark_plans
      where label = 'flow_pgroonga'
+   ), false)
+   or not coalesce((
+     select plan_text ~ 'Buffers: shared'
+       and plan_text ~ 'Execution Time: [0-9]'
+       and plan_text !~ 'temp read=[1-9]'
+       and plan_text !~ 'temp (read=[0-9]+ )?written=[1-9]'
+       and plan_text !~ 'Disk:'
+       and plan_text !~ 'external merge'
+       and (
+         not :'benchmark_sparse_profile'::boolean
+         or (
+           plan_text ~ '(Index Scan using|Bitmap Index Scan on) flows_portal_embedding_eligible_v1_idx'
+           and plan_text !~ 'Seq Scan on flows'
+         )
+       )
+     from pg_temp.portal_benchmark_plans
+     where label = 'flow_embedding_eligibility'
    ), false)
    or not coalesce((
      select plan_text ~ 'processes_embedding_ft_hnsw_idx'
@@ -1671,6 +1719,8 @@ select label,
     as flow_pgroonga,
   plan_text ~ 'processes_embedding_ft_hnsw_idx' as process_hnsw,
   plan_text ~ 'flows_embedding_ft_hnsw_idx' as flow_hnsw,
+  plan_text ~ 'flows_portal_embedding_eligible_v1_idx'
+    as flow_embedding_eligibility,
   (
     plan_text ~ 'temp read=[1-9]'
     or plan_text ~ 'temp (read=[0-9]+ )?written=[1-9]'

--- a/supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql
+++ b/supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql
@@ -1694,17 +1694,39 @@ where (:'process_rows'::integer >= 10000
      where label = 'flow_embedding_eligibility'
    ), false)
    or not coalesce((
-     select plan_text ~ 'processes_embedding_ft_hnsw_idx'
-       and plan_text !~ 'processes_embedding_ft_tg_hnsw_idx'
-       and plan_text !~ 'Seq Scan on processes'
-       and plan_text !~ '(^|\n)[[:space:]]*Sort[[:space:]]'
+     select plan_text ~ 'Buffers: shared'
+       and plan_text ~ 'Execution Time: [0-9]'
+       and plan_text !~ 'temp read=[1-9]'
+       and plan_text !~ 'temp (read=[0-9]+ )?written=[1-9]'
+       and plan_text !~ 'Disk:'
+       and plan_text !~ 'external merge'
+       and (
+         not :'benchmark_release_profile'::boolean
+         or (
+           plan_text ~ 'processes_embedding_ft_hnsw_idx'
+           and plan_text !~ 'processes_embedding_ft_tg_hnsw_idx'
+           and plan_text !~ 'Seq Scan on processes'
+           and plan_text !~ '(^|\n)[[:space:]]*Sort[[:space:]]'
+         )
+       )
      from pg_temp.portal_benchmark_plans
      where label = 'process_source_hnsw'
    ), false)
    or not coalesce((
-     select plan_text ~ 'flows_embedding_ft_hnsw_idx'
-       and plan_text !~ 'Seq Scan on flows'
-       and plan_text !~ '(^|\n)[[:space:]]*Sort[[:space:]]'
+     select plan_text ~ 'Buffers: shared'
+       and plan_text ~ 'Execution Time: [0-9]'
+       and plan_text !~ 'temp read=[1-9]'
+       and plan_text !~ 'temp (read=[0-9]+ )?written=[1-9]'
+       and plan_text !~ 'Disk:'
+       and plan_text !~ 'external merge'
+       and (
+         not :'benchmark_release_profile'::boolean
+         or (
+           plan_text ~ 'flows_embedding_ft_hnsw_idx'
+           and plan_text !~ 'Seq Scan on flows'
+           and plan_text !~ '(^|\n)[[:space:]]*Sort[[:space:]]'
+         )
+       )
      from pg_temp.portal_benchmark_plans
      where label = 'flow_source_hnsw'
    ), false)

--- a/supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql
+++ b/supabase/tests/benchmarks/20260826_portal_candidate_first_explain.sql
@@ -1135,7 +1135,10 @@ set local enable_seqscan = on;
 set local enable_indexscan = on;
 set local enable_indexonlyscan = on;
 set local enable_bitmapscan = on;
-set local enable_sort = on;
+set local enable_sort = off;
+set local plan_cache_mode = force_custom_plan;
+set local jit = off;
+set local row_security = on;
 
 \qecho profile=process-projection-natural-lexical
 explain (analyze, buffers, settings, wal, summary, format json)
@@ -1189,30 +1192,54 @@ set local enable_sort = on;
 
 \qecho profile=flow-source-embedding-eligibility
 explain (analyze, buffers, settings, wal, summary, format json)
-select flow.id,
-  flow.version::text as version,
-  flow.embedding_ft operator(extensions.<=>) pg_temp.portal_bench_vector(1)
-    as semantic_distance
-from public.flows as flow
-where flow.state_code in (100, 200)
-  and flow.embedding_ft is not null
-limit 200;
+select pg_catalog.array_agg(
+    bounded_source.id order by bounded_source.id, bounded_source.version desc
+  ),
+  pg_catalog.array_agg(
+    bounded_source.version order by bounded_source.id, bounded_source.version desc
+  ),
+  pg_catalog.array_agg(
+    bounded_source.semantic_distance
+    order by bounded_source.id, bounded_source.version desc
+  )
+from (
+  select flow.id,
+    flow.version::text as version,
+    flow.embedding_ft operator(extensions.<=>) pg_temp.portal_bench_vector(1)
+      as semantic_distance
+  from public.flows as flow
+  where flow.state_code in (100, 200)
+    and flow.embedding_ft is not null
+  limit 200
+) as bounded_source;
 
 select pg_temp.capture_portal_benchmark_plan(
   'flow_embedding_eligibility',
   $query$
-    select flow.id,
-      flow.version::text as version,
-      flow.embedding_ft operator(extensions.<=>) pg_temp.portal_bench_vector(1)
-        as semantic_distance
-    from public.flows as flow
-    where flow.state_code in (100, 200)
-      and flow.embedding_ft is not null
-    limit 200
+    select pg_catalog.array_agg(
+        bounded_source.id order by bounded_source.id, bounded_source.version desc
+      ),
+      pg_catalog.array_agg(
+        bounded_source.version
+        order by bounded_source.id, bounded_source.version desc
+      ),
+      pg_catalog.array_agg(
+        bounded_source.semantic_distance
+        order by bounded_source.id, bounded_source.version desc
+      )
+    from (
+      select flow.id,
+        flow.version::text as version,
+        flow.embedding_ft operator(extensions.<=>) pg_temp.portal_bench_vector(1)
+          as semantic_distance
+      from public.flows as flow
+      where flow.state_code in (100, 200)
+        and flow.embedding_ft is not null
+      limit 200
+    ) as bounded_source
   $query$
 );
 
-set local enable_sort = off;
 set local hnsw.iterative_scan = relaxed_order;
 set local hnsw.ef_search = 1000;
 set local hnsw.max_scan_tuples = 200000;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: d4c2976
+lastReviewedCommit: 09ca0d6
 lastReviewedNote: "Reviewed for the Portal manifest and sparse benchmark tooling; generated-workspace paths, refresh behavior, and type ownership are unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 450c04e
+lastReviewedCommit: d4c2976
 lastReviewedNote: "Reviewed for the Portal manifest and sparse benchmark tooling; generated-workspace paths, refresh behavior, and type ownership are unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 09ca0d6
+lastReviewedCommit: e46e205
 lastReviewedNote: "Reviewed for the Portal manifest and sparse benchmark tooling; generated-workspace paths, refresh behavior, and type ownership are unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 450c04e
+lastReviewedCommit: d4c2976
 lastReviewedNote: "已复核 Portal manifest 与 sparse benchmark 工具；生成 workspace 路径、刷新行为与类型所有权不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: 09ca0d6
+lastReviewedCommit: e46e205
 lastReviewedNote: "已复核 Portal manifest 与 sparse benchmark 工具；生成 workspace 路径、刷新行为与类型所有权不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-27
-lastReviewedCommit: d4c2976
+lastReviewedCommit: 09ca0d6
 lastReviewedNote: "已复核 Portal manifest 与 sparse benchmark 工具；生成 workspace 路径、刷新行为与类型所有权不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -65984,6 +65984,10 @@ CREATE INDEX "flows_not_emissions_idx" ON "public"."flows" USING "btree" ("state
 
 
 
+CREATE INDEX "flows_portal_embedding_eligible_v1_idx" ON "public"."flows" USING "btree" ("id", "version") WHERE (("state_code" = ANY (ARRAY[100, 200])) AND ("embedding_ft" IS NOT NULL));
+
+
+
 CREATE INDEX "flows_public_latest_keys_cover_idx" ON "public"."flows" USING "btree" ("id", "version" DESC, "modified_at" DESC) INCLUDE ("created_at", "team_id") WHERE ("state_code" = 100);
 
 

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -65984,7 +65984,7 @@ CREATE INDEX "flows_not_emissions_idx" ON "public"."flows" USING "btree" ("state
 
 
 
-CREATE INDEX "flows_portal_embedding_eligible_v1_idx" ON "public"."flows" USING "btree" ("id", "version") WHERE (("state_code" = ANY (ARRAY[100, 200])) AND ("embedding_ft" IS NOT NULL));
+CREATE INDEX "flows_portal_embedding_eligible_v1_idx" ON "public"."flows" USING "btree" ("state_code") WHERE (("state_code" = ANY (ARRAY[100, 200])) AND ("embedding_ft" IS NOT NULL));
 
 
 

--- a/supabase/workspace/schemas/public/tables/flows/indexes/flows_portal_embedding_eligible_v1_idx.sql
+++ b/supabase/workspace/schemas/public/tables/flows/indexes/flows_portal_embedding_eligible_v1_idx.sql
@@ -1,1 +1,1 @@
-CREATE INDEX "flows_portal_embedding_eligible_v1_idx" ON "public"."flows" USING "btree" ("id", "version") WHERE (("state_code" = ANY (ARRAY[100, 200])) AND ("embedding_ft" IS NOT NULL));
+CREATE INDEX "flows_portal_embedding_eligible_v1_idx" ON "public"."flows" USING "btree" ("state_code") WHERE (("state_code" = ANY (ARRAY[100, 200])) AND ("embedding_ft" IS NOT NULL));

--- a/supabase/workspace/schemas/public/tables/flows/indexes/flows_portal_embedding_eligible_v1_idx.sql
+++ b/supabase/workspace/schemas/public/tables/flows/indexes/flows_portal_embedding_eligible_v1_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "flows_portal_embedding_eligible_v1_idx" ON "public"."flows" USING "btree" ("id", "version") WHERE (("state_code" = ANY (ARRAY[100, 200])) AND ("embedding_ft" IS NOT NULL));


### PR DESCRIPTION
Closes #531.

Follow-up to #534 and the hosted finding recorded at https://github.com/tiangong-lca/database-engine/issues/531#issuecomment-5429320666.

## Summary

- Add one Flow-only partial B-tree that makes the exact 0..199 embedding-universe probe index-bounded when the wide Flow table has zero or sparse embeddings.
- Build it concurrently and validate its exact catalog identity in a separate transactional guard migration.
- Extend static governance, pgTAP, representative benchmarks, recovery, generated schema workspace, and operational documentation.
- Leave all immutable Portal functions, public DTOs, HNSW indexes, RLS/ACLs, and Process paths unchanged.

## Why this shape

Persistent Dev has 133,259 Flow rows but zero non-null embeddings. The existing exact underfill branch must prove that universe is empty; without a selective ordinary index it scans the wide Flow heap and produced 7.71–8.52 second Hybrid calls plus one stable timeout.

The accepted index is:

```sql
create index concurrently flows_portal_embedding_eligible_v1_idx
on public.flows using btree (state_code)
where state_code in (100, 200)
  and embedding_ft is not null;
```

It contains no vector payload. `state_code` is intentionally a low-selectivity membership key: sparse probes read an empty/small exact index, while the full-vector exact helper retains its lower-buffer hash/scan plan. An `(id,version)` prototype was rejected because the release gate measured 266,277 exact read blocks.

## Validation

- Exact head `69f5141`; migration head `20260827010003`; 259-file migration tree hash `ad9a34db8beb0df6e6f167de6b7d829624009a3b122758895b3cc417bf7437bf`.
- 696 pgTAP assertions, strict Portal schemas, Portal lint, workspace/types double generation, populated upgrade, static manifest, and Docpact: PASS.
- Recovery including new concurrent-index/guard gaps: PASS.
- `release`: PASS; Flow exact read 176,468; combined 604,051 total / 180,529 read; no spill; Search/Hybrid p95 within budget; recall 1.0.
- `sparse-zero`: PASS; eligibility 0.034 ms; Flow fused Hybrid p95 119 ms; raw 0/0.
- `sparse-199`: PASS; eligibility 0.319 ms; raw 198/198; recall 1.0; zero false positives.
- Writer gate: Flow embedding update p95 0.255 ms in release and 0.282 ms in sparse-zero.
- Independent review: High 0 / Medium 0 / Low 0.

## Risk and rollout

- Only eligible Flow rows receive one narrow int4 B-tree entry. There is no vector duplication and no Process index.
- Concurrent build avoids long write blocking; the guard fails closed on wrong key/opclass/predicate/owner/validity.
- Persistent Dev must re-prove natural index use and five-sample anonymous Flow Hybrid p95/max before Issue completion. Production promotion remains separate and is not authorized by this PR.
- No other repository was modified.
