### PR TITLE
Fix Supabase CLI restart 502 blocking database promote

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-29"
-lastReviewedCommit: "ab87cb5da02b978b119cd983683649a10a05ab8a"
-lastReviewedNote: "Reviewed for Issue #543: 278 migrations, history-unique Portal CAS selection, duplicate-pressure evidence, 13 generated modules, and retained sitemap recovery."
+lastReviewedCommit: "e39fdf422fcf109a16bc8e52bba59538092c521c"
+lastReviewedNote: "Reviewed for Issue #552: the Supabase CLI pin update changes no documentation routing, coverage, or ownership rule."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.github/workflows/supabase-dev.yml
+++ b/.github/workflows/supabase-dev.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.98.0
+          version: 2.116.0
 
       - name: Verify deployment workflow contract
         run: |
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.98.0
+          version: 2.116.0
 
       - name: Link Supabase Dev branch
         run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
@@ -267,7 +267,7 @@ jobs:
         if: steps.preview_authority.outputs.available == 'true'
         uses: supabase/setup-cli@v2
         with:
-          version: 2.98.0
+          version: 2.116.0
 
       - name: Wait for exact Supabase Preview check
         if: steps.preview_authority.outputs.available == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: ab87cb5da02b978b119cd983683649a10a05ab8a
-lastReviewedNote: "Reviewed for Issue #543 history-unique CAS example selection, summary/index isolation, unchanged Search/timeout budgets, and fail-closed forward repair; ownership boundaries remain unchanged."
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "Reviewed for Issue #552: the Supabase CLI pin update changes no ownership, branch, deployment, or integration boundary."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,8 +30,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: ab87cb5da02b978b119cd983683649a10a05ab8a
-lastReviewedNote: "Documented Issue #549 Worker queue growth controls and Worker-owned package-retention safety boundaries."
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "Reviewed for Issue #552: the workflow dependency pin changes no repository architecture or runtime boundary."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: ab87cb5da02b978b119cd983683649a10a05ab8a
-lastReviewedNote: "Added Issue #549 proof for coalesced heartbeats, exact negative admission, maintenance reuse, and Worker-owned package retention."
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "Reviewed for Issue #552: existing workflow validation remains sufficient for the Supabase CLI restart fix."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching.md
+++ b/docs/agents/supabase-branching.md
@@ -20,9 +20,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-08-27
-lastReviewedCommit: 712558e
-lastReviewedNote: "Reviewed for Issue #539 bounded independent Hybrid/sitemap Preview probes; PR, persistent Dev, production, and cross-repository mutation boundaries remain unchanged."
+lastReviewedAt: 2026-08-29
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "Reviewed for Issue #552: the Supabase CLI restart fix changes no PR, persistent Dev, production, or cross-repository mutation boundary."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/supabase-branching_CN.md
+++ b/docs/agents/supabase-branching_CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - .github/workflows/supabase-dev.yml
   - .env.supabase.dev.local.example
   - .env.supabase.main.local.example
-lastReviewedAt: 2026-08-27
-lastReviewedCommit: 712558e
-lastReviewedNote: "已为 Issue #539 的有界且相互独立的 Hybrid/sitemap Preview 探测复核；PR、持久化 Dev、生产和跨仓修改边界均保持不变。"
+lastReviewedAt: 2026-08-29
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "已为 Issue #552 复核：Supabase CLI 重启修复不改变 PR、持久化 Dev、生产或跨仓修改边界。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: ab87cb5da02b978b119cd983683649a10a05ab8a
-lastReviewedNote: "Reviewed for Issue #543: 278-file recovery/benchmark runners, history-unique CAS pressure gates, summary-isolated index evidence, fixed sitemap shards, and 13-module Portal generation are current."
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "Reviewed for Issue #552: the workflow contract now enforces one Supabase CLI version across all three jobs; the script surface is unchanged."
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: ab87cb5da02b978b119cd983683649a10a05ab8a
-lastReviewedNote: "已复核 Issue #543：278-file recovery/benchmark、历史唯一 CAS 压力门、summary-isolated index 证据、固定 sitemap shards 与 13-module Portal 生成均为当前状态。"
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "已为 Issue #552 复核：workflow 合同现在要求三个 job 使用同一 Supabase CLI 版本；脚本命令面不变。"
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/test_supabase_dev_workflow_contract.py
+++ b/scripts/test_supabase_dev_workflow_contract.py
@@ -57,6 +57,15 @@ def main() -> int:
     }
     failures = [label for label, token in forbidden.items() if token in lowered]
 
