### PR TITLE
Count daily process creation and latest-update activity

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-03"
-lastReviewedCommit: "fb63d6e5808c9915a665ef9953e321c77fed0b59"
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: "0958524dd71774965c65da12b4fc7e9e0d936e79"
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -276,7 +276,7 @@ must never be used as an authorization, role, team, or RLS input.
 ## National Carbon Process Statistics
 
 `api.qry_national_carbon_organization_contributions(integer)` returns the
-administrator-only `national_carbon_organization_contribution_v4` snapshot.
+administrator-only `national_carbon_organization_contribution_v5` snapshot.
 Only `public.processes` contributes dataset counts; LifecycleModels are not read.
 
 - `rankings` contains up to `p_limit` units with published processes, ordered by
@@ -298,9 +298,18 @@ Only `public.processes` contributes dataset counts; LifecycleModels are not read
   Preserve unknown codes; separate `GLO` and blank/non-string/missing geography.
   These disjoint buckets reconcile to `totalProcessCount`, which can exceed the
   organization-attributed published KPI.
-- `dailyCreation` counts retained process `(id, version)` primary-key rows by
-  `created_at` in Asia/Shanghai, independent of status/unit. It retains the
-  53-week continuous zero-filled date series. Deletion removes a version's count.
+- `dailyActivity` uses `dataset_version_activity_count`: count retained process
+  versions on both their `created_at` and latest `modified_at` dates in
+  Asia/Shanghai, independent of status/unit. Deduplicate by dataset type, ID,
+  version and local date: same-day creation/modification counts once, different
+  days count once each. NULL timestamps contribute no date. Two independently
+  range-filtered, daily-aggregated scans reuse the timestamp B-trees; the
+  modification branch excludes its creation date before `UNION ALL` and summing.
+  The 53-week continuous zero-filled date series remains unchanged. Deletion
+  removes both dates; a later modification replaces the earlier modification
+  date. This is a current-row activity snapshot, not a full audit history.
+  The yearly total sums version-days, not unique versions or edit operations.
+  V5 deliberately replaces V4's `dailyCreation`; consumers must upgrade together.
 
 The RPC aggregates narrow keys/scalars in PostgreSQL, reads geography only after
 selecting winning open keys, and reuses existing latest-key, timestamp and active

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/supabase/migrations/20260903100000_national_carbon_daily_activity.sql
+++ b/supabase/migrations/20260903100000_national_carbon_daily_activity.sql
@@ -1,7 +1,13 @@
-CREATE OR REPLACE FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer DEFAULT 10) RETURNS "jsonb"
-    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
-    SET "search_path" TO ''
-    AS $$
+-- #606: daily process activity from creation and latest modification, not an audit log.
+-- Both raw timestamp ranges reuse existing B-trees. No history table, source write,
+-- index, permission or non-heatmap statistic changes.
+create or replace function api.qry_national_carbon_organization_contributions(
+  p_limit integer default 10
+)
+returns jsonb
+language plpgsql stable security definer
+set search_path = ''
+as $function$
 declare
   v_actor uuid := auth.uid();
   v_result jsonb;
@@ -177,10 +183,8 @@ begin
   ) into v_result;
   return v_result;
 end;
-$$;
+$function$;
 
-ALTER FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) OWNER TO "postgres";
-
-REVOKE ALL ON FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) FROM PUBLIC;
-
-GRANT ALL ON FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) TO "authenticated";
+alter function api.qry_national_carbon_organization_contributions(integer) owner to postgres;
+revoke all on function api.qry_national_carbon_organization_contributions(integer) from public, anon, service_role;
+grant execute on function api.qry_national_carbon_organization_contributions(integer) to authenticated;

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -445,7 +445,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260903090000'::text,
+  '20260903100000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260901_national_carbon_organization_contributions.sql
+++ b/supabase/tests/20260901_national_carbon_organization_contributions.sql
@@ -296,7 +296,7 @@ insert into organization_contribution_result (snapshot)
 select api.qry_national_carbon_organization_contributions(10);
 reset role;
 
