### PR TITLE
chore: promote dashboard statistics dev to main (2026-09-03)

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-02"
-lastReviewedCommit: '592c669ef2083e709305fccc6a0ca9704621baf9'
-lastReviewedNote: 'Reviewed for Database #600: additive version-aware Portal/Next APIs retain immutable projections and legacy interfaces; bounded candidates, exact groups, ACLs and local proof are explicit.'
+lastReviewedAt: "2026-09-03"
+lastReviewedCommit: "fb63d6e5808c9915a665ef9953e321c77fed0b59"
+lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-03"
-lastReviewedCommit: "fb63d6e5808c9915a665ef9953e321c77fed0b59"
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: "0958524dd71774965c65da12b4fc7e9e0d936e79"
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: '592c669ef2083e709305fccc6a0ca9704621baf9'
-lastReviewedNote: 'Reviewed for Database #600: additive version-aware Portal/Next APIs retain immutable projections and legacy interfaces; bounded candidates, exact groups, ACLs and local proof are explicit.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
+lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -31,8 +31,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -276,7 +276,7 @@ must never be used as an authorization, role, team, or RLS input.
 ## National Carbon Process Statistics
 
 `api.qry_national_carbon_organization_contributions(integer)` returns the
-administrator-only `national_carbon_organization_contribution_v4` snapshot.
+administrator-only `national_carbon_organization_contribution_v5` snapshot.
 Only `public.processes` contributes dataset counts; LifecycleModels are not read.
 
 - `rankings` contains up to `p_limit` units with published processes, ordered by
@@ -298,9 +298,18 @@ Only `public.processes` contributes dataset counts; LifecycleModels are not read
   Preserve unknown codes; separate `GLO` and blank/non-string/missing geography.
   These disjoint buckets reconcile to `totalProcessCount`, which can exceed the
   organization-attributed published KPI.
-- `dailyCreation` counts retained process `(id, version)` primary-key rows by
-  `created_at` in Asia/Shanghai, independent of status/unit. It retains the
-  53-week continuous zero-filled date series. Deletion removes a version's count.
+- `dailyActivity` uses `dataset_version_activity_count`: count retained process
+  versions on both their `created_at` and latest `modified_at` dates in
+  Asia/Shanghai, independent of status/unit. Deduplicate by dataset type, ID,
+  version and local date: same-day creation/modification counts once, different
+  days count once each. NULL timestamps contribute no date. Two independently
+  range-filtered, daily-aggregated scans reuse the timestamp B-trees; the
+  modification branch excludes its creation date before `UNION ALL` and summing.
+  The 53-week continuous zero-filled date series remains unchanged. Deletion
+  removes both dates; a later modification replaces the earlier modification
+  date. This is a current-row activity snapshot, not a full audit history.
+  The yearly total sums version-days, not unique versions or edit operations.
+  V5 deliberately replaces V4's `dailyCreation`; consumers must upgrade together.
 
 The RPC aggregates narrow keys/scalars in PostgreSQL, reads geography only after
 selecting winning open keys, and reuses existing latest-key, timestamp and active

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,9 +30,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: '592c669ef2083e709305fccc6a0ca9704621baf9'
-lastReviewedNote: 'Reviewed for Database #600: additive version-aware Portal/Next APIs retain immutable projections and legacy interfaces; bounded candidates, exact groups, ACLs and local proof are explicit.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
+lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -272,6 +272,40 @@ organization as a trimmed string of at most 200 characters. The database
 validates that representation on `private.users`; the existing Auth-to-private
 mirror remains its only synchronization path. This descriptive profile value
 must never be used as an authorization, role, team, or RLS input.
+
+## National Carbon Process Statistics
+
+`api.qry_national_carbon_organization_contributions(integer)` returns the
+administrator-only `national_carbon_organization_contribution_v4` snapshot.
+Only `public.processes` contributes dataset counts; LifecycleModels are not read.
+
+- `rankings` contains up to `p_limit` units with published processes, ordered by
+  published count and stable normalized unit name. `organizations` contains every
+  non-empty current profile organization, including review-only and zero-data
+  units. The limit never truncates `organizations` or summary metrics.
+- Unit attribution uses normalized `private.users.raw_user_meta_data.organization`.
+  Published and pending-review summary counts retain the organization-attributed
+  scope. Pending review uses the latest process version at state 20; its active
+  root review state 1 means assigned, while state 0 or no active root means
+  awaiting assignment. Counts represent datasets, not reviewer assignments.
+- `summary.reviewerCount` counts distinct users whose role is `review-member` in
+  the platform team (`00000000-0000-0000-0000-000000000000`); administrators and
+  memberships in other teams are excluded.
+- `regions` covers **all** open (`state_code=100`) process IDs, including owners
+  without a unit. Select the latest open version before reading its
+  `json_ordered.processDataSet.processInformation.geography.locationOfOperationSupplyOrProduction.@location`.
+  Trim and uppercase codes without folding country/subdivision codes together.
+  Preserve unknown codes; separate `GLO` and blank/non-string/missing geography.
+  These disjoint buckets reconcile to `totalProcessCount`, which can exceed the
+  organization-attributed published KPI.
+- `dailyCreation` counts retained process `(id, version)` primary-key rows by
+  `created_at` in Asia/Shanghai, independent of status/unit. It retains the
+  53-week continuous zero-filled date series. Deletion removes a version's count.
+
+The RPC aggregates narrow keys/scalars in PostgreSQL, reads geography only after
+selecting winning open keys, and reuses existing latest-key, timestamp and active
+root-review indexes. No wide-row client download, per-unit query, backend
+pagination, new JSON GIN index, or synthetic 50,000-row benchmark is required.
 
 ## Stable Path Map
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,9 +32,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: '592c669ef2083e709305fccc6a0ca9704621baf9'
-lastReviewedNote: 'Reviewed for Database #600: additive version-aware Portal/Next APIs retain immutable projections and legacy interfaces; bounded candidates, exact groups, ACLs and local proof are explicit.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
+lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -33,8 +33,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,9 +20,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: '592c669ef2083e709305fccc6a0ca9704621baf9'
-lastReviewedNote: 'Reviewed for Database #600: additive version-aware Portal/Next APIs retain immutable projections and legacy interfaces; bounded candidates, exact groups, ACLs and local proof are explicit.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
+lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: '592c669ef2083e709305fccc6a0ca9704621baf9'
-lastReviewedNote: 'Reviewed for Database #600: additive version-aware Portal/Next APIs retain immutable projections and legacy interfaces; bounded candidates, exact groups, ACLs and local proof are explicit.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
+lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/supabase/migrations/20260903090000_national_carbon_process_statistics.sql
+++ b/supabase/migrations/20260903090000_national_carbon_process_statistics.sql
@@ -1,7 +1,13 @@
-CREATE OR REPLACE FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer DEFAULT 10) RETURNS "jsonb"
-    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
-    SET "search_path" TO ''
-    AS $$
+-- #604: process-only dashboard. p_limit limits the chart, never the organization table.
+-- Existing primary (id, version), published/latest-version, created_at, and active-root
+-- review indexes serve the narrow scans. Do not index or aggregate whole json_ordered values.
+create or replace function api.qry_national_carbon_organization_contributions(
+  p_limit integer default 10
+)
+returns jsonb
+language plpgsql stable security definer
+set search_path = ''
+as $function$
 declare
   v_actor uuid := auth.uid();
   v_result jsonb;
@@ -162,10 +168,8 @@ begin
   ) into v_result;
   return v_result;
 end;
-$$;
+$function$;
 
-ALTER FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) OWNER TO "postgres";
-
-REVOKE ALL ON FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) FROM PUBLIC;
-
-GRANT ALL ON FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) TO "authenticated";
+alter function api.qry_national_carbon_organization_contributions(integer) owner to postgres;
+revoke all on function api.qry_national_carbon_organization_contributions(integer) from public, anon, service_role;
+grant execute on function api.qry_national_carbon_organization_contributions(integer) to authenticated;

