### PR TITLE
feat: validate user organization metadata

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-08-31"
-lastReviewedCommit: "e6b4afe857d70cb0242dcbc803f288f77da39608"
+lastReviewedCommit: "2dad5b37587bfa0780f5e16cf7830d69dcb3b53a"
 lastReviewedNote: "Reviewed for Issue #568: routing and proof cover the exact forward repair that restores EDGE-BUNDLE-01 to both LifecycleModel bundle signatures before MCP client admission."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: e6b4afe857d70cb0242dcbc803f288f77da39608
+lastReviewedCommit: 2dad5b37587bfa0780f5e16cf7830d69dcb3b53a
 lastReviewedNote: "Reviewed for Issue #568: the exact LifecycleModel bundle RPCs retain EDGE-BUNDLE-01 after actor-command drift repair, so MCP admission never requires the broad CLI-RPC-01 capability."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: e6b4afe857d70cb0242dcbc803f288f77da39608
-lastReviewedNote: "Reviewed for Issue #568: the forward capability repair binds both exact LifecycleModel bundle signatures to EDGE-BUNDLE-01 and prevents MCP from inheriting the broad CLI capability."
+lastReviewedCommit: 2dad5b37587bfa0780f5e16cf7830d69dcb3b53a
+lastReviewedNote: "Updated for Issue #572: organization is an optional bounded string in mirrored user metadata and is never an authorization input."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -255,6 +255,12 @@ identity is deleted. Forward migrations must also reconcile historical Auth
 rows while preserving application-owned profile fields. The trigger helper is
 `SECURITY DEFINER`, uses an empty fixed `search_path`, and is not directly
 executable by application roles.
+
+The optional `raw_user_meta_data.organization` profile key stores the user's
+organization as a trimmed string of at most 200 characters. The database
+validates that representation on `private.users`; the existing Auth-to-private
+mirror remains its only synchronization path. This descriptive profile value
+must never be used as an authorization, role, team, or RLS input.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: e6b4afe857d70cb0242dcbc803f288f77da39608
+lastReviewedCommit: 2dad5b37587bfa0780f5e16cf7830d69dcb3b53a
 lastReviewedNote: "Reviewed for Issue #568: OAuth proof now pins both exact LifecycleModel bundle signatures to EDGE-BUNDLE-01 and rejects CLI-RPC-01 fallback before MCP client admission."
 related:
   - ../../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: e6b4afe857d70cb0242dcbc803f288f77da39608
+lastReviewedCommit: 2dad5b37587bfa0780f5e16cf7830d69dcb3b53a
 lastReviewedNote: "Reviewed for Issue #568: the OAuth bundle regression advances the exact migration head to 20260831130000; helper commands and stable-overlay rules are unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: e6b4afe857d70cb0242dcbc803f288f77da39608
+lastReviewedCommit: 2dad5b37587bfa0780f5e16cf7830d69dcb3b53a
 lastReviewedNote: "为 Issue #568 复核：OAuth bundle 回归把精确 migration head 推进到 20260831130000；helper 命令与稳定 overlay 规则不变。"
 related:
   - ../AGENTS.md

--- a/supabase/migrations/20260831143000_user_organization_metadata_contract.sql
+++ b/supabase/migrations/20260831143000_user_organization_metadata_contract.sql
@@ -1,0 +1,18 @@
+-- Keep organization profile metadata bounded without changing the existing
+-- Supabase Auth -> private.users ownership and synchronization path.
+
+alter table private.users
+  add constraint users_organization_metadata_contract
+  check (
+    raw_user_meta_data is null
+    or not (raw_user_meta_data ? 'organization')
+    or (
+      jsonb_typeof(raw_user_meta_data -> 'organization') = 'string'
+      and (raw_user_meta_data ->> 'organization')
+        !~ '^[[:space:]]|[[:space:]]$'
+      and char_length(raw_user_meta_data ->> 'organization') <= 200
+    )
+  ) not valid;
+
+alter table private.users
+  validate constraint users_organization_metadata_contract;

--- a/supabase/tests/20260805_full_schema_cutover.sql
+++ b/supabase/tests/20260805_full_schema_cutover.sql
@@ -136,7 +136,7 @@ select is(
       'util'::regnamespace
     )
   ),
