### PR TITLE
Fix stale API contract migration-head assertion

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-02"
-lastReviewedCommit: "967a52b8fa41b42e86c82b9881af2d7ca2e62af3"
-lastReviewedNote: "Reviewed for Issue #589: routing and proof cover the nullable Process model_version contract, exact ownership, legacy fallback, generated workspace, and API closure at migration head 20260902104500."
+lastReviewedCommit: "de868b022d5e9175773c3c4fda103810be7fab7a"
+lastReviewedNote: "Reviewed for Issue #598: SQL-test routing and proof remain unchanged; API closure now tracks checkout migration head 20260902120230 after PR #595."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 26f64543a26b49cc5663548089a771424e21f883
-lastReviewedNote: "Reviewed for Issue #589: nullable exact Process model ownership and its API closure head update preserve repository ownership, branch, RPC-authority, and generated-workspace boundaries."
+lastReviewedCommit: de868b022d5e9175773c3c4fda103810be7fab7a
+lastReviewedNote: "Reviewed for Issue #598: the API closure migration-head assertion repair preserves repository ownership, branch, RPC-authority, and generated-workspace boundaries."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 967a52b8fa41b42e86c82b9881af2d7ca2e62af3
-lastReviewedNote: "Updated for Issue #589: Process ownership now records an optional exact LifecycleModel version while preserving the historical same-version fallback for null legacy rows."
+lastReviewedCommit: de868b022d5e9175773c3c4fda103810be7fab7a
+lastReviewedNote: "Reviewed for Issue #598: the repository-only API closure assertion repair does not change schema boundaries, generated workspace, or branch architecture."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-02
-lastReviewedCommit: 967a52b8fa41b42e86c82b9881af2d7ca2e62af3
-lastReviewedNote: "Reviewed for Issue #589: SQL proof covers exact model-version persistence and reads, null legacy fallback, invalid partial ownership rejection, exact review/bundle membership, and API closure at the checkout migration head."
+lastReviewedCommit: de868b022d5e9175773c3c4fda103810be7fab7a
+lastReviewedNote: "Reviewed for Issue #598: existing clean-reset and targeted pgTAP proof requirements cover the API closure migration-head assertion repair."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -445,7 +445,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260902104500'::text,
+  '20260902120230'::text,
   'service-only schema readback reports the exact migration head'
 );
 


### PR DESCRIPTION
## Summary

- align the API closure assertion with the actual checkout migration head `20260902120230`
- retain dynamic deployed-head readback from `api.svc_schema_contract_status()` without adding or changing any migration
- record completed Docpact review evidence for the repository-only test repair

## Validation

- `python3 scripts/test_supabase_dev_workflow_contract.py` — passed
- Supabase CLI `2.116.0` local `db reset` — passed through `20260902120230_national_carbon_reviewer_assignment_metrics.sql`
- `supabase test db --local supabase/tests/20260806_api_contract_closure.sql` — passed, 46/46
- `scripts/docpact validate-config --root . --strict --format json` — passed
- `scripts/docpact lint --root . --worktree` — passed, zero findings
- pre-push Docpact gate — passed for `de868b0..fd64dd0`

## Deployment boundary

This PR changes no deployable Supabase input: no migration, config, seed, or Function file changes. The official Preview deployment may therefore skip by contract. After merge, the latest persistent-Dev workflow must pass before draft promotion PR #597 is marked ready.

Closes tiangong-lca/database-engine#598
