### PR TITLE
新增全国碳每日数据版本创建量聚合

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-01"
-lastReviewedCommit: "b4d8e0cbbb16b3fd4b0565b95132243b659883a1"
+lastReviewedCommit: "92a7bb85152d0d7ac5de07b6ad4c5ada7749aef6"
 lastReviewedNote: "Reviewed for Issue #568: routing and proof cover the exact forward repair that restores EDGE-BUNDLE-01 to both LifecycleModel bundle signatures before MCP client admission."
 
 # Keep deterministic governance facts here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: b4d8e0cbbb16b3fd4b0565b95132243b659883a1
+lastReviewedCommit: 92a7bb85152d0d7ac5de07b6ad4c5ada7749aef6
 lastReviewedNote: "Reviewed for Issue #568: the exact LifecycleModel bundle RPCs retain EDGE-BUNDLE-01 after actor-command drift repair, so MCP admission never requires the broad CLI-RPC-01 capability."
 related:
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -31,7 +31,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: b4d8e0cbbb16b3fd4b0565b95132243b659883a1
+lastReviewedCommit: 92a7bb85152d0d7ac5de07b6ad4c5ada7749aef6
 lastReviewedNote: "Updated for Issue #572: organization is an optional bounded string in mirrored user metadata and is never an authorization input."
 related:
   - ../../AGENTS.md

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: b4d8e0cbbb16b3fd4b0565b95132243b659883a1
+lastReviewedCommit: 92a7bb85152d0d7ac5de07b6ad4c5ada7749aef6
 lastReviewedNote: "Reviewed for Issue #568: OAuth proof now pins both exact LifecycleModel bundle signatures to EDGE-BUNDLE-01 and rejects CLI-RPC-01 fallback before MCP client admission."
 related:
   - ../../AGENTS.md

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: b4d8e0cbbb16b3fd4b0565b95132243b659883a1
+lastReviewedCommit: 92a7bb85152d0d7ac5de07b6ad4c5ada7749aef6
 lastReviewedNote: "Reviewed for Issue #568: the OAuth bundle regression advances the exact migration head to 20260831130000; helper commands and stable-overlay rules are unchanged."
 related:
   - ../AGENTS.md

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: b4d8e0cbbb16b3fd4b0565b95132243b659883a1
+lastReviewedCommit: 92a7bb85152d0d7ac5de07b6ad4c5ada7749aef6
 lastReviewedNote: "为 Issue #568 复核：OAuth bundle 回归把精确 migration head 推进到 20260831130000；helper 命令与稳定 overlay 规则不变。"
 related:
   - ../AGENTS.md

--- a/supabase/migrations/20260901173000_national_carbon_daily_version_creation.sql
+++ b/supabase/migrations/20260901173000_national_carbon_daily_version_creation.sql
@@ -1,3 +1,6 @@
+-- Issue #578: expose the last 53 calendar weeks of daily Process and
+-- LifecycleModel version creation counts in the organization dashboard snapshot.
+
 CREATE OR REPLACE FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer DEFAULT 10) RETURNS "jsonb"
     LANGUAGE "plpgsql" STABLE SECURITY DEFINER
     SET "search_path" TO ''
@@ -415,3 +418,4 @@ ALTER FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" 
 REVOKE ALL ON FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) FROM PUBLIC;
 
 GRANT ALL ON FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) TO "authenticated";
+

--- a/supabase/migrations/20260901173000_national_carbon_daily_version_creation.sql
+++ b/supabase/migrations/20260901173000_national_carbon_daily_version_creation.sql
@@ -90,13 +90,13 @@ begin
       'timezone', 'Asia/Shanghai',
       'startDate', bounds.start_date,
       'endDate', bounds.end_date,