--- a/supabase/migrations/20260903100000_national_carbon_daily_activity.sql
+++ b/supabase/migrations/20260903100000_national_carbon_daily_activity.sql
@@ -1,7 +1,13 @@
-CREATE OR REPLACE FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer DEFAULT 10) RETURNS "jsonb"
-    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
-    SET "search_path" TO ''
-    AS $$
+-- #606: daily process activity from creation and latest modification, not an audit log.
+-- Both raw timestamp ranges reuse existing B-trees. No history table, source write,
+-- index, permission or non-heatmap statistic changes.
+create or replace function api.qry_national_carbon_organization_contributions(
+  p_limit integer default 10
+)
+returns jsonb
+language plpgsql stable security definer
+set search_path = ''
+as $function$
 declare
   v_actor uuid := auth.uid();
   v_result jsonb;
@@ -177,10 +183,8 @@ begin
   ) into v_result;
   return v_result;
 end;
-$$;
+$function$;
 
-ALTER FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) OWNER TO "postgres";
-
-REVOKE ALL ON FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) FROM PUBLIC;
-
-GRANT ALL ON FUNCTION "api"."qry_national_carbon_organization_contributions"("p_limit" integer) TO "authenticated";
+alter function api.qry_national_carbon_organization_contributions(integer) owner to postgres;
+revoke all on function api.qry_national_carbon_organization_contributions(integer) from public, anon, service_role;
+grant execute on function api.qry_national_carbon_organization_contributions(integer) to authenticated;

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -445,7 +445,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260903090000'::text,
+  '20260903100000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -445,7 +445,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260902151000'::text,
+  '20260903090000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260901_national_carbon_organization_contributions.sql
+++ b/supabase/tests/20260901_national_carbon_organization_contributions.sql
@@ -296,7 +296,7 @@ insert into organization_contribution_result (snapshot)
 select api.qry_national_carbon_organization_contributions(10);
 reset role;
 