+    supabase_cli_versions = re.findall(
+        r"uses: supabase/setup-cli@v2\s+with:\s+version:\s*([^\s#]+)", text
+    )
+    if supabase_cli_versions != ["2.116.0"] * 3:
+        failures.append(
+            "all three local, persistent-Dev, and Preview Supabase CLI pins "
+            f"must be 2.116.0, found {supabase_cli_versions or 'none'}"
+        )
+
     expected_head = resolve_migration_head(MIGRATIONS)
     if re.search(r'EXPECTED_MIGRATION_HEAD:\s*["\']?\d{14}', text):
         failures.append("migration head must not be pinned manually")
@@ -155,7 +164,7 @@ def main() -> int:
         "Supabase Preview runtime verification requires SUPABASE_ACCESS_TOKEN, SUPABASE_MAIN_PROJECT_ID, and SUPABASE_DEV_PROJECT_ID",
         "exit 1",
         "uses: supabase/setup-cli@v2",
-        "version: 2.98.0",
+        "version: 2.116.0",
         "Wait for exact Supabase Preview check",
         "check_name=Supabase%20Preview&filter=latest",
         '.name == "Supabase Preview"',

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: ab87cb5da02b978b119cd983683649a10a05ab8a
-lastReviewedNote: "Reviewed for the 278-migration Issue #543 history-unique CAS example and summary-isolated exact index path; generated workspace/type ownership remains unchanged."
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "Reviewed for Issue #552: exact-local regeneration has no drift, and generated workspace/type ownership remains unchanged."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-29
-lastReviewedCommit: ab87cb5da02b978b119cd983683649a10a05ab8a
-lastReviewedNote: "已为 278-migration Issue #543 历史唯一 CAS example 与 summary-isolated exact index path 复核；generated workspace/type 所有权保持不变。"
+lastReviewedCommit: e39fdf422fcf109a16bc8e52bba59538092c521c
+lastReviewedNote: "已为 Issue #552 复核：exact-local 重新生成无漂移，generated workspace/type 所有权保持不变。"
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary

- Upgrade the Supabase CLI pin from `2.98.0` to the current stable `2.116.0` in the local-contract, persistent-Dev, and Preview jobs.
- Make the workflow contract fail closed unless exactly those three jobs use the same `2.116.0` pin.
- Record the required Docpact reviews; repository ownership and deployment boundaries are unchanged.

## Why

The merge-to-`dev` workflow for database PR #550 applied all migrations through `20260829120100`, then failed twice at `Restarting containers...` with HTTP 502. Supabase CLI `2.98.0` predates upstream fix `supabase/cli#6017`, which reloads Kong after `db reset` restarts service containers so it does not retain stale container IPs.

Because the local-contract job failed, the persistent Dev deployment was skipped. That evidence is required before the queued `dev -> main` production promotion.

## Validation

- `npx --yes supabase@2.116.0 start && npx --yes supabase@2.116.0 db reset --no-seed`
  - rebuilt every migration through `20260829120100`
  - completed `Restarting containers...` without the prior 502
- `python scripts/test_resolve_migration_head.py`
- `python scripts/test_supabase_dev_workflow_contract.py`
- `python3 scripts/build_portal_contract_types.py --check`
- workflow YAML parse
- exact-local schema workspace and Data API type regeneration with zero Git drift
- `npx --yes supabase@2.116.0 migration list --local` with parity through `20260829120100`
- Docpact enforce lint and pre-push gate

## Hosted gates

- PR CI must pass with the new pinned CLI.
- After merge, the push-to-`dev` workflow must pass both `Rebuild and verify database contract` and `Deploy and verify persistent Dev`, including exact deployed migration head `20260829120100`.
- `dev -> main` promotion remains blocked until that persistent Dev evidence exists.

## Risk and boundaries

- No migration, schema, seed, generated workspace/type, or `supabase/config.toml` change.
- No production mutation is performed by this PR.
- No rebuild or hosted verification gate is skipped or weakened.

Closes #552

Related: tiangong-lca/workspace#833