-  559::bigint,
+  560::bigint,
   'all application constraints plus the OAuth registry constraints remain present'
 );
 

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -445,7 +445,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260831130000'::text,
+  '20260831143000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260808_auth_user_profile_sync.sql
+++ b/supabase/tests/20260808_auth_user_profile_sync.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, auth;
 
-select plan(15);
+select plan(27);
 
 select ok(
   to_regprocedure('private.sync_auth_users_to_private_users()') is not null,
@@ -62,6 +62,18 @@ select ok(
     'EXECUTE'
   ),
   'the trigger helper is not directly executable by application roles'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'private.users'::regclass
+      and conname = 'users_organization_metadata_contract'
+      and contype = 'c'
+      and convalidated
+  ),
+  'private.users has a validated organization metadata contract'
 );
 
 insert into auth.users (
@@ -165,7 +177,11 @@ select is(
 
 update auth.users
 set raw_user_meta_data =
-  raw_user_meta_data || '{"display_name":"Updated Candidate"}'::jsonb
+  raw_user_meta_data || jsonb_build_object(
+    'display_name', 'Updated Candidate',
+    'organization', 'Tsinghua University',
+    'profile_note', 'preserved'
+  )
 where id = '43500000-0000-4000-8000-000000000002';
 
 select is(
@@ -176,6 +192,139 @@ select is(
   ),
   'Updated Candidate',
   'Auth metadata updates are mirrored into private.users'
+);
+
+select is(
+  (
+    select raw_user_meta_data ->> 'organization'
+    from private.users
+    where id = '43500000-0000-4000-8000-000000000002'
+  ),
+  'Tsinghua University',
+  'organization metadata updates are mirrored into private.users'
+);
+
+select is(
+  (
+    select raw_user_meta_data ->> 'profile_note'
+    from private.users
+    where id = '43500000-0000-4000-8000-000000000002'
+  ),
+  'preserved',
+  'organization metadata updates preserve unrelated user metadata'
+);
+
+update auth.users
+set raw_user_meta_data =
+  raw_user_meta_data || '{"organization":"TianGong Initiative"}'::jsonb
+where id = '43500000-0000-4000-8000-000000000001';
+
+select is(
+  (
+    select raw_user_meta_data ->> 'organization'
+    from private.users
+    where id = '43500000-0000-4000-8000-000000000001'
+  ),
+  'TianGong Initiative',
+  'organization metadata is mirrored for an existing private profile'
+);
+
+select is(
+  (
+    select contact ->> 'kind'
+    from private.users
+    where id = '43500000-0000-4000-8000-000000000001'
+  ),
+  'preserved',
+  'organization metadata updates preserve application-owned contact data'
+);
+
+update auth.users
+set raw_user_meta_data =
+  raw_user_meta_data || '{"organization":""}'::jsonb
+where id = '43500000-0000-4000-8000-000000000002';
+
+select is(
+  (
+    select raw_user_meta_data ->> 'organization'
+    from private.users
+    where id = '43500000-0000-4000-8000-000000000002'
+  ),
+  '',
+  'an empty organization string remains a valid clear value'
+);
+
+select throws_ok(
+  $$
+    update auth.users
+    set raw_user_meta_data = raw_user_meta_data || '{"organization":42}'::jsonb
+    where id = '43500000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  null,
+  'numeric organization metadata is rejected'
+);
+
+select throws_ok(
+  $$
+    update auth.users
+    set raw_user_meta_data =
+      raw_user_meta_data || '{"organization":{"name":"Example"}}'::jsonb
+    where id = '43500000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  null,
+  'object organization metadata is rejected'
+);
+
+select throws_ok(
+  $$
+    update auth.users
+    set raw_user_meta_data =
+      raw_user_meta_data || '{"organization":["Example"]}'::jsonb
+    where id = '43500000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  null,
+  'array organization metadata is rejected'
+);
+
+select throws_ok(
+  $$
+    update auth.users
+    set raw_user_meta_data =
+      raw_user_meta_data || '{"organization":null}'::jsonb
+    where id = '43500000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  null,
+  'JSON null organization metadata is rejected'
+);
+
+select throws_ok(
+  $$
+    update auth.users
+    set raw_user_meta_data =
+      raw_user_meta_data || '{"organization":" Example University "}'::jsonb
+    where id = '43500000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  null,
+  'organization metadata with surrounding whitespace is rejected'
+);
+
+select throws_ok(
+  $$
+    update auth.users
+    set raw_user_meta_data = raw_user_meta_data || jsonb_build_object(
+      'organization',
+      repeat('x', 201)
+    )
+    where id = '43500000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  null,
+  'organization metadata longer than 200 characters is rejected'
 );
 
 delete from auth.users

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: e6b4afe857d70cb0242dcbc803f288f77da39608
+lastReviewedCommit: 2dad5b37587bfa0780f5e16cf7830d69dcb3b53a
 lastReviewedNote: "Reviewed for Issue #568: the forward repair changes only capability-manifest data; generated Data API types, workspace ownership, refresh, and stable-overlay rules are unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-08-31
-lastReviewedCommit: e6b4afe857d70cb0242dcbc803f288f77da39608
+lastReviewedCommit: 2dad5b37587bfa0780f5e16cf7830d69dcb3b53a
 lastReviewedNote: "为 Issue #568 复核：追加修复只改变能力 manifest 数据；生成的 Data API types、workspace 所有权、刷新与稳定 overlay 规则均不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -66790,7 +66790,8 @@ ALTER TABLE "private"."teams" OWNER TO "postgres";
 CREATE TABLE IF NOT EXISTS "private"."users" (
     "id" "uuid" NOT NULL,
     "raw_user_meta_data" "jsonb",
-    "contact" "jsonb"
+    "contact" "jsonb",
+    CONSTRAINT "users_organization_metadata_contract" CHECK ((("raw_user_meta_data" IS NULL) OR (NOT ("raw_user_meta_data" ? 'organization'::"text")) OR (("jsonb_typeof"(("raw_user_meta_data" -> 'organization'::"text")) = 'string'::"text") AND (("raw_user_meta_data" ->> 'organization'::"text") !~ '^[[:space:]]|[[:space:]]$'::"text") AND ("char_length"(("raw_user_meta_data" ->> 'organization'::"text")) <= 200))))
 );
 
 

--- a/supabase/workspace/schemas/private/tables/users/table.sql
+++ b/supabase/workspace/schemas/private/tables/users/table.sql
@@ -1,7 +1,8 @@
 CREATE TABLE IF NOT EXISTS "private"."users" (
     "id" "uuid" NOT NULL,
     "raw_user_meta_data" "jsonb",
-    "contact" "jsonb"
+    "contact" "jsonb",
+    CONSTRAINT "users_organization_metadata_contract" CHECK ((("raw_user_meta_data" IS NULL) OR (NOT ("raw_user_meta_data" ? 'organization'::"text")) OR (("jsonb_typeof"(("raw_user_meta_data" -> 'organization'::"text")) = 'string'::"text") AND (("raw_user_meta_data" ->> 'organization'::"text") !~ '^[[:space:]]|[[:space:]]$'::"text") AND ("char_length"(("raw_user_meta_data" ->> 'organization'::"text")) <= 200))))
 );
 
 ALTER TABLE "private"."users" OWNER TO "postgres";


### PR DESCRIPTION
## 目标

为用户资料中的单位信息建立数据库契约：`private.users.raw_user_meta_data.organization` 在存在时必须是规范化字符串，并继续复用现有 Auth 用户资料同步链路。

## 变更

- 新增 `users_organization_metadata_contract` 检查约束：允许 key 缺失；存在时必须为 JSON 字符串、不得包含首尾空白、长度不超过 200 个字符。
- 保持单位为空时使用空字符串的产品语义；拒绝数字、对象、数组、JSON null、首尾空白和超长值。
- 扩展 Auth 用户资料同步 pgTAP，验证单位写入、清空以及其他 metadata/contact 字段不会被覆盖。
- 更新远端 schema 快照、私有表定义、架构文档和 Docpact 评审元数据。

## 验证

- `npx --yes supabase@2.116.0 db reset --no-seed`
- 专项 pgTAP：27/27 通过
- schema workspace build 通过
- public/API database types build 通过且无漂移
- `supabase db lint --local --level warning` 完成；仅报告仓库既有函数级告警，本变更约束无新增告警
- Docpact enforced：0 findings
- 生成物差异与工作树检查通过

## 风险与边界

- `organization` 仅为展示资料，不参与角色、团队、授权或 RLS 判断。
- 不新增浏览器直连 `private` schema 的权限、RPC 或索引。
- 依赖现有 deferred Auth profile sync trigger 将 `auth.users.raw_user_meta_data` 镜像到 `private.users`。

Closes #572

Parent: tiangong-lca/workspace#907