-select is(snapshot ->> 'schemaVersion', 'national_carbon_organization_contribution_v4', 'process-only v4 contract') from organization_contribution_result;
+select is(snapshot ->> 'schemaVersion', 'national_carbon_organization_contribution_v5', 'process-only activity v5 contract') from organization_contribution_result;
 select is(snapshot ->> 'datasetScope', 'process', 'scope is fixed to processes') from organization_contribution_result;
 select ok(not snapshot ?| array['scopes', 'defaultScope'], 'no model or combined scopes') from organization_contribution_result;
 select is(snapshot #>> '{summary,organizationCount}', '3', 'all registered normalized units count') from organization_contribution_result;
@@ -316,18 +316,18 @@ select is(snapshot #> '{regions,items}', '[{"locationCode":"CN","processCount":1
 select is(snapshot #>> '{regions,globalProcessCount}', '1', 'GLO is its own non-overlapping bucket') from organization_contribution_result;
 select is(snapshot #>> '{regions,unassignedProcessCount}', '1', 'missing geography is counted separately') from organization_contribution_result;
 select is((select sum((d->>'processCount')::bigint) from organization_contribution_result,
-  lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') d), 9::numeric,
-  'daily creation counts all process versions, regardless of state or unit; ignores models');
+  lateral jsonb_array_elements(snapshot #> '{dailyActivity,days}') d), 10::numeric,
+  'daily activity counts all process versions, regardless of state or unit; ignores models');
 select ok(not exists(select 1 from organization_contribution_result,
-  lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') d
+  lateral jsonb_array_elements(snapshot #> '{dailyActivity,days}') d
   where d ?| array['modelCount','allCount']), 'daily series contains no model or combined counts');
-select ok(snapshot #>> '{dailyCreation,metric}' = 'dataset_version_created_count'
-  and snapshot #> '{dailyCreation,deduplicationKey}' = '["datasetType","datasetId","version"]'::jsonb
-  and snapshot #>> '{dailyCreation,timezone}' = 'Asia/Shanghai', 'daily identity/timezone contract retained')
+select ok(snapshot #>> '{dailyActivity,metric}' = 'dataset_version_activity_count'
+  and snapshot #> '{dailyActivity,deduplicationKey}' = '["datasetType","datasetId","version","date"]'::jsonb
+  and snapshot #>> '{dailyActivity,timezone}' = 'Asia/Shanghai', 'daily identity/timezone contract retained')
 from organization_contribution_result;
-select ok(snapshot #>> '{dailyCreation,startDate}' =
+select ok(snapshot #>> '{dailyActivity,startDate}' =
   (date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364)::text
-  and jsonb_array_length(snapshot #> '{dailyCreation,days}') between 365 and 371,
+  and jsonb_array_length(snapshot #> '{dailyActivity,days}') between 365 and 371,
   'continuous 53-week daily window') from organization_contribution_result;
 
 -- The limit applies only to chart output. More than ten units need no extra query.
@@ -362,7 +362,7 @@ select is(api.qry_national_carbon_organization_contributions(10) #>> '{regions,t
 delete from public.processes where id = '57410000-0000-4000-8000-000000000005' and version = '02.00.000';
 set local session_replication_role = origin;
 select is((select sum((d->>'processCount')::bigint) from jsonb_array_elements(
-  api.qry_national_carbon_organization_contributions(10) #> '{dailyCreation,days}') d),
-  8::numeric, 'deletion removes the version from daily history');
+  api.qry_national_carbon_organization_contributions(10) #> '{dailyActivity,days}') d),
+  9::numeric, 'deletion removes the version from daily history');
 select * from finish();
 rollback;

--- a/supabase/tests/20260901_national_carbon_organization_contributions.sql
+++ b/supabase/tests/20260901_national_carbon_organization_contributions.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = extensions, public, api, private, auth;
 
-select plan(29);
+select no_plan();
 
 select is(
   (
@@ -231,6 +231,23 @@ values
     '57400000-0000-4000-8000-000000000004'
   );
 
+update public.processes set json_ordered = json_build_object(
+  'processDataSet', json_build_object('processInformation', json_build_object(
+    'geography', json_build_object('locationOfOperationSupplyOrProduction',
+      json_build_object('@location', case
+        when id = '57410000-0000-4000-8000-000000000001' and version = '01.00.000' then 'DE'
+        when id = '57410000-0000-4000-8000-000000000001' then ' cn '
+        when id = '57410000-0000-4000-8000-000000000002' then 'ZZ'
+        when id = '57410000-0000-4000-8000-000000000003' then 'GLO'
+        else null end)))))
+where id::text like '57410000-%';
+
+insert into private.roles (user_id, team_id, role) values
+  ('57400000-0000-4000-8000-000000000002', '00000000-0000-0000-0000-000000000000', 'review-member'),
+  ('57400000-0000-4000-8000-000000000003', '00000000-0000-0000-0000-000000000000', 'review-member'),
+  ('57400000-0000-4000-8000-000000000003', '57400000-0000-4000-8000-000000000010', 'review-member'),
+  ('57400000-0000-4000-8000-000000000004', '57400000-0000-4000-8000-000000000010', 'review-member');
+
 set local session_replication_role = origin;
 
 select set_config('request.jwt.claim.sub', '', true);
@@ -279,212 +296,73 @@ insert into organization_contribution_result (snapshot)
 select api.qry_national_carbon_organization_contributions(10);
 reset role;
 
-select is(
-  snapshot ->> 'schemaVersion',
-  'national_carbon_organization_contribution_v3'::text,
-  'the response uses the reviewer-assignment v3 schema'
-)
+select is(snapshot ->> 'schemaVersion', 'national_carbon_organization_contribution_v4', 'process-only v4 contract') from organization_contribution_result;
+select is(snapshot ->> 'datasetScope', 'process', 'scope is fixed to processes') from organization_contribution_result;
+select ok(not snapshot ?| array['scopes', 'defaultScope'], 'no model or combined scopes') from organization_contribution_result;
+select is(snapshot #>> '{summary,organizationCount}', '3', 'all registered normalized units count') from organization_contribution_result;
+select is(snapshot #>> '{summary,publishedDatasetCount}', '3', 'latest open process IDs attributed to current units') from organization_contribution_result;
+select is(snapshot #>> '{summary,pendingReviewDatasetCount}', '2', 'only latest state-20 processes count') from organization_contribution_result;
+select is(snapshot #>> '{summary,reviewerCount}', '2', 'only distinct platform review-members, not admins or foreign-team memberships') from organization_contribution_result;
+select ok(not (snapshot -> 'summary') ? 'publishedLast30DaysCount', 'retired 30-day KPI omitted') from organization_contribution_result;
+select is(jsonb_array_length(snapshot -> 'rankings'), 1, 'chart excludes zero-published units') from organization_contribution_result;
+select is(jsonb_array_length(snapshot -> 'organizations'), 3, 'table includes pending-only and zero-data units') from organization_contribution_result;
+select is(snapshot #>> '{rankings,0,organizationKey}', 'acme labs', 'case and whitespace normalization retained') from organization_contribution_result;
+select is(snapshot #>> '{rankings,0,publishedDatasetCount}', '3', 'model publication does not affect process rankings') from organization_contribution_result;
+select is(snapshot #>> '{organizations,1,assignedReviewerDatasetCount}', '1', 'Beta assigned review counted by current version') from organization_contribution_result;
+select is(snapshot #>> '{organizations,1,unassignedReviewerDatasetCount}', '1', 'Beta pending assignment counted independently') from organization_contribution_result;
+select is(snapshot #>> '{organizations,2,publishedDatasetCount}', '0', 'unit with no facts is returned with zeroes') from organization_contribution_result;
+select is(snapshot #>> '{regions,totalProcessCount}', '4', 'regions include every open process, including unknown organizations') from organization_contribution_result;
+select is(snapshot #> '{regions,items}', '[{"locationCode":"CN","processCount":1},{"locationCode":"ZZ","processCount":1}]'::jsonb, 'latest published geography is normalized; unknown codes are retained; old DE version excluded') from organization_contribution_result;
+select is(snapshot #>> '{regions,globalProcessCount}', '1', 'GLO is its own non-overlapping bucket') from organization_contribution_result;
+select is(snapshot #>> '{regions,unassignedProcessCount}', '1', 'missing geography is counted separately') from organization_contribution_result;
+select is((select sum((d->>'processCount')::bigint) from organization_contribution_result,
+  lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') d), 9::numeric,
+  'daily creation counts all process versions, regardless of state or unit; ignores models');
+select ok(not exists(select 1 from organization_contribution_result,
+  lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') d
+  where d ?| array['modelCount','allCount']), 'daily series contains no model or combined counts');
+select ok(snapshot #>> '{dailyCreation,metric}' = 'dataset_version_created_count'
+  and snapshot #> '{dailyCreation,deduplicationKey}' = '["datasetType","datasetId","version"]'::jsonb
+  and snapshot #>> '{dailyCreation,timezone}' = 'Asia/Shanghai', 'daily identity/timezone contract retained')
 from organization_contribution_result;
+select ok(snapshot #>> '{dailyCreation,startDate}' =
+  (date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364)::text
+  and jsonb_array_length(snapshot #> '{dailyCreation,days}') between 365 and 371,
+  'continuous 53-week daily window') from organization_contribution_result;
 
-select ok(
-  snapshot #>> '{dailyCreation,metric}' = 'dataset_version_created_count'
-    and snapshot #> '{dailyCreation,deduplicationKey}' =
-      '["datasetType", "datasetId", "version"]'::jsonb
-    and snapshot #>> '{dailyCreation,timezone}' = 'Asia/Shanghai',
-  'daily creation metadata freezes the version identity and reporting timezone'
-)
-from organization_contribution_result;
+-- The limit applies only to chart output. More than ten units need no extra query.
+set local session_replication_role = replica;
+insert into auth.users (id, raw_user_meta_data)
+select ('57400000-0000-4000-8000-' || lpad((100 + n)::text, 12, '0'))::uuid,
+  jsonb_build_object('organization', 'Extra Unit ' || n) from generate_series(1,12) n;
+insert into private.users (id, raw_user_meta_data)
+select id, raw_user_meta_data from auth.users
+where id::text like '57400000-%' and (raw_user_meta_data->>'organization') like 'Extra Unit %'
+on conflict (id) do update set raw_user_meta_data = excluded.raw_user_meta_data;
+set local session_replication_role = origin;
+select is(jsonb_array_length(api.qry_national_carbon_organization_contributions(1)->'organizations'),
+  15, 'all 15 units are returned even with p_limit=1');
+select is(jsonb_array_length(api.qry_national_carbon_organization_contributions(1)->'rankings'),
+  1, 'chart limit still enforced');
+select is(api.qry_national_carbon_organization_contributions(1) #>> '{summary,organizationCount}',
+  '15', 'all-unit total independent of chart');
 
-select ok(
-  snapshot #>> '{dailyCreation,startDate}' = (
-    date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364
-  )::text
-    and snapshot #>> '{dailyCreation,endDate}' =
-      timezone('Asia/Shanghai', statement_timestamp())::date::text
-    and jsonb_array_length(snapshot #> '{dailyCreation,days}') =
-      timezone('Asia/Shanghai', statement_timestamp())::date
-        - (
-          date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364
-        ) + 1,
-  'daily creation covers 53 calendar-week columns through the current Shanghai date'
-)
-from organization_contribution_result;
+-- Metadata changes dynamically reattribute existing facts; no owner snapshot is persisted.
+update private.users set raw_user_meta_data = '{"organization":"Beta Institute"}'
+where id = '57400000-0000-4000-8000-000000000002';
+select is(api.qry_national_carbon_organization_contributions(10) #>> '{rankings,0,organizationKey}',
+  'beta institute', 'current profile changes reattribute historical process contributions');
 
-select is(
-  (
-    select sum((day ->> 'processCount')::bigint)
-    from organization_contribution_result
-    cross join lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') as day
-  ),
-  9::numeric,
-  'daily Process creation counts every retained Process id-version row regardless of state or organization'
-);
-
-select is(
-  (
-    select sum((day ->> 'modelCount')::bigint)
-    from organization_contribution_result
-    cross join lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') as day
-  ),
-  5::numeric,
-  'daily Model creation counts every retained LifecycleModel id-version row'
-);
-
-select is(
-  (
-    select sum((day ->> 'allCount')::bigint)
-    from organization_contribution_result
-    cross join lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') as day
-  ),
-  14::numeric,
-  'daily All creation keeps Process and Model identities separate before summing them'
-);
-
-select is(
-  (
-    select day - 'date'
-    from organization_contribution_result
-    cross join lateral jsonb_array_elements(snapshot #> '{dailyCreation,days}') as day
-    where day ->> 'date' = (
-      timezone('Asia/Shanghai', statement_timestamp())::date - 2
-    )::text
-  ),
-  '{"processCount": 1, "modelCount": 1, "allCount": 2}'::jsonb,
-  'the same local day reports separate Process and Model counts plus their total'
-);
-
-select is(
-  snapshot #>> '{scopes,process,summary,publishedDatasetCount}',
-  '3'::text,
-  'Process published total counts latest-published IDs assigned to a current organization'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,process,summary,pendingReviewDatasetCount}',
-  '2'::text,
-  'Process pending review includes only IDs whose current latest version is state 20'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,model,summary,publishedDatasetCount}',
-  '2'::text,
-  'Model published total excludes a latest-published ID without a current organization'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,model,summary,pendingReviewDatasetCount}',
-  '1'::text,
-  'Model pending-review total excludes a current state-20 ID without an organization'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,summary,publishedDatasetCount}',
-  '5'::text,
-  'All keeps typed datasets separate while excluding rows without a current organization'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,summary,organizationCount}',
-  '3'::text,
-  'participating-unit count includes every current organization even without contribution facts'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,summary,publishedLast30DaysCount}',
-  '5'::text,
-  'last-30-day published total includes only rows assigned to a current organization'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,rankings,0,organizationKey}',
-  'acme labs'::text,
-  'organization normalization merges casing and repeated whitespace'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,rankings,0,publishedDatasetCount}',
-  '4'::text,
-  'the combined ranking aggregates published Process and Model facts'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,rankings,0,assignedReviewerDatasetCount}',
-  '1'::text,
-  'Acme has one assigned current review dataset'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,rankings,0,unassignedReviewerDatasetCount}',
-  '0'::text,
-  'Acme has no current review dataset awaiting assignment'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,rankings,1,assignedReviewerDatasetCount}',
-  '1'::text,
-  'Beta has one current review dataset with an assigned reviewer'
-)
-from organization_contribution_result;
-
-select is(
-  snapshot #>> '{scopes,all,rankings,1,unassignedReviewerDatasetCount}',
-  '1'::text,
-  'Beta has one current review dataset awaiting reviewer assignment'
-)
-from organization_contribution_result;
-
-select ok(
-  not (snapshot #> '{scopes,all,rankings,0}') ?| array[
-    'reviewingDatasetCount',
-    'contributorCount',
-    'contributionShare',
-    'latestContributedAt'
-  ],
-  'v3 ranking rows omit the retired review, contributor, share, and timestamp fields'
-)
-from organization_contribution_result;
-
-select is(
-  jsonb_array_length(snapshot #> '{scopes,process,rankings}'),
-  1,
-  'pending-only and unassigned organizations do not enter the Process ranking'
-)
-from organization_contribution_result;
-
-delete from public.processes
-where id = '57410000-0000-4000-8000-000000000005'
-  and version = '02.00.000';
-
-set local role authenticated;
-select set_config('request.jwt.claim.sub', '57400000-0000-4000-8000-000000000001', true);
-select set_config(
-  'request.jwt.claims',
-  '{"role":"authenticated","sub":"57400000-0000-4000-8000-000000000001"}',
-  true
-);
-select is(
-  (
-    select sum((day ->> 'allCount')::bigint)
-    from jsonb_array_elements(
-      api.qry_national_carbon_organization_contributions(10) #> '{dailyCreation,days}'
-    ) as day
-  ),
-  13::numeric,
-  'physical deletion removes the version from historical daily creation counts'
-);
-reset role;
-
+-- Commercial rows never enter the regional open-data count.
+set local session_replication_role = replica;
+update public.processes set state_code = 200
+where id = '57410000-0000-4000-8000-000000000002';
+select is(api.qry_national_carbon_organization_contributions(10) #>> '{regions,totalProcessCount}',
+  '3', 'commercial state 200 excluded from regions');
+delete from public.processes where id = '57410000-0000-4000-8000-000000000005' and version = '02.00.000';
+set local session_replication_role = origin;
+select is((select sum((d->>'processCount')::bigint) from jsonb_array_elements(
+  api.qry_national_carbon_organization_contributions(10) #> '{dailyCreation,days}') d),
+  8::numeric, 'deletion removes the version from daily history');
 select * from finish();
-
 rollback;

--- a/supabase/tests/20260903_national_carbon_daily_activity.sql
+++ b/supabase/tests/20260903_national_carbon_daily_activity.sql
@@ -1,0 +1,110 @@
+-- Rollback-only fixtures for an isolated local migration rebuild.
+begin;
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, api, private, auth;
+select no_plan();
+
+create temporary table activity_bounds as
+select timezone('Asia/Shanghai', statement_timestamp())::date - 30 as d,
+  date_trunc('week', timezone('Asia/Shanghai', statement_timestamp()))::date - 364 as start_day,
+  timezone('Asia/Shanghai', statement_timestamp())::date as end_day;
+
+-- Isolate authored timestamps from ordinary writer triggers; no real data is touched.
+set local session_replication_role = replica;
+insert into auth.users (id, raw_user_meta_data)
+values ('60600000-0000-4000-8000-000000000001', '{}');
+insert into private.users (id, raw_user_meta_data)
+values ('60600000-0000-4000-8000-000000000001', '{}');
+insert into private.roles (user_id, team_id, role)
+values ('60600000-0000-4000-8000-000000000001',
+  '00000000-0000-0000-0000-000000000000', 'admin');
+
+insert into public.processes (id, version, state_code, created_at, modified_at)
+select ('60610000-0000-4000-8000-' || lpad(n::text, 12, '0'))::uuid,
+  version, state_code, created_at, modified_at
+from activity_bounds b cross join lateral (values
+  -- Different UTC dates, same Shanghai date: one activity.
+  (1, '01.00.000', 0, (b.d::timestamp - interval '7 hours') at time zone 'UTC',
+    (b.d::timestamp + interval '10 hours') at time zone 'UTC'),
+  (2, '01.00.000', 20, b.d::timestamp at time zone 'Asia/Shanghai',
+    (b.d + 1)::timestamp at time zone 'Asia/Shanghai'),
+  (2, '02.00.000', 0, (b.d + 1)::timestamp at time zone 'Asia/Shanghai',
+    (b.d + 1)::timestamp at time zone 'Asia/Shanghai'),
+  (3, '01.00.000', 100, (b.start_day - 1)::timestamp at time zone 'Asia/Shanghai',
+    (b.d + 2)::timestamp at time zone 'Asia/Shanghai'),
+  (4, '01.00.000', 200, null, (b.d + 3)::timestamp at time zone 'Asia/Shanghai'),
+  (5, '01.00.000', 0, (b.d + 4)::timestamp at time zone 'Asia/Shanghai', null),
+  (6, '01.00.000', 0, null, null),
+  (7, '01.00.000', 0, b.start_day::timestamp at time zone 'Asia/Shanghai',
+    b.start_day::timestamp at time zone 'Asia/Shanghai'),
+  (8, '01.00.000', 0, (b.d + 5)::timestamp at time zone 'Asia/Shanghai',
+    (b.end_day + 1)::timestamp at time zone 'Asia/Shanghai'),
+  -- Same UTC date, different Shanghai dates: two activities.
+  (9, '01.00.000', 0, ((b.d + 6)::timestamp + interval '15:59:59') at time zone 'UTC',
+    ((b.d + 6)::timestamp + interval '16 hours') at time zone 'UTC'),
+  (10, '01.00.000', 0, (b.end_day + 1)::timestamp at time zone 'Asia/Shanghai',
+    (b.end_day + 1)::timestamp at time zone 'Asia/Shanghai'),
+  (11, '01.00.000', 0, (b.end_day::timestamp + interval '23:59:59') at time zone 'Asia/Shanghai', null),
+  (12, '01.00.000', 0, (b.start_day - 2)::timestamp at time zone 'Asia/Shanghai',
+    (b.start_day - 1)::timestamp at time zone 'Asia/Shanghai')
+) v(n, version, state_code, created_at, modified_at);
+
+insert into public.lifecyclemodels (id, version, created_at, modified_at)
+select '60610000-0000-4000-8000-000000000001', '01.00.000',
+  d::timestamp at time zone 'Asia/Shanghai', (d + 8)::timestamp at time zone 'Asia/Shanghai'
+from activity_bounds;
+set local session_replication_role = origin;
+
+create temporary table activity_result (snapshot jsonb);
+grant all on activity_result to authenticated;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '60600000-0000-4000-8000-000000000001', true);
+select set_config('request.jwt.claims', '{"role":"authenticated","sub":"60600000-0000-4000-8000-000000000001"}', true);
+insert into activity_result select api.qry_national_carbon_organization_contributions(10);
+reset role;
+
+select is(snapshot->>'schemaVersion', 'national_carbon_organization_contribution_v5', 'explicit activity v5 contract') from activity_result;
+select ok(snapshot ? 'dailyActivity' and not snapshot ? 'dailyCreation', 'creation-only field is not silently reinterpreted') from activity_result;
+select is(snapshot #>> '{dailyActivity,metric}', 'dataset_version_activity_count', 'activity metric acknowledged') from activity_result;
+select is(snapshot #> '{dailyActivity,deduplicationKey}', '["datasetType","datasetId","version","date"]'::jsonb, 'deduplication includes local day') from activity_result;
+select is(snapshot #>> '{dailyActivity,timezone}', 'Asia/Shanghai', 'timezone is explicit') from activity_result;
+
+create temporary view activity_days as
+select (item->>'date')::date as day, (item->>'processCount')::bigint as count
+from activity_result, lateral jsonb_array_elements(snapshot #> '{dailyActivity,days}') item;
+create temporary table expected_activity as
+select day, count from activity_bounds b cross join lateral (values
+  (b.start_day, 1::bigint), (b.d, 2), (b.d + 1, 2), (b.d + 2, 1),
+  (b.d + 3, 1), (b.d + 4, 1), (b.d + 5, 1), (b.d + 6, 1), (b.d + 7, 1), (b.end_day, 1)
+) v(day, count);
+select results_eq('select day, count from activity_days where count > 0 order by day',
+  'select day, count from expected_activity order by day',
+  'exact union covers versions, status/unit independence, timezone, NULL and both window boundaries');
+select is((select sum(count) from activity_days), 12::numeric, 'total counts version-days, not operations or globally distinct versions');
+select is((select count from activity_days, activity_bounds where day = d + 8), 0::bigint, 'model-only modification does not enter activity');
+select is((select count from activity_days, activity_bounds where day = d + 9), 0::bigint, 'missing activity dates are zero-filled');
+select is((select count(*) from activity_days), (select (end_day - start_day + 1)::bigint from activity_bounds), 'continuous date window unchanged');
+
+-- Changing the session timezone must not move any local-day buckets.
+set local time zone 'America/Los_Angeles';
+select is(api.qry_national_carbon_organization_contributions(1)->'dailyActivity',
+  (select snapshot->'dailyActivity' from activity_result), 'session timezone and chart limit do not alter activity');
+
+set local session_replication_role = replica;
+update public.processes set modified_at = (select (d + 8)::timestamp at time zone 'Asia/Shanghai' from activity_bounds)
+where id = '60610000-0000-4000-8000-000000000002' and version = '01.00.000';
+set local session_replication_role = origin;
+update activity_result set snapshot = api.qry_national_carbon_organization_contributions(10);
+select is((select count from activity_days, activity_bounds where day = d + 1), 1::bigint, 'previous modification removed; distinct version still counts');
+select is((select count from activity_days, activity_bounds where day = d + 8), 1::bigint, 'latest modification replaces earlier modification');
+select is((select count from activity_days, activity_bounds where day = d), 2::bigint, 'creation day preserved after later modification');
+
+set local session_replication_role = replica;
+delete from public.processes where id = '60610000-0000-4000-8000-000000000002' and version = '01.00.000';
+set local session_replication_role = origin;
+update activity_result set snapshot = api.qry_national_carbon_organization_contributions(10);
+select is((select sum(count) from activity_days), 10::numeric, 'deletion removes both creation and latest-modification activity');
+select is((select count from activity_days, activity_bounds where day = d + 8), 0::bigint, 'no deleted-version activity history retained');
+select is((select count from activity_days, activity_bounds where day = d + 1), 1::bigint, 'deleting one version preserves the other');
+select * from finish();
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -20,9 +20,9 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: '592c669ef2083e709305fccc6a0ca9704621baf9'
-lastReviewedNote: 'Reviewed for Database #600: additive version-aware Portal/Next APIs retain immutable projections and legacy interfaces; bounded candidates, exact groups, ACLs and local proof are explicit.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
+lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -20,9 +20,9 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-02
-lastReviewedCommit: '592c669ef2083e709305fccc6a0ca9704621baf9'
-lastReviewedNote: 'Reviewed for Database #600: additive version-aware Portal/Next APIs retain immutable projections and legacy interfaces; bounded candidates, exact groups, ACLs and local proof are explicit.'
+lastReviewedAt: 2026-09-03
+lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
+lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-03
-lastReviewedCommit: fb63d6e5808c9915a665ef9953e321c77fed0b59
-lastReviewedNote: 'Reviewed for Database #604: process-only dashboard RPC v4 preserves administrator ACLs, returns all current-profile organizations and open-process geography, and retains canonical local schema generation and coordinated consumer release boundaries.'
+lastReviewedCommit: 0958524dd71774965c65da12b4fc7e9e0d936e79
+lastReviewedNote: 'Reviewed for Database #606: the query-only v5 daily activity contract counts process version-days from creation and latest modification; timezone deduplication, existing timestamp indexes, administrator ACLs, canonical local generation and coordinated consumer rollout are preserved.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -20939,19 +20939,34 @@ begin
       pg_catalog.timezone('Asia/Shanghai', pg_catalog.statement_timestamp())::date as end_date
   ),
   daily_counts as (
-    -- The processes primary key already enforces one row per dataset ID + version.
-    -- Date filtering uses created_at directly; status changes do not change creation history.
-    select pg_catalog.timezone('Asia/Shanghai', p.created_at)::date as day,
-      pg_catalog.count(*)::bigint as process_count
-    from public.processes p cross join date_bounds b
-    where p.created_at >= pg_catalog.timezone('Asia/Shanghai', b.start_date::timestamp)
-      and p.created_at < pg_catalog.timezone('Asia/Shanghai', (b.end_date + 1)::timestamp)
-    group by 1
+    -- Each branch uses its existing timestamp B-tree and aggregates before UNION ALL.
+    -- The (id, version) primary key makes each branch unique per version/day.
+    -- Excluding same-local-day modifications makes the branches disjoint without
+    -- sorting/hashing the entire version identity set. NULL creation dates are safe.
+    select day, pg_catalog.sum(process_count)::bigint as process_count
+    from (
+      select pg_catalog.timezone('Asia/Shanghai', p.created_at)::date as day,
+        pg_catalog.count(*)::bigint as process_count
+      from public.processes p cross join date_bounds b
+      where p.created_at >= pg_catalog.timezone('Asia/Shanghai', b.start_date::timestamp)
+        and p.created_at < pg_catalog.timezone('Asia/Shanghai', (b.end_date + 1)::timestamp)
+      group by 1
+      union all
+      select pg_catalog.timezone('Asia/Shanghai', p.modified_at)::date as day,
+        pg_catalog.count(*)::bigint as process_count
+      from public.processes p cross join date_bounds b
+      where p.modified_at >= pg_catalog.timezone('Asia/Shanghai', b.start_date::timestamp)
+        and p.modified_at < pg_catalog.timezone('Asia/Shanghai', (b.end_date + 1)::timestamp)
+        and pg_catalog.timezone('Asia/Shanghai', p.modified_at)::date
+          is distinct from pg_catalog.timezone('Asia/Shanghai', p.created_at)::date
+      group by 1
+    ) activity
+    group by day
   ),
   daily_payload as (
     select pg_catalog.jsonb_build_object(
-      'metric', 'dataset_version_created_count',
-      'deduplicationKey', pg_catalog.jsonb_build_array('datasetType', 'datasetId', 'version'),
+      'metric', 'dataset_version_activity_count',
+      'deduplicationKey', pg_catalog.jsonb_build_array('datasetType', 'datasetId', 'version', 'date'),
       'timezone', 'Asia/Shanghai', 'startDate', b.start_date, 'endDate', b.end_date,
       'days', pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
         'date', d.day::date, 'processCount', coalesce(c.process_count, 0)
@@ -21048,7 +21063,7 @@ begin
     from locations group by location_code
   )
   select pg_catalog.jsonb_build_object(
-    'schemaVersion', 'national_carbon_organization_contribution_v4',
+    'schemaVersion', 'national_carbon_organization_contribution_v5',
     'datasetScope', 'process', 'attributionMode', 'current_user_profile',
     'generatedAt', pg_catalog.statement_timestamp(),
     'dataAsOf', coalesce((select pg_catalog.max(modified_at) from facts), pg_catalog.statement_timestamp()),
@@ -21073,7 +21088,7 @@ begin
       'globalProcessCount', coalesce((select process_count from regions where location_code = 'GLO'), 0),
       'unassignedProcessCount', coalesce((select process_count from regions where location_code is null), 0)
     ),
-    'dailyCreation', (select payload from daily_payload)
+    'dailyActivity', (select payload from daily_payload)
   ) into v_result;
   return v_result;
 end;

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -20922,429 +20922,159 @@ declare
   v_result jsonb;
 begin
   if v_actor is null then
-    raise exception using
-      errcode = '28000',
-      message = 'AUTH_REQUIRED';
+    raise exception using errcode = '28000', message = 'AUTH_REQUIRED';
   end if;
-
   if not api.cmd_membership_is_system_manager(v_actor) then
-    raise exception using
-      errcode = '42501',
-      message = 'SYSTEM_MANAGER_REQUIRED';
+    raise exception using errcode = '42501', message = 'SYSTEM_MANAGER_REQUIRED';
   end if;
-
   if p_limit is null or p_limit < 1 or p_limit > 50 then
-    raise exception using
-      errcode = '22023',
-      message = 'INVALID_LIMIT';
+    raise exception using errcode = '22023', message = 'INVALID_LIMIT';
   end if;
 
   with
-  daily_date_bounds as materialized (
+  date_bounds as materialized (
     select
-      (
-        pg_catalog.date_trunc(
-          'week',
-          pg_catalog.timezone('Asia/Shanghai', pg_catalog.statement_timestamp())
-        )::date - 364
-      ) as start_date,
-      pg_catalog.timezone(
-        'Asia/Shanghai',
-        pg_catalog.statement_timestamp()
-      )::date as end_date
+      pg_catalog.date_trunc('week', pg_catalog.timezone('Asia/Shanghai',
+        pg_catalog.statement_timestamp()))::date - 364 as start_date,
+      pg_catalog.timezone('Asia/Shanghai', pg_catalog.statement_timestamp())::date as end_date
   ),
-  daily_time_bounds as materialized (
-    select
-      bounds.start_date,
-      bounds.end_date,
-      pg_catalog.timezone(
-        'Asia/Shanghai',
-        bounds.start_date::timestamp without time zone
-      ) as start_at,
-      pg_catalog.timezone(
-        'Asia/Shanghai',
-        (bounds.end_date + 1)::timestamp without time zone
-      ) as end_at
-    from daily_date_bounds as bounds
+  daily_counts as (
+    -- The processes primary key already enforces one row per dataset ID + version.
+    -- Date filtering uses created_at directly; status changes do not change creation history.
+    select pg_catalog.timezone('Asia/Shanghai', p.created_at)::date as day,
+      pg_catalog.count(*)::bigint as process_count
+    from public.processes p cross join date_bounds b
+    where p.created_at >= pg_catalog.timezone('Asia/Shanghai', b.start_date::timestamp)
+      and p.created_at < pg_catalog.timezone('Asia/Shanghai', (b.end_date + 1)::timestamp)
+    group by 1
   ),
-  daily_version_facts as materialized (
-    select
-      'process'::text as dataset_kind,
-      pg_catalog.timezone('Asia/Shanghai', process_row.created_at)::date as created_date
-    from public.processes as process_row
-    cross join daily_time_bounds as bounds
-    where process_row.created_at >= bounds.start_at
-      and process_row.created_at < bounds.end_at
-    union all
-    select
-      'model'::text as dataset_kind,
-      pg_catalog.timezone('Asia/Shanghai', model_row.created_at)::date as created_date
-    from public.lifecyclemodels as model_row
-    cross join daily_time_bounds as bounds
-    where model_row.created_at >= bounds.start_at
-      and model_row.created_at < bounds.end_at
-  ),
-  daily_version_counts as materialized (
-    select
-      fact.created_date,
-      pg_catalog.count(*) filter (where fact.dataset_kind = 'process')::bigint
-        as process_count,
-      pg_catalog.count(*) filter (where fact.dataset_kind = 'model')::bigint
-        as model_count,
-      pg_catalog.count(*)::bigint as all_count
-    from daily_version_facts as fact
-    group by fact.created_date
-  ),
-  daily_creation_payload as materialized (
+  daily_payload as (
     select pg_catalog.jsonb_build_object(
       'metric', 'dataset_version_created_count',
       'deduplicationKey', pg_catalog.jsonb_build_array('datasetType', 'datasetId', 'version'),
-      'timezone', 'Asia/Shanghai',
-      'startDate', bounds.start_date,
-      'endDate', bounds.end_date,
-      'days', coalesce(
-        pg_catalog.jsonb_agg(
-          pg_catalog.jsonb_build_object(
-            'date', series.created_date,
-            'processCount', coalesce(counts.process_count, 0::bigint),
-            'modelCount', coalesce(counts.model_count, 0::bigint),
-            'allCount', coalesce(counts.all_count, 0::bigint)
-          )
-          order by series.created_date
-        ),
-        '[]'::jsonb
-      )
+      'timezone', 'Asia/Shanghai', 'startDate', b.start_date, 'endDate', b.end_date,
+      'days', pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+        'date', d.day::date, 'processCount', coalesce(c.process_count, 0)
+      ) order by d.day)
     ) as payload
-    from daily_time_bounds as bounds
-    cross join lateral pg_catalog.generate_series(
-      bounds.start_date::timestamp without time zone,
-      bounds.end_date::timestamp without time zone,
-      interval '1 day'
-    ) as generated(created_at)
-    cross join lateral (
-      select generated.created_at::date as created_date
-    ) as series
-    left join daily_version_counts as counts using (created_date)
-    group by bounds.start_date, bounds.end_date
+    from date_bounds b
+    cross join lateral pg_catalog.generate_series(b.start_date::timestamp,
+      b.end_date::timestamp, interval '1 day') as d(day)
+    left join daily_counts c on c.day = d.day::date
+    group by b.start_date, b.end_date
   ),
-  latest_published_process as materialized (
-    select distinct on (process_row.id)
-      'process'::text as dataset_kind,
-      process_row.id as dataset_id,
-      process_row.user_id,
-      process_row.modified_at
-    from public.processes as process_row
-    where process_row.state_code = 100
-    order by
-      process_row.id,
-      process_row.version desc,
-      process_row.modified_at desc
+  published_keys as materialized (
+    -- Select IDs/versions first, then read geography only for the winning open version.
+    select distinct on (p.id) p.id, p.version, p.user_id, p.modified_at
+    from public.processes p where p.state_code = 100
+    order by p.id, p.version desc, p.modified_at desc
   ),
-  latest_current_process as materialized (
-    select distinct on (process_row.id)
-      'process'::text as dataset_kind,
-      process_row.id as dataset_id,
-      pg_catalog.btrim(process_row.version::text) as dataset_version,
-      process_row.user_id,
-      process_row.state_code,
-      process_row.modified_at
-    from public.processes as process_row
-    order by
-      process_row.id,
-      process_row.version desc,
-      process_row.modified_at desc
+  latest_current as materialized (
+    select distinct on (p.id) p.id, p.version, p.user_id, p.state_code, p.modified_at
+    from public.processes p
+    order by p.id, p.version desc, p.modified_at desc
   ),
-  latest_published_model as materialized (
-    select distinct on (model_row.id)
-      'model'::text as dataset_kind,
-      model_row.id as dataset_id,
-      model_row.user_id,
-      model_row.modified_at
-    from public.lifecyclemodels as model_row
-    where model_row.state_code = 100
-    order by
-      model_row.id,
-      model_row.version desc,
-      model_row.modified_at desc
-  ),
-  latest_current_model as materialized (
-    select distinct on (model_row.id)
-      'model'::text as dataset_kind,
-      model_row.id as dataset_id,
-      pg_catalog.btrim(model_row.version::text) as dataset_version,
-      model_row.user_id,
-      model_row.state_code,
-      model_row.modified_at
-    from public.lifecyclemodels as model_row
-    order by
-      model_row.id,
-      model_row.version desc,
-      model_row.modified_at desc
-  ),
-  published_facts as materialized (
-    select * from latest_published_process
-    union all
-    select * from latest_published_model
-  ),
-  pending_review_facts as materialized (
-    select
-      latest_row.dataset_kind,
-      latest_row.dataset_id,
-      latest_row.dataset_version,
-      latest_row.user_id,
-      case when active_review.state_code = 1 then 1 else 0 end::integer
-        as assigned_reviewer_count,
-      case when active_review.state_code = 1 then 0 else 1 end::integer
-        as unassigned_reviewer_count,
-      latest_row.modified_at
-    from latest_current_process as latest_row
+  pending as materialized (
+    select p.user_id, p.modified_at,
+      case when r.state_code = 1 then 1 else 0 end as assigned_count,
+      case when r.state_code = 1 then 0 else 1 end as unassigned_count
+    from latest_current p
     left join lateral (
-      select review_row.state_code
-      from private.reviews as review_row
-      where review_row.review_kind = 'root'
-        and review_row.target_table = 'processes'
-        and review_row.data_id = latest_row.dataset_id
-        and review_row.data_version = latest_row.dataset_version::character(9)
-        and review_row.state_code in (0, 1)
-      order by review_row.state_code desc, review_row.modified_at desc, review_row.id
+      select review.state_code from private.reviews review
+      where review.review_kind = 'root' and review.target_table = 'processes'
+        and review.data_id = p.id and review.data_version = p.version
+        and review.state_code in (0, 1)
+      order by review.state_code desc, review.modified_at desc, review.id
       limit 1
-    ) as active_review on true
-    where latest_row.state_code = 20
+    ) r on true
+    where p.state_code = 20
+  ),
+  profile_names as materialized (
+    select u.id as user_id,
+      nullif(pg_catalog.regexp_replace(pg_catalog.btrim(u.raw_user_meta_data ->> 'organization'),
+        '[[:space:]]+', ' ', 'g'), '') as organization_name
+    from private.users u
+    where pg_catalog.jsonb_typeof(u.raw_user_meta_data -> 'organization') = 'string'
+  ),
+  profiles as materialized (
+    select user_id, organization_name, pg_catalog.lower(organization_name) as organization_key
+    from profile_names where organization_name is not null
+  ),
+  catalog as (
+    select organization_key, pg_catalog.min(organization_name collate "C") as organization_name
+    from profiles group by organization_key
+  ),
+  facts as materialized (
+    select user_id, modified_at, 1 as published_count, 0 as assigned_count, 0 as unassigned_count
+    from published_keys
     union all
-    select
-      latest_row.dataset_kind,
-      latest_row.dataset_id,
-      latest_row.dataset_version,
-      latest_row.user_id,
-      case when active_review.state_code = 1 then 1 else 0 end::integer
-        as assigned_reviewer_count,
-      case when active_review.state_code = 1 then 0 else 1 end::integer
-        as unassigned_reviewer_count,
-      latest_row.modified_at
-    from latest_current_model as latest_row
-    left join lateral (
-      select review_row.state_code
-      from private.reviews as review_row
-      where review_row.review_kind = 'root'
-        and review_row.target_table = 'lifecyclemodels'
-        and review_row.data_id = latest_row.dataset_id
-        and review_row.data_version = latest_row.dataset_version::character(9)
-        and review_row.state_code in (0, 1)
-      order by review_row.state_code desc, review_row.modified_at desc, review_row.id
-      limit 1
-    ) as active_review on true
-    where latest_row.state_code = 20
+    select user_id, modified_at, 0, assigned_count, unassigned_count from pending
   ),
-  user_organization_names as materialized (
-    select
-      profile.id as user_id,
-      nullif(
-        pg_catalog.regexp_replace(
-          pg_catalog.btrim(profile.raw_user_meta_data ->> 'organization'),
-          '[[:space:]]+',
-          ' ',
-          'g'
-        ),
-        ''
-      ) as organization_name
-    from private.users as profile
-    where pg_catalog.jsonb_typeof(profile.raw_user_meta_data -> 'organization') = 'string'
+  aggregates as (
+    select p.organization_key, pg_catalog.sum(f.published_count)::bigint as published_count,
+      pg_catalog.sum(f.assigned_count)::bigint as assigned_count,
+      pg_catalog.sum(f.unassigned_count)::bigint as unassigned_count
+    from facts f join profiles p using (user_id)
+    group by p.organization_key
   ),
-  user_organizations as materialized (
-    select
-      named.user_id,
-      pg_catalog.lower(named.organization_name) as organization_key,
-      named.organization_name
-    from user_organization_names as named
+  organizations as materialized (
+    select pg_catalog.row_number() over (order by coalesce(a.published_count, 0) desc,
+      c.organization_name collate "C", c.organization_key collate "C")::integer as rank,
+      c.organization_key, c.organization_name,
+      coalesce(a.published_count, 0)::bigint as published_count,
+      coalesce(a.assigned_count, 0)::bigint as assigned_count,
+      coalesce(a.unassigned_count, 0)::bigint as unassigned_count
+    from catalog c left join aggregates a using (organization_key)
   ),
-  organization_catalog as materialized (
-    select distinct organization.organization_key
-    from user_organizations as organization
-    where organization.organization_key is not null
+  organization_rows as materialized (
+    select rank, published_count, pg_catalog.jsonb_build_object(
+      'rank', rank, 'organizationKey', organization_key, 'organizationName', organization_name,
+      'publishedDatasetCount', published_count,
+      'assignedReviewerDatasetCount', assigned_count,
+      'unassignedReviewerDatasetCount', unassigned_count
+    ) as payload from organizations
   ),
-  organization_summary as materialized (
-    select pg_catalog.count(*)::bigint as organization_count
-    from organization_catalog
+  locations as (
+    select case when pg_catalog.json_typeof(location.value) = 'string'
+      then nullif(pg_catalog.upper(pg_catalog.btrim(location.value #>> '{}')), '')
+      else null end as location_code
+    from published_keys k join public.processes p on p.id = k.id and p.version = k.version
+    cross join lateral (select p.json_ordered #>
+      '{processDataSet,processInformation,geography,locationOfOperationSupplyOrProduction,@location}'
+      as value) location
   ),
-  contribution_facts as (
-    select
-      published.dataset_kind,
-      published.dataset_id,
-      published.user_id,
-      organization.organization_key,
-      organization.organization_name,
-      1::integer as published_count,
-      0::integer as assigned_reviewer_count,
-      0::integer as unassigned_reviewer_count,
-      published.modified_at
-    from published_facts as published
-    left join user_organizations as organization using (user_id)
-    union all
-    select
-      pending.dataset_kind,
-      pending.dataset_id,
-      pending.user_id,
-      organization.organization_key,
-      organization.organization_name,
-      0::integer as published_count,
-      pending.assigned_reviewer_count,
-      pending.unassigned_reviewer_count,
-      pending.modified_at
-    from pending_review_facts as pending
-    left join user_organizations as organization using (user_id)
-  ),
-  scoped_facts as materialized (
-    select
-      scope.dataset_scope,
-      fact.dataset_kind,
-      fact.dataset_id,
-      fact.user_id,
-      fact.organization_key,
-      fact.organization_name,
-      fact.published_count,
-      fact.assigned_reviewer_count,
-      fact.unassigned_reviewer_count,
-      fact.modified_at
-    from contribution_facts as fact
-    cross join lateral (
-      values (fact.dataset_kind), ('all'::text)
-    ) as scope(dataset_scope)
-  ),
-  scope_catalog(dataset_scope) as (
-    values ('process'::text), ('model'::text), ('all'::text)
-  ),
-  scope_summary_values as materialized (
-    select
-      scope.dataset_scope,
-      organization_summary.organization_count,
-      coalesce(
-        pg_catalog.sum(fact.published_count)
-          filter (where fact.organization_key is not null),
-        0::bigint
-      )::bigint
-        as published_dataset_count,
-      coalesce(
-        pg_catalog.sum(
-          fact.assigned_reviewer_count + fact.unassigned_reviewer_count
-        )
-          filter (where fact.organization_key is not null),
-        0::bigint
-      )::bigint
-        as pending_review_dataset_count,
-      coalesce(
-        pg_catalog.sum(fact.published_count)
-          filter (
-            where fact.organization_key is not null
-              and fact.modified_at >= pg_catalog.statement_timestamp() - interval '30 days'
-          ),
-        0::bigint
-      )::bigint as published_last_30_days_count
-    from scope_catalog as scope
-    cross join organization_summary
-    left join scoped_facts as fact on fact.dataset_scope = scope.dataset_scope
-    group by scope.dataset_scope, organization_summary.organization_count
-  ),
-  scope_organization_aggregate as materialized (
-    select
-      fact.dataset_scope,
-      fact.organization_key,
-      pg_catalog.min(fact.organization_name collate "C") as organization_name,
-      pg_catalog.sum(fact.published_count)::bigint as published_dataset_count,
-      pg_catalog.sum(fact.assigned_reviewer_count)::bigint
-        as assigned_reviewer_dataset_count,
-      pg_catalog.sum(fact.unassigned_reviewer_count)::bigint
-        as unassigned_reviewer_dataset_count
-    from scoped_facts as fact
-    where fact.organization_key is not null
-    group by fact.dataset_scope, fact.organization_key
-  ),
-  scope_ranked as (
-    select
-      aggregate.dataset_scope,
-      pg_catalog.row_number() over (
-        partition by aggregate.dataset_scope
-        order by
-          aggregate.published_dataset_count desc,
-          aggregate.organization_name collate "C" asc,
-          aggregate.organization_key collate "C" asc
-      )::integer as rank,
-      aggregate.organization_key,
-      aggregate.organization_name,
-      aggregate.published_dataset_count,
-      aggregate.assigned_reviewer_dataset_count,
-      aggregate.unassigned_reviewer_dataset_count
-    from scope_organization_aggregate as aggregate
-    where aggregate.published_dataset_count > 0
-  ),
-  scope_ranked_limited as materialized (
-    select *
-    from scope_ranked
-    where rank <= p_limit
-  ),
-  scope_payloads as materialized (
-    select
-      summary.dataset_scope,
-      pg_catalog.jsonb_build_object(
-        'datasetScope', summary.dataset_scope,
-        'metric', 'latest_published_dataset_count',
-        'summary', pg_catalog.jsonb_build_object(
-          'organizationCount', summary.organization_count,
-          'publishedDatasetCount', summary.published_dataset_count,
-          'pendingReviewDatasetCount', summary.pending_review_dataset_count,
-          'publishedLast30DaysCount', summary.published_last_30_days_count
-        ),
-        'rankings', coalesce(
-          (
-            select pg_catalog.jsonb_agg(
-              pg_catalog.jsonb_build_object(
-                'rank', ranked.rank,
-                'organizationKey', ranked.organization_key,
-                'organizationName', ranked.organization_name,
-                'publishedDatasetCount', ranked.published_dataset_count,
-                'assignedReviewerDatasetCount', ranked.assigned_reviewer_dataset_count,
-                'unassignedReviewerDatasetCount', ranked.unassigned_reviewer_dataset_count
-              )
-              order by ranked.rank
-            )
-            from scope_ranked_limited as ranked
-            where ranked.dataset_scope = summary.dataset_scope
-          ),
-          '[]'::jsonb
-        )
-      ) as payload
-    from scope_summary_values as summary
-  ),
-  snapshot_metadata as (
-    select coalesce(
-      pg_catalog.max(fact.modified_at),
-      pg_catalog.statement_timestamp()
-    ) as data_as_of
-    from contribution_facts as fact
+  regions as materialized (
+    select location_code, pg_catalog.count(*)::bigint as process_count
+    from locations group by location_code
   )
   select pg_catalog.jsonb_build_object(
-    'schemaVersion', 'national_carbon_organization_contribution_v3',
-    'attributionMode', 'current_user_profile',
+    'schemaVersion', 'national_carbon_organization_contribution_v4',
+    'datasetScope', 'process', 'attributionMode', 'current_user_profile',
     'generatedAt', pg_catalog.statement_timestamp(),
-    'dataAsOf', metadata.data_as_of,
-    'defaultScope', 'all',
-    'dailyCreation', (
-      select payload from daily_creation_payload
+    'dataAsOf', coalesce((select pg_catalog.max(modified_at) from facts), pg_catalog.statement_timestamp()),
+    'summary', pg_catalog.jsonb_build_object(
+      'organizationCount', (select pg_catalog.count(*) from organizations),
+      'publishedDatasetCount', (select coalesce(pg_catalog.sum(published_count), 0) from organizations),
+      'pendingReviewDatasetCount', (select coalesce(pg_catalog.sum(assigned_count + unassigned_count), 0) from organizations),
+      'reviewerCount', (select pg_catalog.count(distinct r.user_id) from private.roles r
+        where r.team_id = '00000000-0000-0000-0000-000000000000'::uuid and r.role = 'review-member')
     ),
-    'scopes', pg_catalog.jsonb_build_object(
-      'process', (
-        select payload from scope_payloads where dataset_scope = 'process'
-      ),
-      'model', (
-        select payload from scope_payloads where dataset_scope = 'model'
-      ),
-      'all', (
-        select payload from scope_payloads where dataset_scope = 'all'
-      )
-    )
-  )
-  into v_result
-  from snapshot_metadata as metadata;
-
+    'rankings', coalesce((select pg_catalog.jsonb_agg(payload order by rank)
+      from organization_rows where published_count > 0 and rank <= p_limit), '[]'::jsonb),
+    'organizations', coalesce((select pg_catalog.jsonb_agg(payload order by rank)
+      from organization_rows), '[]'::jsonb),
+    'regions', pg_catalog.jsonb_build_object(
+      'metric', 'latest_open_process_count',
+      'totalProcessCount', (select pg_catalog.count(*) from published_keys),
+      'items', coalesce((select pg_catalog.jsonb_agg(pg_catalog.jsonb_build_object(
+        'locationCode', location_code, 'processCount', process_count
+      ) order by process_count desc, location_code collate "C") from regions
+        where location_code is not null and location_code <> 'GLO'), '[]'::jsonb),
+      'globalProcessCount', coalesce((select process_count from regions where location_code = 'GLO'), 0),
+      'unassignedProcessCount', coalesce((select process_count from regions where location_code is null), 0)
+    ),
+    'dailyCreation', (select payload from daily_payload)
+  ) into v_result;
   return v_result;
 end;
 $$;


### PR DESCRIPTION
## Promotion Contract

- Source: `dev` at `6daed39ef26da7b3da6f2c7053ef835c8a5c75ad`.
- Target: `main` at `521741a064f402c9b674583ef69a5947d1b5885f` at submission.
- `main` is an ancestor of the selected `dev`; no back-merge is needed for this promotion.
- Workspace integration is required after merge, using the exact eligible main SHA.

## Linked Issue

Closes #608

## Changes

- Promote #605: process-only dashboard geography and organization statistics.
- Promote #607: daily process activity counts from creation and updates.
- Include both append-only migrations (`20260903090000` and `20260903100000`), owning SQL tests, generated schema snapshots, and reviewed documentation.
- No additional implementation changes, config changes, or manual production mutations are included.

## Validation

- `git diff --check origin/main...origin/dev`: passed.
- `git merge-base --is-ancestor origin/main origin/dev`: passed.
- `git diff --quiet origin/main...origin/dev -- supabase/config.toml`: passed (unchanged).
- Exact dev head rebuild/deploy/verification: [successful run](https://github.com/tiangong-lca/database-engine/actions/runs/33716693391).
- #607 passed `Rebuild and verify database contract`, `Verify Supabase Preview runtime`, official `Supabase Preview`, and `Gitleaks Security Scan` before merge.
- No new local Supabase reset was run for this promotion-only task; the exact committed dev workflow supplies database proof. This new PR's checks and review remain to be verified.

## Release Risk and Follow-Up

- Paired frontend: [Next v0.0.98 tracking](https://github.com/linancn/tiangong-lca-next/issues/1018), including Next #1016/#1017. Verify these migrations on production before releasing the frontend consumer.
- Merge advances production migration input through the Supabase GitHub integration. Do not manually apply migrations as part of PR preparation.
- No config push is required by this diff because `supabase/config.toml` is unchanged.
- After a separately authorized merge, verify production migration state, run `scripts/workspace-ops task finish tiangong-lca/database-engine#608`, and execute only its returned continuation. Root gitlink integration remains pending.