-select is(snapshot ->> 'schemaVersion', 'national_carbon_organization_contribution_v4', 'process-only v4 contract') from organization_contribution_result;
+select is(snapshot ->> 'schemaVersion', 'national_carbon_organization_contribution_v5', 'process-only activity v5 contract') from organization_contribution_result;
 select is(snapshot ->> 'datasetScope', 'process', 'scope is fixed to processes') from organization_contribution_result;
 select ok(not snapshot ?| array['scopes', 'defaultScope'], 'no model or combined scopes') from organization_contribution_result;
 select is(snapshot #>> '{summary,organizationCount}', '3', 'all registered normalized units count') from organization_contribution_result;
@@ -316,18 +316,18 @@ select is(snapshot #> '{regions,items}', '[{"locationCode":"CN","processCount":1
 select is(snapshot #>> '{regions,globalProcessCount}', '1', 'GLO is its own non-overlapping bucket') from organization_contribution_result;
 select is(snapshot #>> '{regions,unassignedProcessCount}', '1', 'missing geography is counted separately') from organization_contribution_result;
 select is((select sum((d->>'processCount')::bigint) from organization_contribution_result,
-  lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') d), 9::numeric,
-  'daily creation counts all process versions, regardless of state or unit; ignores models');
+  lateral jsonb_array_elements(snapshot #> '{dailyActivity,days}') d), 10::numeric,
+  'daily activity counts all process versions, regardless of state or unit; ignores models');
 select ok(not exists(select 1 from organization_contribution_result,
-  lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') d
+  lateral jsonb_array_elements(snapshot #> '{dailyActivity,days}') d
   where d ?| array['modelCount','allCount']), 'daily series contains no model or combined counts');
-select ok(snapshot #>> '{dailyCreation,metric}' = 'dataset_version_created_count'
-  and snapshot #> '{dailyCreation,deduplicationKey}' = '["datasetType","datasetId","version"]'::jsonb
-  and snapshot #>> '{dailyCreation,timezone}' = 'Asia/Shanghai', 'daily identity/timezone contract retained')
+select ok(snapshot #>> '{dailyActivity,metric}' = 'dataset_version_activity_count'
+  and snapshot #> '{dailyActivity,deduplicationKey}' = '["datasetType","datasetId","version","date"]'::jsonb
+  and snapshot #>> '{dailyActivity,timezone}' = 'Asia/Shanghai', 'daily identity/timezone contract retained')
 from organization_contribution_result;
-select ok(snapshot #>> '{dailyCreation,startDate}' =
+select ok(snapshot #>> '{dailyActivity,startDate}' =
   (date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364)::text
-  and jsonb_array_length(snapshot #> '{dailyCreation,days}') between 365 and 371,
+  and jsonb_array_length(snapshot #> '{dailyActivity,days}') between 365 and 371,
   'continuous 53-week daily window') from organization_contribution_result;
 
 -- The limit applies only to chart output. More than ten units need no extra query.
@@ -362,7 +362,7 @@ select is(api.qry_national_carbon_organization_contributions(10) #>> '{regions,t
 delete from public.processes where id = '57410000-0000-4000-8000-000000000005' and version = '02.00.000';
 set local session_replication_role = origin;
 select is((select sum((d->>'processCount')::bigint) from jsonb_array_elements(
-  api.qry_national_carbon_organization_contributions(10) #> '{dailyCreation,days}') d),
-  8::numeric, 'deletion removes the version from daily history');
+  api.qry_national_carbon_organization_contributions(10) #> '{dailyActivity,days}') d),
+  9::numeric, 'deletion removes the version from daily history');
 select * from finish();
 rollback;

--- a/supabase/tests/20260903_national_carbon_daily_activity.sql
+++ b/supabase/tests/20260903_national_carbon_daily_activity.sql
@@ -1,0 +1,110 @@
+-- Rollback-only fixtures for an isolated local migration rebuild.
+begin;
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, api, private, auth;
+select no_plan();
+
+create temporary table activity_bounds as
+select timezone('Asia/Shanghai', statement_timestamp())::date - 30 as d,
+  date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364 as start_day,
+  timezone('Asia/Shanghai', statement_timestamp())::date as end_day;
+
+-- Isolate authored timestamps from ordinary writer triggers; no real data is touched.
+set local session_replication_role = replica;
+insert into auth.users (id, raw_user_meta_data)
+values ('60600000-0000-4000-8000-000000000001', '{}');
+insert into private.users (id, raw_user_meta_data)
+values ('60600000-0000-4000-8000-000000000001', '{}');
+insert into private.roles (user_id, team_id, role)
+values ('60600000-0000-4000-8000-000000000001',
+  '00000000-0000-0000-0000-000000000000', 'admin');
+
+insert into public.processes (id, version, state_code, created_at, modified_at)
+select ('60610000-0000-4000-8000-' || lpad(n::text, 12, '0'))::uuid,
+  version, state_code, created_at, modified_at
+from activity_bounds b cross join lateral (values
+  -- Different UTC dates, same Shanghai date: one activity.
+  (1, '01.00.000', 0, (b.d::timestamp - interval '7 hours') at time zone 'UTC',
+    (b.d::timestamp + interval '10 hours') at time zone 'UTC'),
+  (2, '01.00.000', 20, b.d::timestamp at time zone 'Asia/Shanghai',
+    (b.d + 1)::timestamp at time zone 'Asia/Shanghai'),
+  (2, '02.00.000', 0, (b.d + 1)::timestamp at time zone 'Asia/Shanghai',
+    (b.d + 1)::timestamp at time zone 'Asia/Shanghai'),
+  (3, '01.00.000', 100, (b.start_day - 1)::timestamp at time zone 'Asia/Shanghai',
+    (b.d + 2)::timestamp at time zone 'Asia/Shanghai'),
+  (4, '01.00.000', 200, null, (b.d + 3)::timestamp at time zone 'Asia/Shanghai'),
+  (5, '01.00.000', 0, (b.d + 4)::timestamp at time zone 'Asia/Shanghai', null),
+  (6, '01.00.000', 0, null, null),
+  (7, '01.00.000', 0, b.start_day::timestamp at time zone 'Asia/Shanghai',
+    b.start_day::timestamp at time zone 'Asia/Shanghai'),
+  (8, '01.00.000', 0, (b.d + 5)::timestamp at time zone 'Asia/Shanghai',
+    (b.end_day + 1)::timestamp at time zone 'Asia/Shanghai'),
+  -- Same UTC date, different Shanghai dates: two activities.
+  (9, '01.00.000', 0, ((b.d + 6)::timestamp + interval '15:59:59') at time zone 'UTC',
+    ((b.d + 6)::timestamp + interval '16 hours') at time zone 'UTC'),
+  (10, '01.00.000', 0, (b.end_day + 1)::timestamp at time zone 'Asia/Shanghai',
+    (b.end_day + 1)::timestamp at time zone 'Asia/Shanghai'),
+  (11, '01.00.000', 0, (b.end_day::timestamp + interval '23:59:59') at time zone 'Asia/Shanghai', null),
+  (12, '01.00.000', 0, (b.start_day - 2)::timestamp at time zone 'Asia/Shanghai',
+    (b.start_day - 1)::timestamp at time zone 'Asia/Shanghai')
+) v(n, version, state_code, created_at, modified_at);
+
+insert into public.lifecyclemodels (id, version, created_at, modified_at)
+select '60610000-0000-4000-8000-000000000001', '01.00.000',
+  d::timestamp at time zone 'Asia/Shanghai', (d + 8)::timestamp at time zone 'Asia/Shanghai'
+from activity_bounds;
+set local session_replication_role = origin;
+
+create temporary table activity_result (snapshot jsonb);
+grant all on activity_result to authenticated;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '60600000-0000-4000-8000-000000000001', true);
+select set_config('request.jwt.claims', '{"role":"authenticated","sub":"60600000-0000-4000-8000-000000000001"}', true);
+insert into activity_result select api.qry_national_carbon_organization_contributions(10);
+reset role;
+
+select is(snapshot->>'schemaVersion', 'national_carbon_organization_contribution_v5', 'explicit activity v5 contract') from activity_result;
+select ok(snapshot ? 'dailyActivity' and not snapshot ? 'dailyCreation', 'creation-only field is not silently reinterpreted') from activity_result;
+select is(snapshot #>> '{dailyActivity,metric}', 'dataset_version_activity_count', 'activity metric acknowledged') from activity_result;
+select is(snapshot #> '{dailyActivity,deduplicationKey}', '["datasetType","datasetId","version","date"]'::jsonb, 'deduplication includes local day') from activity_result;
+select is(snapshot #>> '{dailyActivity,timezone}', 'Asia/Shanghai', 'timezone is explicit') from activity_result;
+
+create temporary view activity_days as
+select (item->>'date')::date as day, (item->>'processCount')::bigint as count
+from activity_result, lateral jsonb_array_elements(snapshot #> '{dailyActivity,days}') item;
+create temporary table expected_activity as
+select day, count from activity_bounds b cross join lateral (values
+  (b.start_day, 1::bigint), (b.d, 2), (b.d + 1, 2), (b.d + 2, 1),
+  (b.d + 3, 1), (b.d + 4, 1), (b.d + 5, 1), (b.d + 6, 1), (b.d + 7, 1), (b.end_day, 1)
+) v(day, count);
+select results_eq('select day, count from activity_days where count > 0 order by day',
+  'select day, count from expected_activity order by day',
+  'exact union covers versions, status/unit independence, timezone, NULL and both window boundaries');
+select is((select sum(count) from activity_days), 12::numeric, 'total counts version-days, not operations or globally distinct versions');
+select is((select count from activity_days, activity_bounds where day = d + 8), 0::bigint, 'model-only modification does not enter activity');
+select is((select count from activity_days, activity_bounds where day = d + 9), 0::bigint, 'missing activity dates are zero-filled');
+select is((select count(*) from activity_days), (select (end_day - start_day + 1)::bigint from activity_bounds), 'continuous date window unchanged');
+
+-- Changing the session timezone must not move any local-day buckets.
+set local time zone 'America/Los_Angeles';
+select is(api.qry_national_carbon_organization_contributions(1)->'dailyActivity',
+  (select snapshot->'dailyActivity' from activity_result), 'session timezone and chart limit do not alter activity');
+
+set local session_replication_role = replica;
+update public.processes set modified_at = (select (d + 8)::timestamp at time zone 'Asia/Shanghai' from activity_bounds)
+where id = '60610000-0000-4000-8000-000000000002' and version = '01.00.000';
+set local session_replication_role = origin;
+update activity_result set snapshot = api.qry_national_carbon_organization_contributions(10);
+select is((select count from activity_days, activity_bounds where day = d + 1), 1::bigint, 'previous modification removed; distinct version still counts');
+select is((select count from activity_days, activity_bounds where day = d + 8), 1::bigint, 'latest modification replaces earlier modification');
+select is((select count from activity_days, activity_bounds where day = d), 2::bigint, 'creation day preserved after later modification');
+
+set local session_replication_role = replica;
+delete from public.processes where id = '60610000-0000-4000-8000-000000000002' and version = '01.00.000';
+set local session_replication_role = origin;
+update activity_result set snapshot = api.qry_national_carbon_organization_contributions(10);
+select is((select sum(count) from activity_days), 10::numeric, 'deletion removes both creation and latest-modification activity');
+select is((select count from activity_days, activity_bounds where day = d + 8), 0::bigint, 'no deleted-version activity history retained');
+select is((select count from activity_days, activity_bounds where day = d + 1), 1::bigint, 'deleting one version preserves the other');
+select * from finish();
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -20939,19 +20939,34 @@ begin
       pg_catalog.timezone('Asia/Shanghai', pg_catalog.statement_timestamp())::date as end_date
   ),
   daily_counts as (
-    -- The processes primary key already enforces one row per dataset ID + version.
-    -- Date filtering uses created_at directly; status changes do not change creation history.
-    select pg_catalog.timezone('Asia/Shanghai', p.created_at)::date as day,
-      pg_catalog.count(*)::bigint as process_count
-    from public.processes p cross join date_bounds b
-    where p.created_at >= pg_catalog.timezone('Asia/Shanghai', b.start_date::timestamp)
-      and p.created_at < pg_catalog.timezone('Asia/Shanghai', (b.end_date + 1)::timestamp)
-    group by 1
+    -- Each branch uses its existing timestamp B-tree and aggregates before UNION ALL.
+    -- The (id, version) primary key makes each branch unique per version/day.
+    -- Excluding same-local-day modifications makes the branches disjoint without
+    -- sorting/hashing the entire version identity set. NULL creation dates are safe.
+    select day, pg_catalog.sum(process_count)::bigint as process_count
+    from (
+      select pg_catalog.timezone('Asia/Shanghai', p.created_at)::date as day,
+        pg_catalog.count(*)::bigint as process_count
+      from public.processes p cross join date_bounds b
+      where p.created_at >= pg_catalog.timezone('Asia/Shanghai', b.start_date::timestamp)
+        and p.created_at < pg_catalog.timezone('Asia/Shanghai', (b.end_date + 1)::timestamp)
+      group by 1
+      union all
+      select pg_catalog.timezone('Asia/Shanghai', p.modified_at)::date as day,
+        pg_catalog.count(*)::bigint as process_count
+      from public.processes p cross join date_bounds b
+      where p.modified_at >= pg_catalog.timezone('Asia/Shanghai', b.start_date::timestamp)
+        and p.modified_at < pg_catalog.timezone('Asia/Shanghai', (b.end_date + 1)::timestamp)
+        and pg_catalog.timezone('Asia/Shanghai', p.modified_at)::date
+          is distinct from pg_catalog.timezone('Asia/Shanghai', p.created_at)::date
+      group by 1
+    ) activity
+    group by day
   ),
   daily_payload as (
     select pg_catalog.jsonb_build_object(
-      'metric', 'dataset_version_created_count',
-      'deduplicationKey', pg_catalog.jsonb_build_array('datasetType', 'datasetId', 'version'),
+      'metric', 'dataset_version_activity_count',
+      'deduplicationKey', pg_catalog.jsonb_build_array('datasetType', 'datasetId', 'version', 'date'),
       'timezone', 'Asia/Shanghai', 'startDate', b.start_date, 'endDate', b.end_date,
       'days', pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
         'date', d.day::date, 'processCount', coalesce(c.process_count, 0)
@@ -21048,7 +21063,7 @@ begin
     from locations group by location_code
   )
   select pg_catalog.jsonb_build_object(
-    'schemaVersion', 'national_carbon_organization_contribution_v4',
+    'schemaVersion', 'national_carbon_organization_contribution_v5',
     'datasetScope', 'process', 'attributionMode', 'current_user_profile',
     'generatedAt', pg_catalog.statement_timestamp(),
     'dataAsOf', coalesce((select pg_catalog.max(modified_at) from facts), pg_catalog.statement_timestamp()),
@@ -21073,7 +21088,7 @@ begin
       'globalProcessCount', coalesce((select process_count from regions where location_code = 'GLO'), 0),
       'unassignedProcessCount', coalesce((select process_count from regions where location_code is null), 0)
     ),
-    'dailyCreation', (select payload from daily_payload)
+    'dailyActivity', (select payload from daily_payload)
   ) into v_result;
   return v_result;
 end;


### PR DESCRIPTION
## Summary

Closes #606.

- Upgrade the administrator-only National Carbon RPC to `national_carbon_organization_contribution_v5` and return `dailyActivity` with the explicit `dataset_version_activity_count` metric.
- Count each retained Process version on its creation and latest-modification dates in Asia/Shanghai. Same-version/same-day creation and modification count once; different dates count once on each date. NULL timestamps add no event; deletion removes both dates and subsequent edits replace the prior modification date.
- Keep all other process-only organization, geography, reviewer and permission behavior unchanged. No model counts, history table, new index or source-data write is introduced.
- Two independent raw timestamp range filters reuse existing B-trees, aggregate by date before UNION ALL and return the existing zero-filled yearly calendar. The yearly sum counts version-days, not distinct versions or all edit operations.
- Add append-only migration `20260903100000_national_carbon_daily_activity.sql`, regression cases, generated schema and matching architecture/review documentation.

## Validation

- Complete migration rebuild passed in the task-owned isolated local Supabase project (no shared or remote database reset).
- **98 pgTAP assertions passed** across `20260806_api_contract_closure.sql`, `20260901_national_carbon_organization_contributions.sql`, and `20260903_national_carbon_daily_activity.sql`.
- Cases cover same-day deduplication, cross-day activity, independent versions, status/organization independence, model exclusion, NULL timestamps, both calendar boundaries, session timezone independence, zero filling, later-modification replacement, deletion and unchanged ACLs/other metrics.
- Canonical schema generated twice with byte-identical outputs; generated Data API types unchanged. Migration-head and retired-table checks passed.
- Complete changed-path Docpact and `git diff --check` passed. The push hook enforces the committed Docpact gate.
- No synthetic 50k benchmark, production-volume timing claim or remote mutation. Isolated local database stopped with backup retained.

## Compatibility and rollout

This intentionally replaces v4 `dailyCreation`; consumers must deploy the v5 decoder with the backend. Frontend work is tracked at https://github.com/linancn/tiangong-lca-next/issues/1014 and remains on its existing branch; it is not included in this PR. Its old-payload rejection prevents creation-only values from being labelled as activity.

After merge, verify the database-owned Dev deployment reaches migration `20260903100000`, hosted catalog checks pass, and remote-Dev schema generation matches this exact-local review snapshot. Promote and workspace integration remain separate future actions. This PR does not authorize automatic merge or manual remote deployment.