-      'days', pg_catalog.coalesce(
+      'days', coalesce(
         pg_catalog.jsonb_agg(
           pg_catalog.jsonb_build_object(
             'date', series.created_date,
-            'processCount', pg_catalog.coalesce(counts.process_count, 0::bigint),
-            'modelCount', pg_catalog.coalesce(counts.model_count, 0::bigint),
-            'allCount', pg_catalog.coalesce(counts.all_count, 0::bigint)
+            'processCount', coalesce(counts.process_count, 0::bigint),
+            'modelCount', coalesce(counts.model_count, 0::bigint),
+            'allCount', coalesce(counts.all_count, 0::bigint)
           )
           order by series.created_date
         ),

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -445,7 +445,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260901160000'::text,
+  '20260901173000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260901_national_carbon_organization_contributions.sql
+++ b/supabase/tests/20260901_national_carbon_organization_contributions.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, api, private, auth;
 
-select plan(20);
+select plan(27);
 
 select is(
   (
@@ -207,10 +207,77 @@ reset role;
 
 select is(
   snapshot ->> 'schemaVersion',
-  'national_carbon_organization_contribution_v1'::text,
-  'the response uses the frozen v1 schema'
+  'national_carbon_organization_contribution_v2'::text,
+  'the response uses the frozen v2 schema'
 )
 from organization_contribution_result;
+
+select ok(
+  snapshot #>> '{dailyCreation,metric}' = 'dataset_version_created_count'
+    and snapshot #> '{dailyCreation,deduplicationKey}' =
+      '["datasetType", "datasetId", "version"]'::jsonb
+    and snapshot #>> '{dailyCreation,timezone}' = 'Asia/Shanghai',
+  'daily creation metadata freezes the version identity and reporting timezone'
+)
+from organization_contribution_result;
+
+select ok(
+  snapshot #>> '{dailyCreation,startDate}' = (
+    date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364
+  )::text
+    and snapshot #>> '{dailyCreation,endDate}' =
+      timezone('Asia/Shanghai', statement_timestamp())::date::text
+    and jsonb_array_length(snapshot #> '{dailyCreation,days}') =
+      timezone('Asia/Shanghai', statement_timestamp())::date
+        - (
+          date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364
+        ) + 1,
+  'daily creation covers 53 calendar-week columns through the current Shanghai date'
+)
+from organization_contribution_result;
+
+select is(
+  (
+    select sum((day ->> 'processCount')::bigint)
+    from organization_contribution_result
+    cross join lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') as day
+  ),
+  9::numeric,
+  'daily Process creation counts every retained Process id-version row regardless of state or organization'
+);
+
+select is(
+  (
+    select sum((day ->> 'modelCount')::bigint)
+    from organization_contribution_result
+    cross join lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') as day
+  ),
+  5::numeric,
+  'daily Model creation counts every retained LifecycleModel id-version row'
+);
+
+select is(
+  (
+    select sum((day ->> 'allCount')::bigint)
+    from organization_contribution_result
+    cross join lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') as day
+  ),
+  14::numeric,
+  'daily All creation keeps Process and Model identities separate before summing them'
+);
+
+select is(
+  (
+    select day - 'date'
+    from organization_contribution_result
+    cross join lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') as day
+    where day ->> 'date' = (
+      timezone('Asia/Shanghai', statement_timestamp())::date - 2
+    )::text
+  ),
+  '{"processCount": 1, "modelCount": 1, "allCount": 2}'::jsonb,
+  'the same local day reports separate Process and Model counts plus their total'
+);
 
 select is(
   snapshot #>> '{scopes,process,summary,publishedDatasetCount}',
@@ -303,6 +370,29 @@ select is(
   'pending-only and unassigned organizations do not enter the Process ranking'
 )
 from organization_contribution_result;
+
+delete from public.processes
+where id = '57410000-0000-4000-8000-000000000005'
+  and version = '02.00.000';
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '57400000-0000-4000-8000-000000000001', true);
+select set_config(
+  'request.jwt.claims',
+  '{"role":"authenticated","sub":"57400000-0000-4000-8000-000000000001"}',
+  true
+);
+select is(
+  (
+    select sum((day ->> 'allCount')::bigint)
+    from jsonb_array_elements(
+      api.qry_national_carbon_organization_contributions(10) #> '{dailyCreation,days}'
+    ) as day
+  ),
+  13::numeric,
+  'physical deletion removes the version from historical daily creation counts'
+);
+reset role;
 
 select * from finish();
 

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: b4d8e0cbbb16b3fd4b0565b95132243b659883a1
+lastReviewedCommit: 92a7bb85152d0d7ac5de07b6ad4c5ada7749aef6
 lastReviewedNote: "Reviewed for Issue #568: the forward repair changes only capability-manifest data; generated Data API types, workspace ownership, refresh, and stable-overlay rules are unchanged."
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,7 +21,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-01
-lastReviewedCommit: b4d8e0cbbb16b3fd4b0565b95132243b659883a1
+lastReviewedCommit: 92a7bb85152d0d7ac5de07b6ad4c5ada7749aef6
 lastReviewedNote: "为 Issue #568 复核：追加修复只改变能力 manifest 数据；生成的 Data API types、workspace 所有权、刷新与稳定 overlay 规则均不变。"
 related:
   - ../../AGENTS.md

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -20475,6 +20475,93 @@ begin
   end if;
 
   with
+  daily_date_bounds as materialized (
+    select
+      (
+        pg_catalog.date_trunc(
+          'week',
+          pg_catalog.timezone('Asia/Shanghai', pg_catalog.statement_timestamp())
+        )::date - 364
+      ) as start_date,
+      pg_catalog.timezone(
+        'Asia/Shanghai',
+        pg_catalog.statement_timestamp()
+      )::date as end_date
+  ),
+  daily_time_bounds as materialized (
+    select
+      bounds.start_date,
+      bounds.end_date,
+      pg_catalog.timezone(
+        'Asia/Shanghai',
+        bounds.start_date::timestamp without time zone
+      ) as start_at,
+      pg_catalog.timezone(
+        'Asia/Shanghai',
+        (bounds.end_date + 1)::timestamp without time zone
+      ) as end_at
+    from daily_date_bounds as bounds
+  ),
+  daily_version_facts as materialized (
+    select
+      'process'::text as dataset_kind,
+      pg_catalog.timezone('Asia/Shanghai', process_row.created_at)::date as created_date
+    from public.processes as process_row
+    cross join daily_time_bounds as bounds
+    where process_row.created_at >= bounds.start_at
+      and process_row.created_at < bounds.end_at
+    union all
+    select
+      'model'::text as dataset_kind,
+      pg_catalog.timezone('Asia/Shanghai', model_row.created_at)::date as created_date
+    from public.lifecyclemodels as model_row
+    cross join daily_time_bounds as bounds
+    where model_row.created_at >= bounds.start_at
+      and model_row.created_at < bounds.end_at
+  ),
+  daily_version_counts as materialized (
+    select
+      fact.created_date,
+      pg_catalog.count(*) filter (where fact.dataset_kind = 'process')::bigint
+        as process_count,
+      pg_catalog.count(*) filter (where fact.dataset_kind = 'model')::bigint
+        as model_count,
+      pg_catalog.count(*)::bigint as all_count
+    from daily_version_facts as fact
+    group by fact.created_date
+  ),
+  daily_creation_payload as materialized (
+    select pg_catalog.jsonb_build_object(
+      'metric', 'dataset_version_created_count',
+      'deduplicationKey', pg_catalog.jsonb_build_array('datasetType', 'datasetId', 'version'),
+      'timezone', 'Asia/Shanghai',
+      'startDate', bounds.start_date,
+      'endDate', bounds.end_date,
+      'days', pg_catalog.coalesce(
+        pg_catalog.jsonb_agg(
+          pg_catalog.jsonb_build_object(
+            'date', series.created_date,
+            'processCount', pg_catalog.coalesce(counts.process_count, 0::bigint),
+            'modelCount', pg_catalog.coalesce(counts.model_count, 0::bigint),
+            'allCount', pg_catalog.coalesce(counts.all_count, 0::bigint)
+          )
+          order by series.created_date
+        ),
+        '[]'::jsonb
+      )
+    ) as payload
+    from daily_time_bounds as bounds
+    cross join lateral pg_catalog.generate_series(
+      bounds.start_date::timestamp without time zone,
+      bounds.end_date::timestamp without time zone,
+      interval '1 day'
+    ) as generated(created_at)
+    cross join lateral (
+      select generated.created_at::date as created_date
+    ) as series
+    left join daily_version_counts as counts using (created_date)
+    group by bounds.start_date, bounds.end_date
+  ),
   latest_published_process as materialized (
     select distinct on (process_row.id)
       'process'::text as dataset_kind,
@@ -20746,11 +20833,14 @@ begin
     from contribution_facts as fact
   )
   select pg_catalog.jsonb_build_object(
-    'schemaVersion', 'national_carbon_organization_contribution_v1',
+    'schemaVersion', 'national_carbon_organization_contribution_v2',
     'attributionMode', 'current_user_profile',
     'generatedAt', pg_catalog.statement_timestamp(),
     'dataAsOf', metadata.data_as_of,
     'defaultScope', 'all',
+    'dailyCreation', (
+      select payload from daily_creation_payload
+    ),
     'scopes', pg_catalog.jsonb_build_object(
       'process', (
         select payload from scope_payloads where dataset_scope = 'process'
@@ -20769,7 +20859,6 @@ begin
   return v_result;
 end;
 $$;
-
 
 ALTER FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) OWNER TO "postgres";
 
@@ -75871,8 +75960,6 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUN
 
 
 ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TABLES TO "postgres";
-
-
 
 
 

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -20860,6 +20860,7 @@ begin
 end;
 $$;
 
+
 ALTER FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) OWNER TO "postgres";
 
 
@@ -75960,6 +75961,8 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON FUN
 
 
 ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TABLES TO "postgres";
+
+
 
 
 

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -20537,13 +20537,13 @@ begin
       'timezone', 'Asia/Shanghai',
       'startDate', bounds.start_date,
       'endDate', bounds.end_date,
-      'days', pg_catalog.coalesce(
+      'days', coalesce(
         pg_catalog.jsonb_agg(
           pg_catalog.jsonb_build_object(
             'date', series.created_date,
-            'processCount', pg_catalog.coalesce(counts.process_count, 0::bigint),
-            'modelCount', pg_catalog.coalesce(counts.model_count, 0::bigint),
-            'allCount', pg_catalog.coalesce(counts.all_count, 0::bigint)
+            'processCount', coalesce(counts.process_count, 0::bigint),
+            'modelCount', coalesce(counts.model_count, 0::bigint),
+            'allCount', coalesce(counts.all_count, 0::bigint)
           )
           order by series.created_date
         ),

--- a/supabase/workspace/schemas/api/functions/qry_national_carbon_organization_contributions/definition.sql
+++ b/supabase/workspace/schemas/api/functions/qry_national_carbon_organization_contributions/definition.sql
@@ -87,13 +87,13 @@ begin
       'timezone', 'Asia/Shanghai',
       'startDate', bounds.start_date,
       'endDate', bounds.end_date,
-      'days', pg_catalog.coalesce(
+      'days', coalesce(
         pg_catalog.jsonb_agg(
           pg_catalog.jsonb_build_object(
             'date', series.created_date,
-            'processCount', pg_catalog.coalesce(counts.process_count, 0::bigint),
-            'modelCount', pg_catalog.coalesce(counts.model_count, 0::bigint),
-            'allCount', pg_catalog.coalesce(counts.all_count, 0::bigint)
+            'processCount', coalesce(counts.process_count, 0::bigint),
+            'modelCount', coalesce(counts.model_count, 0::bigint),
+            'allCount', coalesce(counts.all_count, 0::bigint)
           )
           order by series.created_date
         ),


### PR DESCRIPTION
## Summary

- upgrade `api.qry_national_carbon_organization_contributions` to schema v2
- add one shared 53-week `dailyCreation` series for Process, Model, and All scopes
- count retained versions by `dataset_type + id + version` on the `Asia/Shanghai` creation date
- keep deletion semantics live: physically deleted versions disappear from historical counts
- reuse the existing `created_at` indexes and fill zero-activity dates with `generate_series`

## Validation

- `git diff --check`
- exact migration / schema-workspace function synchronization check
- Docpact route and enforced lint: pass
- repository pre-push Docpact gate: pass
- pgTAP contract expanded to 27 assertions, including all states, typed identity, zero-filled range, scope totals, and physical deletion

## Remaining environment proof

The host does not have the Supabase CLI, so it did not reset or mutate the existing populated test database. Run the migration and `supabase/tests/20260901_national_carbon_organization_contributions.sql` on the PR Preview or another non-production branch before merge.

Closes #578
