### PR TITLE
支持 TIDAS 分组导入的原子提交、已有数据跳过与恢复

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-09"
-lastReviewedCommit: "945000520246b82916671ec2a01c60f172648924"
-lastReviewedNote: 'Reviewed for Database #632: additive v4 review queues reuse existing seven-type lexical projections with exact version and actor boundaries; V3, schema ownership, migration authoring and hosted promotion proof remain unchanged.'
+lastReviewedCommit: "3368bffbe37b62bd76ee6cb4f07f064acccccdb9"
+lastReviewedNote: "Database #634: reviewed service-only v2 package admission, per-root insert-only transactions, lease fences and owner-scoped committed receipt readback."
 
 # Keep deterministic governance facts here.
 # AGENTS.md remains the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-09
-lastReviewedCommit: 945000520246b82916671ec2a01c60f172648924
-lastReviewedNote: 'Reviewed for Database #632: additive v4 review queues reuse existing seven-type lexical projections with exact version and actor boundaries; V3, schema ownership, migration authoring and hosted promotion proof remain unchanged.'
+lastReviewedAt: "2026-09-09"
+lastReviewedCommit: "3368bffbe37b62bd76ee6cb4f07f064acccccdb9"
+lastReviewedNote: "Database #634: reviewed additive service-only TIDAS partial-import transactions and receipt readback. Existing migration generation, caller roles and branch/deployment gates remain in force."
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,9 +30,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-09
-lastReviewedCommit: 945000520246b82916671ec2a01c60f172648924
-lastReviewedNote: 'Reviewed for Database #632: additive v4 review queues reuse existing seven-type lexical projections with exact version and actor boundaries; V3, schema ownership, migration authoring and hosted promotion proof remain unchanged.'
+lastReviewedAt: "2026-09-09"
+lastReviewedCommit: "3368bffbe37b62bd76ee6cb4f07f064acccccdb9"
+lastReviewedNote: "Database #634: reviewed service-only v2 package admission, per-root insert-only transactions, lease fences and owner-scoped committed receipt readback."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -786,3 +786,5 @@ If a task changes both schema and app behavior, the SQL truth still starts here.
 ## Local Docpact Push Gate
 
 This repository has a versioned local `pre-push` hook under `.githooks/pre-push` that delegates to `scripts/docpact-gate.sh`. The gate resolves the CLI through `scripts/docpact`, so local agent shells do not need bare `docpact` on `PATH`. The hook is a local developer guard for docpact config validation and enforced doc-governance linting; ordinary PRs and pushes rely on the local gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback for remote reproduction.
+
+TIDAS v2 import adds private immutable input/plan bindings and committed root-group receipts. The Worker supplies a completed ZIP-only validation plan; the service-only group function owns atomic insert-only writes and the final lease fence. `api.svc_tidas_package_read_v2` reuses the existing owner check before returning committed counts when reports are unavailable. Legacy v1 admission remains available.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -32,9 +32,9 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-09-09
-lastReviewedCommit: 945000520246b82916671ec2a01c60f172648924
-lastReviewedNote: 'Reviewed for Database #632: additive v4 review queues reuse existing seven-type lexical projections with exact version and actor boundaries; V3, schema ownership, migration authoring and hosted promotion proof remain unchanged.'
+lastReviewedAt: "2026-09-09"
+lastReviewedCommit: "3368bffbe37b62bd76ee6cb4f07f064acccccdb9"
+lastReviewedNote: "Database #634: reviewed service-only v2 package admission, per-root insert-only transactions, lease fences and owner-scoped committed receipt readback."
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -473,3 +473,5 @@ Install the versioned local hook once per checkout:
 ```
 
 The `pre-push` hook runs `scripts/docpact-gate.sh`, which delegates CLI lookup to `scripts/docpact` and performs strict config validation plus enforced lint before the push leaves the machine. The wrapper checks `DOCPACT_BIN`, Cargo install locations, Homebrew install locations, and then `PATH`, so local agent shells should not fail only because bare `docpact` is unavailable. The default comparison base is `origin/dev` for routine branches and `origin/main` for promote or hotfix branches. Override it for unusual stacks with `DOCPACT_BASE_REF=<ref>` or `scripts/docpact-gate.sh --base <ref>`. The gate writes its detailed report to a temporary file so normal pushes do not create `.docpact/runs/` artifacts.
+
+TIDAS partial import requires `supabase/tests/20260909_tidas_partial_import.sql`, including insert/skip, rollback isolation, replay counts, caller ownership, lease rejection and v2 admission. Preserve actual database triggers; tests may record calls at the external webhook boundary. Also qualify concurrent identity collisions and failure-after-commit recovery. Generated schema/ACL snapshots must follow the existing generation workflow after migration replay.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-09
-lastReviewedCommit: fc743392d4ce256b5de1f6409a8ab7e90ec30614
-lastReviewedNote: 'Reviewed for Database #632: regenerate the exact local review-queue V4 schema and public/api types after migration proof; remote Dev remains authoritative after deployment and must be compared before promotion.'
+lastReviewedCommit: 3368bffbe37b62bd76ee6cb4f07f064acccccdb9
+lastReviewedNote: 'Database #634: exact isolated migration replay, five-schema snapshots and public/api type regeneration cover the additive partial-import routines and receipt tables; remote Dev provenance remains a post-deployment gate.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/scripts/README.zh-CN.md
+++ b/scripts/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-09
-lastReviewedCommit: fc743392d4ce256b5de1f6409a8ab7e90ec30614
-lastReviewedNote: 'Reviewed for Database #632: regenerate the exact local review-queue V4 schema and public/api types after migration proof; remote Dev remains authoritative after deployment and must be compared before promotion.'
+lastReviewedCommit: 3368bffbe37b62bd76ee6cb4f07f064acccccdb9
+lastReviewedNote: 'Database #634: exact isolated migration replay, five-schema snapshots and public/api type regeneration cover the additive partial-import routines and receipt tables; remote Dev provenance remains a post-deployment gate.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml

--- a/supabase/migrations/20260909121000_tidas_partial_import.sql
+++ b/supabase/migrations/20260909121000_tidas_partial_import.sql
@@ -1,0 +1,234 @@
+-- Database #634 / workspace #1077. Additive, service-only partial package import.
+-- Validation is Worker-owned and package-local. These functions run only after
+-- the immutable validation plan is complete; they never validate against live data.
+begin;
+
+alter table private.lca_package_artifacts drop constraint lca_package_artifacts_format_chk;
+alter table private.lca_package_artifacts add constraint lca_package_artifacts_format_chk
+  check (artifact_format in ('tidas-package-zip:v1','tidas-package-export-report:v1',
+    'tidas-package-import-report:v1','tidas-package-import-report:v2','tidas-package-import-details:v2'));
+alter table private.lca_package_artifacts drop constraint lca_package_artifacts_kind_chk;
+alter table private.lca_package_artifacts add constraint lca_package_artifacts_kind_chk
+  check (artifact_kind in ('import_source','export_zip','export_report','import_report','import_details'));
+
+create table private.tidas_import_plans_v2 (
+  worker_job_id uuid primary key references private.worker_jobs(id),
+  source_artifact_id uuid not null references private.lca_package_artifacts(id),
+  source_sha256 text not null check (source_sha256 ~ '^[0-9a-f]{64}$'),
+  plan_sha256 text not null check (plan_sha256 ~ '^[0-9a-f]{64}$'),
+  created_at timestamptz not null default now()
+);
+
+create table private.tidas_import_groups_v2 (
+  worker_job_id uuid not null references private.tidas_import_plans_v2(worker_job_id),
+  root_table text not null check (root_table in ('processes', 'lifecyclemodels')),
+  root_id uuid not null,
+  root_version text not null check (root_version ~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'),
+  entries_sha256 text not null,
+  receipt jsonb not null check (jsonb_typeof(receipt) = 'object'),
+  committed_at timestamptz not null default now(),
+  primary key (worker_job_id, root_table, root_id, root_version)
+);
+
+alter table private.tidas_import_plans_v2 enable row level security;
+alter table private.tidas_import_groups_v2 enable row level security;
+revoke all on private.tidas_import_plans_v2, private.tidas_import_groups_v2 from public, anon, authenticated, service_role;
+
+-- No job-row lock during the insert loop: heartbeats must remain possible.
+-- The final fence takes the lock immediately before the transaction returns.
+create function private.tidas_import_guard_v2(p_worker_job_id uuid, p_lease_token uuid, p_source_artifact_id uuid)
+returns uuid language plpgsql security definer set search_path = '' as $$
+declare v_user uuid;
+begin
+  select j.requested_by into v_user
+  from private.worker_jobs j
+  join private.lca_package_artifacts a on a.worker_job_id = j.id
+  where j.id = p_worker_job_id and j.lease_token = p_lease_token
+    and j.status = 'running' and j.lease_expires_at > clock_timestamp()
+    and j.job_kind = 'tidas.import_package'
+    and j.payload_schema_version = 'tidas.import_package.request.v2'
+    and j.payload_json ->> 'import_policy' = 'root_closure_v2'
+    and j.payload_json ->> 'source_artifact_id' = p_source_artifact_id::text
+    and a.id = p_source_artifact_id and a.artifact_kind = 'import_source'
+    and a.status = 'ready' and a.artifact_sha256 ~ '^[0-9a-f]{64}$'
+    and a.metadata ->> 'requested_by' = j.requested_by::text;
+  if v_user is null then
+    raise exception using errcode = '55000', message = 'TIDAS_IMPORT_LEASE_OR_SOURCE_INVALID';
+  end if;
+  return v_user;
+end $$;
+
+create function private.tidas_import_group_apply_v2(
+  p_worker_job_id uuid, p_lease_token uuid, p_source_artifact_id uuid,
+  p_plan_sha256 text, p_root jsonb, p_entries jsonb
+) returns jsonb language plpgsql security definer set search_path = '' as $$
+declare
+  v_user uuid;
+  v_plan private.tidas_import_plans_v2%rowtype;
+  v_previous private.tidas_import_groups_v2%rowtype;
+  v_source_sha text;
+  v_entries_sha text;
+  v_root_table text := p_root ->> 'table';
+  v_root_id uuid := (p_root ->> 'id')::uuid;
+  v_root_version text := p_root ->> 'version';
+  v_entry jsonb;
+  v_table text;
+  v_id uuid;
+  v_version text;
+  v_inserted bigint;
+  v_count bigint := 0;
+  v_items jsonb := '[]'::jsonb;
+  v_receipt jsonb;
+begin
+  v_user := private.tidas_import_guard_v2(p_worker_job_id, p_lease_token, p_source_artifact_id);
+  if p_plan_sha256 is null or p_plan_sha256 !~ '^[0-9a-f]{64}$'
+     or v_root_table is null or v_root_table not in ('processes', 'lifecyclemodels')
+     or v_root_id is null or v_root_version is null
+     or v_root_version !~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'
+     or jsonb_typeof(p_entries) is distinct from 'array' then
+    raise exception using errcode = '22023', message = 'TIDAS_IMPORT_GROUP_INVALID';
+  end if;
+  -- Explicit capacity admission; never silently truncate a root closure.
+  if jsonb_array_length(p_entries) = 0 or jsonb_array_length(p_entries) > 50000
+     or octet_length(p_entries::text) > 67108864 then
+    raise exception using errcode = '54000', message = 'TIDAS_IMPORT_GROUP_CAPACITY_EXCEEDED';
+  end if;
+  if not exists (select 1 from jsonb_array_elements(p_entries) e
+    where e ->> 'table' = v_root_table and e ->> 'id' = v_root_id::text
+      and e ->> 'version' = v_root_version)
+    or exists (select 1 from jsonb_array_elements(p_entries) e
+      group by e ->> 'table', e ->> 'id', e ->> 'version' having count(*) > 1) then
+    raise exception using errcode = '22023', message = 'TIDAS_IMPORT_GROUP_IDENTITY_INVALID';
+  end if;
+
+  select artifact_sha256 into v_source_sha from private.lca_package_artifacts where id = p_source_artifact_id;
+  insert into private.tidas_import_plans_v2(worker_job_id, source_artifact_id, source_sha256, plan_sha256)
+  values (p_worker_job_id, p_source_artifact_id, v_source_sha, p_plan_sha256)
+  on conflict (worker_job_id) do nothing;
+  select * into v_plan from private.tidas_import_plans_v2 where worker_job_id = p_worker_job_id for update;
+  if v_plan.source_artifact_id <> p_source_artifact_id or v_plan.source_sha256 <> v_source_sha
+     or v_plan.plan_sha256 <> p_plan_sha256 then
+    raise exception using errcode = '55000', message = 'TIDAS_IMPORT_PLAN_MISMATCH';
+  end if;
+  v_entries_sha := encode(extensions.digest(convert_to(p_entries::text, 'UTF8'), 'sha256'), 'hex');
+  select * into v_previous from private.tidas_import_groups_v2
+  where worker_job_id = p_worker_job_id and root_table = v_root_table
+    and root_id = v_root_id and root_version = v_root_version;
+  if found then
+    if v_previous.entries_sha256 <> v_entries_sha then
+      raise exception using errcode = '55000', message = 'TIDAS_IMPORT_GROUP_REPLAY_MISMATCH';
+    end if;
+    return v_previous.receipt;
+  end if;
+
+  for v_entry in select e from jsonb_array_elements(p_entries) e order by
+    case e ->> 'table' when 'contacts' then 1 when 'sources' then 2
+      when 'unitgroups' then 3 when 'flowproperties' then 4 when 'flows' then 5
+      when 'lifecyclemodels' then 6 when 'processes' then 7 else 8 end,
+    e ->> 'id', e ->> 'version'
+  loop
+    v_table := v_entry ->> 'table';
+    v_id := (v_entry ->> 'id')::uuid;
+    v_version := v_entry ->> 'version';
+    if v_table is null or v_table not in ('contacts','sources','unitgroups','flowproperties','flows','lifecyclemodels','processes')
+       or v_id is null or v_version is null or v_version !~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'
+       or jsonb_typeof(v_entry -> 'json_ordered') is distinct from 'object' then
+      raise exception using errcode = '22023', message = 'TIDAS_IMPORT_ENTRY_INVALID';
+    end if;
+    if v_table = 'lifecyclemodels' then
+      insert into public.lifecyclemodels(id, version, json_ordered, rule_verification, json_tg, user_id)
+      values (v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true),
+        coalesce(nullif(v_entry -> 'json_tg', 'null'::jsonb), '{}'::jsonb), v_user)
+      on conflict (id, version) do nothing;
+    elsif v_table = 'processes' then
+      insert into public.processes(id, version, json_ordered, rule_verification, model_id, user_id)
+      values (v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true),
+        (v_entry ->> 'model_id')::uuid, v_user)
+      on conflict (id, version) do nothing;
+    else
+      execute format('insert into public.%I(id, version, json_ordered, rule_verification, user_id)
+        values ($1,$2,$3,$4,$5) on conflict (id, version) do nothing', v_table)
+      using v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true), v_user;
+    end if;
+    get diagnostics v_inserted = row_count;
+    v_count := v_count + v_inserted;
+    v_items := v_items || jsonb_build_array(jsonb_build_object(
+      'table', v_table, 'id', v_id, 'version', v_version,
+      'disposition', case when v_inserted = 1 then 'inserted' else 'existing' end));
+  end loop;
+  v_receipt := jsonb_build_object('root', p_root,
+    'status', case when v_count > 0 then 'imported' else 'reused' end,
+    'inserted_count', v_count, 'existing_count', jsonb_array_length(p_entries) - v_count, 'items', v_items);
+  insert into private.tidas_import_groups_v2(worker_job_id, root_table, root_id, root_version, entries_sha256, receipt)
+  values (p_worker_job_id, v_root_table, v_root_id, v_root_version, v_entries_sha, v_receipt);
+  perform 1 from private.worker_jobs where id = p_worker_job_id for update;
+  perform private.tidas_import_guard_v2(p_worker_job_id, p_lease_token, p_source_artifact_id);
+  return v_receipt;
+end $$;
+
+create function api.svc_tidas_package_import_enqueue_v2(
+  p_requested_by uuid, p_job_id uuid, p_source_artifact_id uuid,
+  p_artifact_sha256 text, p_artifact_byte_size bigint, p_filename text,
+  p_content_type text default null
+) returns jsonb language plpgsql security definer set search_path = '' as $$
+declare v_existing uuid; v_schema text; v_result jsonb; v_worker_id uuid;
+begin
+  select worker_job_id into v_existing from private.lca_package_artifacts
+  where id = p_source_artifact_id and job_id = p_job_id
+    and metadata ->> 'requested_by' = p_requested_by::text for update;
+  if v_existing is not null then
+    select payload_schema_version into v_schema from private.worker_jobs where id = v_existing;
+    if v_schema is distinct from 'tidas.import_package.request.v2' then
+      return jsonb_build_object('ok', false, 'code', 'IMPORT_POLICY_MISMATCH', 'status', 409);
+    end if;
+  end if;
+  v_result := api.svc_tidas_package_import_enqueue(p_requested_by, p_job_id, p_source_artifact_id,
+    p_artifact_sha256, p_artifact_byte_size, p_filename, p_content_type);
+  if coalesce((v_result ->> 'ok')::boolean, false) then
+    v_worker_id := (v_result ->> 'worker_job_id')::uuid;
+    update private.worker_jobs set payload_schema_version = 'tidas.import_package.request.v2',
+      payload_json = payload_json || jsonb_build_object('import_policy', 'root_closure_v2')
+    where id = v_worker_id and status = 'queued' and attempt_count = 0;
+  end if;
+  return v_result;
+end $$;
+
+revoke all on function private.tidas_import_guard_v2(uuid,uuid,uuid) from public, anon, authenticated, service_role;
+revoke all on function private.tidas_import_group_apply_v2(uuid,uuid,uuid,text,jsonb,jsonb) from public, anon, authenticated;
+grant execute on function private.tidas_import_group_apply_v2(uuid,uuid,uuid,text,jsonb,jsonb) to service_role;
+revoke all on function api.svc_tidas_package_import_enqueue_v2(uuid,uuid,uuid,text,bigint,text,text) from public, anon, authenticated;
+grant execute on function api.svc_tidas_package_import_enqueue_v2(uuid,uuid,uuid,text,bigint,text,text) to service_role;
+insert into private.api_capability_grants(routine_identity, capability_id, allow_anon, allow_authenticated, allow_service_role)
+values ('api.svc_tidas_package_import_enqueue_v2(uuid, uuid, uuid, text, bigint, text, text)', 'EDGE-PKG-01', false, false, true);
+
+-- A missing report must never erase evidence of earlier committed groups.
+-- Reuse the existing owner check before reading the private receipt ledger.
+create function api.svc_tidas_package_read_v2(p_requested_by uuid, p_lookup_id uuid)
+returns jsonb language plpgsql stable security definer set search_path = '' as $$
+declare v_result jsonb; v_worker uuid; v_progress jsonb;
+begin
+  v_result := api.svc_tidas_package_read(p_requested_by, p_lookup_id);
+  v_worker := (v_result #>> '{data,workerJobId}')::uuid;
+  if v_worker is null or v_result #>> '{data,payload,import_policy}' is distinct from 'root_closure_v2' then
+    return v_result;
+  end if;
+  with identities as (
+    select item ->> 'table' as tab, item ->> 'id' as id, item ->> 'version' as ver,
+      bool_or(item ->> 'disposition' = 'inserted') as inserted
+    from private.tidas_import_groups_v2 g
+    cross join lateral jsonb_array_elements(g.receipt -> 'items') item
+    where g.worker_job_id = v_worker
+    group by 1,2,3
+  )
+  select jsonb_build_object('imported_count', count(*) filter (where inserted),
+    'existing_count', count(*) filter (where not inserted),
+    'successful_root_count', (select count(*) from private.tidas_import_groups_v2 where worker_job_id = v_worker),
+    'source', 'committed_receipts') into v_progress from identities;
+  return jsonb_set(v_result, '{data,importProgress}', v_progress);
+end $$;
+revoke all on function api.svc_tidas_package_read_v2(uuid,uuid) from public, anon, authenticated;
+grant execute on function api.svc_tidas_package_read_v2(uuid,uuid) to service_role;
+insert into private.api_capability_grants(routine_identity, capability_id, allow_anon, allow_authenticated, allow_service_role)
+values ('api.svc_tidas_package_read_v2(uuid, uuid)', 'EDGE-PKG-01', false, false, true);
+
+commit;

--- a/supabase/tests/20260805_full_schema_cutover.sql
+++ b/supabase/tests/20260805_full_schema_cutover.sql
@@ -68,8 +68,8 @@ select is(
     where namespace.nspname = 'api'
       and routine.prokind = 'f'
   ),
-  288::bigint,
-  'api contains the active cutover and consumer facades, including eight additive Portal/Next version-search APIs and two V4 review queues'
+  290::bigint,
+  'api contains the active cutover and consumer facades, including eight additive Portal/Next version-search APIs and two V4 review queues plus two partial-import APIs'
 );
 
 select is(
@@ -80,8 +80,8 @@ select is(
     where namespace.nspname = 'private'
       and routine.prokind = 'f'
   ),
-  338::bigint,
-  'private contains the active helpers, including the twenty-five exact-version, thirteen composite-name and one review-search internals'
+  340::bigint,
+  'private contains the active helpers, including the twenty-five exact-version, thirteen composite-name and one review-search internals plus two partial-import helpers'
 );
 
 select ok(
@@ -136,8 +136,8 @@ select is(
       'util'::regnamespace
     )
   ),
-  587::bigint,
-  'all application, OAuth registry and twenty-two composite-name constraints remain present'
+  597::bigint,
+  'all application, OAuth registry and twenty-two composite-name constraints plus ten partial-import constraints remain present'
 );
 
 select is(
@@ -165,8 +165,8 @@ select is(
       and class.relkind in ('r', 'p')
       and class.relrowsecurity
   ),
-  75::bigint,
-  'RLS covers existing tables plus four private composite-name relations'
+  77::bigint,
+  'RLS covers existing tables plus four private composite-name relations and two private import receipt relations'
 );
 
 select ok(

--- a/supabase/tests/20260806_api_contract_closure.sql
+++ b/supabase/tests/20260806_api_contract_closure.sql
@@ -445,7 +445,7 @@ select is(
 
 select is(
   api.svc_schema_contract_status() ->> 'migrationHead',
-  '20260909120000'::text,
+  '20260909121000'::text,
   'service-only schema readback reports the exact migration head'
 );
 

--- a/supabase/tests/20260909_tidas_partial_import.sql
+++ b/supabase/tests/20260909_tidas_partial_import.sql
@@ -1,0 +1,58 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public, private, api;
+select no_plan();
+select set_config('request.jwt.claim.role','service_role',true);
+select set_config('request.jwt.claims','{"role":"service_role"}',true);
+-- Keep triggers active while replacing only the external network boundary.
+create temporary table import_webhooks(name text, body jsonb);
+create or replace function util.invoke_edge_function(name text, body jsonb, timeout_milliseconds integer default 300000)
+returns void language plpgsql security definer set search_path = '' as $$
+begin insert into pg_temp.import_webhooks values(name,body); end $$;
+
+
+insert into private.worker_job_kinds(job_kind,worker_queue,payload_schema_version)
+values ('tidas.import_package','package','tidas.import_package.request.v1') on conflict do nothing;
+insert into auth.users(id) values ('10770000-0000-4000-8000-000000000001');
+insert into private.worker_jobs(id,job_kind,worker_queue,requested_by,status,payload_schema_version,payload_json,lease_token,lease_expires_at,subject_type,subject_id)
+values ('10770000-0000-4000-8000-000000000002','tidas.import_package','package','10770000-0000-4000-8000-000000000001','running','tidas.import_package.request.v2',
+ '{"type":"import_package","import_policy":"root_closure_v2","source_artifact_id":"10770000-0000-4000-8000-000000000003"}',
+ '10770000-0000-4000-8000-000000000004',clock_timestamp()+interval '5 minutes','lca_package_job','10770000-0000-4000-8000-000000000005');
+insert into private.lca_package_artifacts(id,job_id,worker_job_id,artifact_kind,status,artifact_url,artifact_sha256,artifact_format,content_type,metadata)
+values ('10770000-0000-4000-8000-000000000003','10770000-0000-4000-8000-000000000005','10770000-0000-4000-8000-000000000002','import_source','ready','fixture://package',repeat('a',64),'tidas-package-zip:v1','application/zip','{"requested_by":"10770000-0000-4000-8000-000000000001"}');
+
+create function pg_temp.apply_group(root_id text, entries jsonb) returns jsonb language sql as $$
+ select private.tidas_import_group_apply_v2('10770000-0000-4000-8000-000000000002','10770000-0000-4000-8000-000000000004','10770000-0000-4000-8000-000000000003',repeat('b',64),jsonb_build_object('table','processes','id',root_id,'version','01.00.000'),entries)
+$$;
+create temporary table test_groups(name text, entries jsonb, receipt jsonb);
+insert into test_groups values ('first','[{"table":"sources","id":"10770000-0000-4000-8000-000000000010","version":"01.00.000","json_ordered":{}},{"table":"processes","id":"10770000-0000-4000-8000-000000000011","version":"01.00.000","json_ordered":{}}]',null);
+update test_groups set receipt=pg_temp.apply_group('10770000-0000-4000-8000-000000000011',entries);
+select is((select receipt->>'inserted_count' from test_groups),'2','root and dependency commit together');
+select is((select pg_temp.apply_group('10770000-0000-4000-8000-000000000011',entries) from test_groups),(select receipt from test_groups),'replay returns original commit receipt');
+select is((select count(*) from private.tidas_import_groups_v2 where worker_job_id='10770000-0000-4000-8000-000000000002'),1::bigint,'replay does not duplicate receipt');
+
+update public.sources set state_code=100,json_ordered='{"unchanged":true}' where id='10770000-0000-4000-8000-000000000010';
+insert into test_groups values ('shared','[{"table":"sources","id":"10770000-0000-4000-8000-000000000010","version":"01.00.000","json_ordered":{"incoming":"different"}},{"table":"processes","id":"10770000-0000-4000-8000-000000000012","version":"01.00.000","json_ordered":{}}]',null);
+update test_groups set receipt=pg_temp.apply_group('10770000-0000-4000-8000-000000000012',entries) where name='shared';
+select is((select receipt->>'existing_count' from test_groups where name='shared'),'1','existing shared dependency skipped');
+select is((select json_ordered::jsonb from public.sources where id='10770000-0000-4000-8000-000000000010'),'{"unchanged":true}'::jsonb,'different incoming content never overwrites existing state 100 data');
+select is((select state_code from public.sources where id='10770000-0000-4000-8000-000000000010'),100,'skip preserves state code');
+
+select throws_ok($q$select pg_temp.apply_group('10770000-0000-4000-8000-000000000013','[{"table":"sources","id":"10770000-0000-4000-8000-000000000014","version":"01.00.000","json_ordered":{}},{"table":"processes","id":"10770000-0000-4000-8000-000000000013","version":"01.00.000","json_ordered":null}]')$q$,'22023','TIDAS_IMPORT_ENTRY_INVALID','late invalid entry fails group');
+select is((select count(*) from public.sources where id='10770000-0000-4000-8000-000000000014'),0::bigint,'late failure rolls back earlier dependency insert');
+select is((select count(*) from public.processes where id in ('10770000-0000-4000-8000-000000000011','10770000-0000-4000-8000-000000000012')),2::bigint,'prior successful groups survive later failure');
+select is((select count(*) from private.tidas_import_groups_v2 where worker_job_id='10770000-0000-4000-8000-000000000002'),2::bigint,'failed group leaves no receipt');
+select is(api.svc_tidas_package_read_v2('10770000-0000-4000-8000-000000000001','10770000-0000-4000-8000-000000000002')#>>'{data,importProgress,imported_count}','3','readback reports distinct committed records without report artifact');
+select is(api.svc_tidas_package_read_v2('10770000-0000-4000-8000-000000000099','10770000-0000-4000-8000-000000000002')->'data','null'::jsonb,'foreign user cannot read receipt summary');
+select ok(not has_function_privilege('authenticated','private.tidas_import_group_apply_v2(uuid,uuid,uuid,text,jsonb,jsonb)','EXECUTE'),'browser cannot write groups');
+select ok(not has_table_privilege('service_role','private.tidas_import_groups_v2','SELECT'),'receipts require reviewed capability');
+update private.worker_jobs set lease_expires_at=clock_timestamp()-interval '1 second' where id='10770000-0000-4000-8000-000000000002';
+select throws_ok($q$select pg_temp.apply_group('10770000-0000-4000-8000-000000000011',(select entries from test_groups where name='first'))$q$,'55000','TIDAS_IMPORT_LEASE_OR_SOURCE_INVALID','expired lease cannot replay or write');
+insert into private.lca_package_artifacts(id,job_id,artifact_kind,status,artifact_url,artifact_format,content_type,metadata)
+values ('10770000-0000-4000-8000-000000000020','10770000-0000-4000-8000-000000000021','import_source','pending','fixture://v2','tidas-package-zip:v1','application/zip','{"requested_by":"10770000-0000-4000-8000-000000000001"}');
+select is(api.svc_tidas_package_import_enqueue_v2('10770000-0000-4000-8000-000000000001','10770000-0000-4000-8000-000000000021','10770000-0000-4000-8000-000000000020',repeat('c',64),100,'test.zip','application/zip')->>'ok','true','v2 admission reuses existing source/queue checks');
+select is((select j.payload_schema_version from private.worker_jobs j join private.lca_package_artifacts a on a.worker_job_id=j.id where a.id='10770000-0000-4000-8000-000000000020'),'tidas.import_package.request.v2','new job pins v2 before it becomes claimable');
+select is((select j.payload_json->>'import_policy' from private.worker_jobs j join private.lca_package_artifacts a on a.worker_job_id=j.id where a.id='10770000-0000-4000-8000-000000000020'),'root_closure_v2','new job pins partial policy');
+select is(api.svc_tidas_package_import_enqueue_v2('10770000-0000-4000-8000-000000000001','10770000-0000-4000-8000-000000000021','10770000-0000-4000-8000-000000000020',repeat('c',64),100,'test.zip','application/zip')->>'mode','in_progress','v2 re-enqueue reuses active job');
+select * from finish();
+rollback;

--- a/supabase/workspace/README.md
+++ b/supabase/workspace/README.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-09
-lastReviewedCommit: fc743392d4ce256b5de1f6409a8ab7e90ec30614
-lastReviewedNote: 'Reviewed for Database #632: regenerate the exact local review-queue V4 schema and public/api types after migration proof; remote Dev remains authoritative after deployment and must be compared before promotion.'
+lastReviewedCommit: 3368bffbe37b62bd76ee6cb4f07f064acccccdb9
+lastReviewedNote: 'Database #634: exact isolated migration replay, five-schema snapshots and public/api type regeneration cover the additive partial-import routines and receipt tables; remote Dev provenance remains a post-deployment gate.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/README.zh-CN.md
+++ b/supabase/workspace/README.zh-CN.md
@@ -21,8 +21,8 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-09-09
-lastReviewedCommit: fc743392d4ce256b5de1f6409a8ab7e90ec30614
-lastReviewedNote: 'Reviewed for Database #632: regenerate the exact local review-queue V4 schema and public/api types after migration proof; remote Dev remains authoritative after deployment and must be compared before promotion.'
+lastReviewedCommit: 3368bffbe37b62bd76ee6cb4f07f064acccccdb9
+lastReviewedNote: 'Database #634: exact isolated migration replay, five-schema snapshots and public/api type regeneration cover the additive partial-import routines and receipt tables; remote Dev provenance remains a post-deployment gate.'
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/workspace/database.types.ts
+++ b/supabase/workspace/database.types.ts
@@ -3081,6 +3081,18 @@ export type Database = {
         }
         Returns: Json
       }
+      svc_tidas_package_import_enqueue_v2: {
+        Args: {
+          p_artifact_byte_size: number
+          p_artifact_sha256: string
+          p_content_type?: string
+          p_filename: string
+          p_job_id: string
+          p_requested_by: string
+          p_source_artifact_id: string
+        }
+        Returns: Json
+      }
       svc_tidas_package_import_prepare: {
         Args: {
           p_artifact_url: string
@@ -3094,6 +3106,10 @@ export type Database = {
         Returns: Json
       }
       svc_tidas_package_read: {
+        Args: { p_lookup_id: string; p_requested_by: string }
+        Returns: Json
+      }
+      svc_tidas_package_read_v2: {
         Args: { p_lookup_id: string; p_requested_by: string }
         Returns: Json
       }

--- a/supabase/workspace/remote_schema.sql
+++ b/supabase/workspace/remote_schema.sql
@@ -26384,6 +26384,36 @@ $$;
 ALTER FUNCTION "api"."svc_tidas_package_import_enqueue"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text") OWNER TO "postgres";
 
 
+CREATE OR REPLACE FUNCTION "api"."svc_tidas_package_import_enqueue_v2"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text" DEFAULT NULL::"text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare v_existing uuid; v_schema text; v_result jsonb; v_worker_id uuid;
+begin
+  select worker_job_id into v_existing from private.lca_package_artifacts
+  where id = p_source_artifact_id and job_id = p_job_id
+    and metadata ->> 'requested_by' = p_requested_by::text for update;
+  if v_existing is not null then
+    select payload_schema_version into v_schema from private.worker_jobs where id = v_existing;
+    if v_schema is distinct from 'tidas.import_package.request.v2' then
+      return jsonb_build_object('ok', false, 'code', 'IMPORT_POLICY_MISMATCH', 'status', 409);
+    end if;
+  end if;
+  v_result := api.svc_tidas_package_import_enqueue(p_requested_by, p_job_id, p_source_artifact_id,
+    p_artifact_sha256, p_artifact_byte_size, p_filename, p_content_type);
+  if coalesce((v_result ->> 'ok')::boolean, false) then
+    v_worker_id := (v_result ->> 'worker_job_id')::uuid;
+    update private.worker_jobs set payload_schema_version = 'tidas.import_package.request.v2',
+      payload_json = payload_json || jsonb_build_object('import_policy', 'root_closure_v2')
+    where id = v_worker_id and status = 'queued' and attempt_count = 0;
+  end if;
+  return v_result;
+end $$;
+
+
+ALTER FUNCTION "api"."svc_tidas_package_import_enqueue_v2"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text") OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "api"."svc_tidas_package_import_prepare"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_url" "text", "p_content_type" "text", "p_filename" "text", "p_idempotency_key" "text" DEFAULT NULL::"text") RETURNS "jsonb"
     LANGUAGE "plpgsql" SECURITY DEFINER
     SET "search_path" TO ''
@@ -26539,6 +26569,36 @@ $$;
 
 
 ALTER FUNCTION "api"."svc_tidas_package_read"("p_requested_by" "uuid", "p_lookup_id" "uuid") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "api"."svc_tidas_package_read_v2"("p_requested_by" "uuid", "p_lookup_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare v_result jsonb; v_worker uuid; v_progress jsonb;
+begin
+  v_result := api.svc_tidas_package_read(p_requested_by, p_lookup_id);
+  v_worker := (v_result #>> '{data,workerJobId}')::uuid;
+  if v_worker is null or v_result #>> '{data,payload,import_policy}' is distinct from 'root_closure_v2' then
+    return v_result;
+  end if;
+  with identities as (
+    select item ->> 'table' as tab, item ->> 'id' as id, item ->> 'version' as ver,
+      bool_or(item ->> 'disposition' = 'inserted') as inserted
+    from private.tidas_import_groups_v2 g
+    cross join lateral jsonb_array_elements(g.receipt -> 'items') item
+    where g.worker_job_id = v_worker
+    group by 1,2,3
+  )
+  select jsonb_build_object('imported_count', count(*) filter (where inserted),
+    'existing_count', count(*) filter (where not inserted),
+    'successful_root_count', (select count(*) from private.tidas_import_groups_v2 where worker_job_id = v_worker),
+    'source', 'committed_receipts') into v_progress from identities;
+  return jsonb_set(v_result, '{data,importProgress}', v_progress);
+end $$;
+
+
+ALTER FUNCTION "api"."svc_tidas_package_read_v2"("p_requested_by" "uuid", "p_lookup_id" "uuid") OWNER TO "postgres";
 
 
 CREATE OR REPLACE FUNCTION "api"."svc_worker_cancel_job"("p_job_id" "uuid", "p_cancelled_by" "uuid" DEFAULT NULL::"uuid", "p_reason" "text" DEFAULT NULL::"text") RETURNS "jsonb"
@@ -61776,6 +61836,146 @@ $$;
 ALTER FUNCTION "private"."sync_portal_sitemap_row_v1"() OWNER TO "api_internal_executor";
 
 
+CREATE OR REPLACE FUNCTION "private"."tidas_import_group_apply_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid", "p_plan_sha256" "text", "p_root" "jsonb", "p_entries" "jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $_$
+declare
+  v_user uuid;
+  v_plan private.tidas_import_plans_v2%rowtype;
+  v_previous private.tidas_import_groups_v2%rowtype;
+  v_source_sha text;
+  v_entries_sha text;
+  v_root_table text := p_root ->> 'table';
+  v_root_id uuid := (p_root ->> 'id')::uuid;
+  v_root_version text := p_root ->> 'version';
+  v_entry jsonb;
+  v_table text;
+  v_id uuid;
+  v_version text;
+  v_inserted bigint;
+  v_count bigint := 0;
+  v_items jsonb := '[]'::jsonb;
+  v_receipt jsonb;
+begin
+  v_user := private.tidas_import_guard_v2(p_worker_job_id, p_lease_token, p_source_artifact_id);
+  if p_plan_sha256 is null or p_plan_sha256 !~ '^[0-9a-f]{64}$'
+     or v_root_table is null or v_root_table not in ('processes', 'lifecyclemodels')
+     or v_root_id is null or v_root_version is null
+     or v_root_version !~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'
+     or jsonb_typeof(p_entries) is distinct from 'array' then
+    raise exception using errcode = '22023', message = 'TIDAS_IMPORT_GROUP_INVALID';
+  end if;
+  -- Explicit capacity admission; never silently truncate a root closure.
+  if jsonb_array_length(p_entries) = 0 or jsonb_array_length(p_entries) > 50000
+     or octet_length(p_entries::text) > 67108864 then
+    raise exception using errcode = '54000', message = 'TIDAS_IMPORT_GROUP_CAPACITY_EXCEEDED';
+  end if;
+  if not exists (select 1 from jsonb_array_elements(p_entries) e
+    where e ->> 'table' = v_root_table and e ->> 'id' = v_root_id::text
+      and e ->> 'version' = v_root_version)
+    or exists (select 1 from jsonb_array_elements(p_entries) e
+      group by e ->> 'table', e ->> 'id', e ->> 'version' having count(*) > 1) then
+    raise exception using errcode = '22023', message = 'TIDAS_IMPORT_GROUP_IDENTITY_INVALID';
+  end if;
+
+  select artifact_sha256 into v_source_sha from private.lca_package_artifacts where id = p_source_artifact_id;
+  insert into private.tidas_import_plans_v2(worker_job_id, source_artifact_id, source_sha256, plan_sha256)
+  values (p_worker_job_id, p_source_artifact_id, v_source_sha, p_plan_sha256)
+  on conflict (worker_job_id) do nothing;
+  select * into v_plan from private.tidas_import_plans_v2 where worker_job_id = p_worker_job_id for update;
+  if v_plan.source_artifact_id <> p_source_artifact_id or v_plan.source_sha256 <> v_source_sha
+     or v_plan.plan_sha256 <> p_plan_sha256 then
+    raise exception using errcode = '55000', message = 'TIDAS_IMPORT_PLAN_MISMATCH';
+  end if;
+  v_entries_sha := encode(extensions.digest(convert_to(p_entries::text, 'UTF8'), 'sha256'), 'hex');
+  select * into v_previous from private.tidas_import_groups_v2
+  where worker_job_id = p_worker_job_id and root_table = v_root_table
+    and root_id = v_root_id and root_version = v_root_version;
+  if found then
+    if v_previous.entries_sha256 <> v_entries_sha then
+      raise exception using errcode = '55000', message = 'TIDAS_IMPORT_GROUP_REPLAY_MISMATCH';
+    end if;
+    return v_previous.receipt;
+  end if;
+
+  for v_entry in select e from jsonb_array_elements(p_entries) e order by
+    case e ->> 'table' when 'contacts' then 1 when 'sources' then 2
+      when 'unitgroups' then 3 when 'flowproperties' then 4 when 'flows' then 5
+      when 'lifecyclemodels' then 6 when 'processes' then 7 else 8 end,
+    e ->> 'id', e ->> 'version'
+  loop
+    v_table := v_entry ->> 'table';
+    v_id := (v_entry ->> 'id')::uuid;
+    v_version := v_entry ->> 'version';
+    if v_table is null or v_table not in ('contacts','sources','unitgroups','flowproperties','flows','lifecyclemodels','processes')
+       or v_id is null or v_version is null or v_version !~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'
+       or jsonb_typeof(v_entry -> 'json_ordered') is distinct from 'object' then
+      raise exception using errcode = '22023', message = 'TIDAS_IMPORT_ENTRY_INVALID';
+    end if;
+    if v_table = 'lifecyclemodels' then
+      insert into public.lifecyclemodels(id, version, json_ordered, rule_verification, json_tg, user_id)
+      values (v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true),
+        coalesce(nullif(v_entry -> 'json_tg', 'null'::jsonb), '{}'::jsonb), v_user)
+      on conflict (id, version) do nothing;
+    elsif v_table = 'processes' then
+      insert into public.processes(id, version, json_ordered, rule_verification, model_id, user_id)
+      values (v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true),
+        (v_entry ->> 'model_id')::uuid, v_user)
+      on conflict (id, version) do nothing;
+    else
+      execute format('insert into public.%I(id, version, json_ordered, rule_verification, user_id)
+        values ($1,$2,$3,$4,$5) on conflict (id, version) do nothing', v_table)
+      using v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true), v_user;
+    end if;
+    get diagnostics v_inserted = row_count;
+    v_count := v_count + v_inserted;
+    v_items := v_items || jsonb_build_array(jsonb_build_object(
+      'table', v_table, 'id', v_id, 'version', v_version,
+      'disposition', case when v_inserted = 1 then 'inserted' else 'existing' end));
+  end loop;
+  v_receipt := jsonb_build_object('root', p_root,
+    'status', case when v_count > 0 then 'imported' else 'reused' end,
+    'inserted_count', v_count, 'existing_count', jsonb_array_length(p_entries) - v_count, 'items', v_items);
+  insert into private.tidas_import_groups_v2(worker_job_id, root_table, root_id, root_version, entries_sha256, receipt)
+  values (p_worker_job_id, v_root_table, v_root_id, v_root_version, v_entries_sha, v_receipt);
+  perform 1 from private.worker_jobs where id = p_worker_job_id for update;
+  perform private.tidas_import_guard_v2(p_worker_job_id, p_lease_token, p_source_artifact_id);
+  return v_receipt;
+end $_$;
+
+
+ALTER FUNCTION "private"."tidas_import_group_apply_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid", "p_plan_sha256" "text", "p_root" "jsonb", "p_entries" "jsonb") OWNER TO "postgres";
+
+
+CREATE OR REPLACE FUNCTION "private"."tidas_import_guard_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid") RETURNS "uuid"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $_$
+declare v_user uuid;
+begin
+  select j.requested_by into v_user
+  from private.worker_jobs j
+  join private.lca_package_artifacts a on a.worker_job_id = j.id
+  where j.id = p_worker_job_id and j.lease_token = p_lease_token
+    and j.status = 'running' and j.lease_expires_at > clock_timestamp()
+    and j.job_kind = 'tidas.import_package'
+    and j.payload_schema_version = 'tidas.import_package.request.v2'
+    and j.payload_json ->> 'import_policy' = 'root_closure_v2'
+    and j.payload_json ->> 'source_artifact_id' = p_source_artifact_id::text
+    and a.id = p_source_artifact_id and a.artifact_kind = 'import_source'
+    and a.status = 'ready' and a.artifact_sha256 ~ '^[0-9a-f]{64}$'
+    and a.metadata ->> 'requested_by' = j.requested_by::text;
+  if v_user is null then
+    raise exception using errcode = '55000', message = 'TIDAS_IMPORT_LEASE_OR_SOURCE_INVALID';
+  end if;
+  return v_user;
+end $_$;
+
+
+ALTER FUNCTION "private"."tidas_import_guard_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid") OWNER TO "postgres";
+
+
 CREATE OR REPLACE FUNCTION "private"."unitgroups_sync_jsonb_version"() RETURNS "trigger"
     LANGUAGE "plpgsql"
     SET "search_path" TO 'private', 'api', 'public', 'util', 'extensions', 'pg_temp'
@@ -70574,8 +70774,8 @@ CREATE TABLE IF NOT EXISTS "private"."lca_package_artifacts" (
     "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "worker_job_id" "uuid",
-    CONSTRAINT "lca_package_artifacts_format_chk" CHECK (("artifact_format" = ANY (ARRAY['tidas-package-zip:v1'::"text", 'tidas-package-export-report:v1'::"text", 'tidas-package-import-report:v1'::"text"]))),
-    CONSTRAINT "lca_package_artifacts_kind_chk" CHECK (("artifact_kind" = ANY (ARRAY['import_source'::"text", 'export_zip'::"text", 'export_report'::"text", 'import_report'::"text"]))),
+    CONSTRAINT "lca_package_artifacts_format_chk" CHECK (("artifact_format" = ANY (ARRAY['tidas-package-zip:v1'::"text", 'tidas-package-export-report:v1'::"text", 'tidas-package-import-report:v1'::"text", 'tidas-package-import-report:v2'::"text", 'tidas-package-import-details:v2'::"text"]))),
+    CONSTRAINT "lca_package_artifacts_kind_chk" CHECK (("artifact_kind" = ANY (ARRAY['import_source'::"text", 'export_zip'::"text", 'export_report'::"text", 'import_report'::"text", 'import_details'::"text"]))),
     CONSTRAINT "lca_package_artifacts_size_chk" CHECK ((("artifact_byte_size" IS NULL) OR ("artifact_byte_size" >= 0))),
     CONSTRAINT "lca_package_artifacts_status_chk" CHECK (("status" = ANY (ARRAY['pending'::"text", 'ready'::"text", 'failed'::"text", 'deleted'::"text"]))),
     CONSTRAINT "lca_package_artifacts_url_chk" CHECK (("length"("btrim"("artifact_url")) > 0))
@@ -72278,6 +72478,37 @@ CREATE TABLE IF NOT EXISTS "private"."teams" (
 ALTER TABLE "private"."teams" OWNER TO "postgres";
 
 
+CREATE TABLE IF NOT EXISTS "private"."tidas_import_groups_v2" (
+    "worker_job_id" "uuid" NOT NULL,
+    "root_table" "text" NOT NULL,
+    "root_id" "uuid" NOT NULL,
+    "root_version" "text" NOT NULL,
+    "entries_sha256" "text" NOT NULL,
+    "receipt" "jsonb" NOT NULL,
+    "committed_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "tidas_import_groups_v2_receipt_check" CHECK (("jsonb_typeof"("receipt") = 'object'::"text")),
+    CONSTRAINT "tidas_import_groups_v2_root_table_check" CHECK (("root_table" = ANY (ARRAY['processes'::"text", 'lifecyclemodels'::"text"]))),
+    CONSTRAINT "tidas_import_groups_v2_root_version_check" CHECK (("root_version" ~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'::"text"))
+);
+
+
+ALTER TABLE "private"."tidas_import_groups_v2" OWNER TO "postgres";
+
+
+CREATE TABLE IF NOT EXISTS "private"."tidas_import_plans_v2" (
+    "worker_job_id" "uuid" NOT NULL,
+    "source_artifact_id" "uuid" NOT NULL,
+    "source_sha256" "text" NOT NULL,
+    "plan_sha256" "text" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "tidas_import_plans_v2_plan_sha256_check" CHECK (("plan_sha256" ~ '^[0-9a-f]{64}$'::"text")),
+    CONSTRAINT "tidas_import_plans_v2_source_sha256_check" CHECK (("source_sha256" ~ '^[0-9a-f]{64}$'::"text"))
+);
+
+
+ALTER TABLE "private"."tidas_import_plans_v2" OWNER TO "postgres";
+
+
 CREATE TABLE IF NOT EXISTS "private"."users" (
     "id" "uuid" NOT NULL,
     "raw_user_meta_data" "jsonb",
@@ -73859,6 +74090,16 @@ ALTER TABLE ONLY "private"."roles"
 
 ALTER TABLE ONLY "private"."teams"
     ADD CONSTRAINT "teams_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "private"."tidas_import_groups_v2"
+    ADD CONSTRAINT "tidas_import_groups_v2_pkey" PRIMARY KEY ("worker_job_id", "root_table", "root_id", "root_version");
+
+
+
+ALTER TABLE ONLY "private"."tidas_import_plans_v2"
+    ADD CONSTRAINT "tidas_import_plans_v2_pkey" PRIMARY KEY ("worker_job_id");
 
 
 
@@ -76310,6 +76551,21 @@ ALTER TABLE ONLY "private"."roles"
 
 
 
+ALTER TABLE ONLY "private"."tidas_import_groups_v2"
+    ADD CONSTRAINT "tidas_import_groups_v2_worker_job_id_fkey" FOREIGN KEY ("worker_job_id") REFERENCES "private"."tidas_import_plans_v2"("worker_job_id");
+
+
+
+ALTER TABLE ONLY "private"."tidas_import_plans_v2"
+    ADD CONSTRAINT "tidas_import_plans_v2_source_artifact_id_fkey" FOREIGN KEY ("source_artifact_id") REFERENCES "private"."lca_package_artifacts"("id");
+
+
+
+ALTER TABLE ONLY "private"."tidas_import_plans_v2"
+    ADD CONSTRAINT "tidas_import_plans_v2_worker_job_id_fkey" FOREIGN KEY ("worker_job_id") REFERENCES "private"."worker_jobs"("id");
+
+
+
 ALTER TABLE ONLY "private"."worker_job_artifacts"
     ADD CONSTRAINT "worker_job_artifacts_job_id_fkey" FOREIGN KEY ("job_id") REFERENCES "private"."worker_jobs"("id") ON DELETE CASCADE;
 
@@ -76815,6 +77071,12 @@ CREATE POLICY "select by self and team and admin" ON "private"."users" FOR SELEC
 
 
 ALTER TABLE "private"."teams" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "private"."tidas_import_groups_v2" ENABLE ROW LEVEL SECURITY;
+
+
+ALTER TABLE "private"."tidas_import_plans_v2" ENABLE ROW LEVEL SECURITY;
 
 
 CREATE POLICY "transitional_reviews_update_submitter_only" ON "private"."reviews" FOR UPDATE TO "authenticated" USING (((( SELECT "auth"."uid"() AS "uid") IS NOT NULL) AND (((("json" -> 'user'::"text") ->> 'id'::"text"))::"uuid" = ( SELECT "auth"."uid"() AS "uid")))) WITH CHECK (((( SELECT "auth"."uid"() AS "uid") IS NOT NULL) AND (((("json" -> 'user'::"text") ->> 'id'::"text"))::"uuid" = ( SELECT "auth"."uid"() AS "uid"))));
@@ -78893,6 +79155,11 @@ GRANT ALL ON FUNCTION "api"."svc_tidas_package_import_enqueue"("p_requested_by" 
 
 
 
+REVOKE ALL ON FUNCTION "api"."svc_tidas_package_import_enqueue_v2"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text") FROM PUBLIC;
+GRANT ALL ON FUNCTION "api"."svc_tidas_package_import_enqueue_v2"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text") TO "service_role";
+
+
+
 REVOKE ALL ON FUNCTION "api"."svc_tidas_package_import_prepare"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_url" "text", "p_content_type" "text", "p_filename" "text", "p_idempotency_key" "text") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."svc_tidas_package_import_prepare"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_url" "text", "p_content_type" "text", "p_filename" "text", "p_idempotency_key" "text") TO "service_role";
 
@@ -78900,6 +79167,11 @@ GRANT ALL ON FUNCTION "api"."svc_tidas_package_import_prepare"("p_requested_by" 
 
 REVOKE ALL ON FUNCTION "api"."svc_tidas_package_read"("p_requested_by" "uuid", "p_lookup_id" "uuid") FROM PUBLIC;
 GRANT ALL ON FUNCTION "api"."svc_tidas_package_read"("p_requested_by" "uuid", "p_lookup_id" "uuid") TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "api"."svc_tidas_package_read_v2"("p_requested_by" "uuid", "p_lookup_id" "uuid") FROM PUBLIC;
+GRANT ALL ON FUNCTION "api"."svc_tidas_package_read_v2"("p_requested_by" "uuid", "p_lookup_id" "uuid") TO "service_role";
 
 
 
@@ -80571,6 +80843,15 @@ REVOKE ALL ON FUNCTION "private"."sync_portal_catalog_search_row_v2"() FROM PUBL
 
 
 REVOKE ALL ON FUNCTION "private"."sync_portal_sitemap_row_v1"() FROM PUBLIC;
+
+
+
+REVOKE ALL ON FUNCTION "private"."tidas_import_group_apply_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid", "p_plan_sha256" "text", "p_root" "jsonb", "p_entries" "jsonb") FROM PUBLIC;
+GRANT ALL ON FUNCTION "private"."tidas_import_group_apply_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid", "p_plan_sha256" "text", "p_root" "jsonb", "p_entries" "jsonb") TO "service_role";
+
+
+
+REVOKE ALL ON FUNCTION "private"."tidas_import_guard_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid") FROM PUBLIC;
 
 
 

--- a/supabase/workspace/schemas/api/functions/svc_tidas_package_import_enqueue_v2/definition.sql
+++ b/supabase/workspace/schemas/api/functions/svc_tidas_package_import_enqueue_v2/definition.sql
@@ -1,0 +1,31 @@
+CREATE OR REPLACE FUNCTION "api"."svc_tidas_package_import_enqueue_v2"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text" DEFAULT NULL::"text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare v_existing uuid; v_schema text; v_result jsonb; v_worker_id uuid;
+begin
+  select worker_job_id into v_existing from private.lca_package_artifacts
+  where id = p_source_artifact_id and job_id = p_job_id
+    and metadata ->> 'requested_by' = p_requested_by::text for update;
+  if v_existing is not null then
+    select payload_schema_version into v_schema from private.worker_jobs where id = v_existing;
+    if v_schema is distinct from 'tidas.import_package.request.v2' then
+      return jsonb_build_object('ok', false, 'code', 'IMPORT_POLICY_MISMATCH', 'status', 409);
+    end if;
+  end if;
+  v_result := api.svc_tidas_package_import_enqueue(p_requested_by, p_job_id, p_source_artifact_id,
+    p_artifact_sha256, p_artifact_byte_size, p_filename, p_content_type);
+  if coalesce((v_result ->> 'ok')::boolean, false) then
+    v_worker_id := (v_result ->> 'worker_job_id')::uuid;
+    update private.worker_jobs set payload_schema_version = 'tidas.import_package.request.v2',
+      payload_json = payload_json || jsonb_build_object('import_policy', 'root_closure_v2')
+    where id = v_worker_id and status = 'queued' and attempt_count = 0;
+  end if;
+  return v_result;
+end $$;
+
+ALTER FUNCTION "api"."svc_tidas_package_import_enqueue_v2"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."svc_tidas_package_import_enqueue_v2"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."svc_tidas_package_import_enqueue_v2"("p_requested_by" "uuid", "p_job_id" "uuid", "p_source_artifact_id" "uuid", "p_artifact_sha256" "text", "p_artifact_byte_size" bigint, "p_filename" "text", "p_content_type" "text") TO "service_role";

--- a/supabase/workspace/schemas/api/functions/svc_tidas_package_read_v2/definition.sql
+++ b/supabase/workspace/schemas/api/functions/svc_tidas_package_read_v2/definition.sql
@@ -1,0 +1,31 @@
+CREATE OR REPLACE FUNCTION "api"."svc_tidas_package_read_v2"("p_requested_by" "uuid", "p_lookup_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $$
+declare v_result jsonb; v_worker uuid; v_progress jsonb;
+begin
+  v_result := api.svc_tidas_package_read(p_requested_by, p_lookup_id);
+  v_worker := (v_result #>> '{data,workerJobId}')::uuid;
+  if v_worker is null or v_result #>> '{data,payload,import_policy}' is distinct from 'root_closure_v2' then
+    return v_result;
+  end if;
+  with identities as (
+    select item ->> 'table' as tab, item ->> 'id' as id, item ->> 'version' as ver,
+      bool_or(item ->> 'disposition' = 'inserted') as inserted
+    from private.tidas_import_groups_v2 g
+    cross join lateral jsonb_array_elements(g.receipt -> 'items') item
+    where g.worker_job_id = v_worker
+    group by 1,2,3
+  )
+  select jsonb_build_object('imported_count', count(*) filter (where inserted),
+    'existing_count', count(*) filter (where not inserted),
+    'successful_root_count', (select count(*) from private.tidas_import_groups_v2 where worker_job_id = v_worker),
+    'source', 'committed_receipts') into v_progress from identities;
+  return jsonb_set(v_result, '{data,importProgress}', v_progress);
+end $$;
+
+ALTER FUNCTION "api"."svc_tidas_package_read_v2"("p_requested_by" "uuid", "p_lookup_id" "uuid") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "api"."svc_tidas_package_read_v2"("p_requested_by" "uuid", "p_lookup_id" "uuid") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "api"."svc_tidas_package_read_v2"("p_requested_by" "uuid", "p_lookup_id" "uuid") TO "service_role";

--- a/supabase/workspace/schemas/private/functions/tidas_import_group_apply_v2/definition.sql
+++ b/supabase/workspace/schemas/private/functions/tidas_import_group_apply_v2/definition.sql
@@ -1,0 +1,113 @@
+CREATE OR REPLACE FUNCTION "private"."tidas_import_group_apply_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid", "p_plan_sha256" "text", "p_root" "jsonb", "p_entries" "jsonb") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $_$
+declare
+  v_user uuid;
+  v_plan private.tidas_import_plans_v2%rowtype;
+  v_previous private.tidas_import_groups_v2%rowtype;
+  v_source_sha text;
+  v_entries_sha text;
+  v_root_table text := p_root ->> 'table';
+  v_root_id uuid := (p_root ->> 'id')::uuid;
+  v_root_version text := p_root ->> 'version';
+  v_entry jsonb;
+  v_table text;
+  v_id uuid;
+  v_version text;
+  v_inserted bigint;
+  v_count bigint := 0;
+  v_items jsonb := '[]'::jsonb;
+  v_receipt jsonb;
+begin
+  v_user := private.tidas_import_guard_v2(p_worker_job_id, p_lease_token, p_source_artifact_id);
+  if p_plan_sha256 is null or p_plan_sha256 !~ '^[0-9a-f]{64}$'
+     or v_root_table is null or v_root_table not in ('processes', 'lifecyclemodels')
+     or v_root_id is null or v_root_version is null
+     or v_root_version !~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'
+     or jsonb_typeof(p_entries) is distinct from 'array' then
+    raise exception using errcode = '22023', message = 'TIDAS_IMPORT_GROUP_INVALID';
+  end if;
+  -- Explicit capacity admission; never silently truncate a root closure.
+  if jsonb_array_length(p_entries) = 0 or jsonb_array_length(p_entries) > 50000
+     or octet_length(p_entries::text) > 67108864 then
+    raise exception using errcode = '54000', message = 'TIDAS_IMPORT_GROUP_CAPACITY_EXCEEDED';
+  end if;
+  if not exists (select 1 from jsonb_array_elements(p_entries) e
+    where e ->> 'table' = v_root_table and e ->> 'id' = v_root_id::text
+      and e ->> 'version' = v_root_version)
+    or exists (select 1 from jsonb_array_elements(p_entries) e
+      group by e ->> 'table', e ->> 'id', e ->> 'version' having count(*) > 1) then
+    raise exception using errcode = '22023', message = 'TIDAS_IMPORT_GROUP_IDENTITY_INVALID';
+  end if;
+
+  select artifact_sha256 into v_source_sha from private.lca_package_artifacts where id = p_source_artifact_id;
+  insert into private.tidas_import_plans_v2(worker_job_id, source_artifact_id, source_sha256, plan_sha256)
+  values (p_worker_job_id, p_source_artifact_id, v_source_sha, p_plan_sha256)
+  on conflict (worker_job_id) do nothing;
+  select * into v_plan from private.tidas_import_plans_v2 where worker_job_id = p_worker_job_id for update;
+  if v_plan.source_artifact_id <> p_source_artifact_id or v_plan.source_sha256 <> v_source_sha
+     or v_plan.plan_sha256 <> p_plan_sha256 then
+    raise exception using errcode = '55000', message = 'TIDAS_IMPORT_PLAN_MISMATCH';
+  end if;
+  v_entries_sha := encode(extensions.digest(convert_to(p_entries::text, 'UTF8'), 'sha256'), 'hex');
+  select * into v_previous from private.tidas_import_groups_v2
+  where worker_job_id = p_worker_job_id and root_table = v_root_table
+    and root_id = v_root_id and root_version = v_root_version;
+  if found then
+    if v_previous.entries_sha256 <> v_entries_sha then
+      raise exception using errcode = '55000', message = 'TIDAS_IMPORT_GROUP_REPLAY_MISMATCH';
+    end if;
+    return v_previous.receipt;
+  end if;
+
+  for v_entry in select e from jsonb_array_elements(p_entries) e order by
+    case e ->> 'table' when 'contacts' then 1 when 'sources' then 2
+      when 'unitgroups' then 3 when 'flowproperties' then 4 when 'flows' then 5
+      when 'lifecyclemodels' then 6 when 'processes' then 7 else 8 end,
+    e ->> 'id', e ->> 'version'
+  loop
+    v_table := v_entry ->> 'table';
+    v_id := (v_entry ->> 'id')::uuid;
+    v_version := v_entry ->> 'version';
+    if v_table is null or v_table not in ('contacts','sources','unitgroups','flowproperties','flows','lifecyclemodels','processes')
+       or v_id is null or v_version is null or v_version !~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'
+       or jsonb_typeof(v_entry -> 'json_ordered') is distinct from 'object' then
+      raise exception using errcode = '22023', message = 'TIDAS_IMPORT_ENTRY_INVALID';
+    end if;
+    if v_table = 'lifecyclemodels' then
+      insert into public.lifecyclemodels(id, version, json_ordered, rule_verification, json_tg, user_id)
+      values (v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true),
+        coalesce(nullif(v_entry -> 'json_tg', 'null'::jsonb), '{}'::jsonb), v_user)
+      on conflict (id, version) do nothing;
+    elsif v_table = 'processes' then
+      insert into public.processes(id, version, json_ordered, rule_verification, model_id, user_id)
+      values (v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true),
+        (v_entry ->> 'model_id')::uuid, v_user)
+      on conflict (id, version) do nothing;
+    else
+      execute format('insert into public.%I(id, version, json_ordered, rule_verification, user_id)
+        values ($1,$2,$3,$4,$5) on conflict (id, version) do nothing', v_table)
+      using v_id, v_version, v_entry -> 'json_ordered', coalesce((v_entry ->> 'rule_verification')::boolean, true), v_user;
+    end if;
+    get diagnostics v_inserted = row_count;
+    v_count := v_count + v_inserted;
+    v_items := v_items || jsonb_build_array(jsonb_build_object(
+      'table', v_table, 'id', v_id, 'version', v_version,
+      'disposition', case when v_inserted = 1 then 'inserted' else 'existing' end));
+  end loop;
+  v_receipt := jsonb_build_object('root', p_root,
+    'status', case when v_count > 0 then 'imported' else 'reused' end,
+    'inserted_count', v_count, 'existing_count', jsonb_array_length(p_entries) - v_count, 'items', v_items);
+  insert into private.tidas_import_groups_v2(worker_job_id, root_table, root_id, root_version, entries_sha256, receipt)
+  values (p_worker_job_id, v_root_table, v_root_id, v_root_version, v_entries_sha, v_receipt);
+  perform 1 from private.worker_jobs where id = p_worker_job_id for update;
+  perform private.tidas_import_guard_v2(p_worker_job_id, p_lease_token, p_source_artifact_id);
+  return v_receipt;
+end $_$;
+
+ALTER FUNCTION "private"."tidas_import_group_apply_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid", "p_plan_sha256" "text", "p_root" "jsonb", "p_entries" "jsonb") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "private"."tidas_import_group_apply_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid", "p_plan_sha256" "text", "p_root" "jsonb", "p_entries" "jsonb") FROM PUBLIC;
+
+GRANT ALL ON FUNCTION "private"."tidas_import_group_apply_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid", "p_plan_sha256" "text", "p_root" "jsonb", "p_entries" "jsonb") TO "service_role";

--- a/supabase/workspace/schemas/private/functions/tidas_import_guard_v2/definition.sql
+++ b/supabase/workspace/schemas/private/functions/tidas_import_guard_v2/definition.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION "private"."tidas_import_guard_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid") RETURNS "uuid"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO ''
+    AS $_$
+declare v_user uuid;
+begin
+  select j.requested_by into v_user
+  from private.worker_jobs j
+  join private.lca_package_artifacts a on a.worker_job_id = j.id
+  where j.id = p_worker_job_id and j.lease_token = p_lease_token
+    and j.status = 'running' and j.lease_expires_at > clock_timestamp()
+    and j.job_kind = 'tidas.import_package'
+    and j.payload_schema_version = 'tidas.import_package.request.v2'
+    and j.payload_json ->> 'import_policy' = 'root_closure_v2'
+    and j.payload_json ->> 'source_artifact_id' = p_source_artifact_id::text
+    and a.id = p_source_artifact_id and a.artifact_kind = 'import_source'
+    and a.status = 'ready' and a.artifact_sha256 ~ '^[0-9a-f]{64}$'
+    and a.metadata ->> 'requested_by' = j.requested_by::text;
+  if v_user is null then
+    raise exception using errcode = '55000', message = 'TIDAS_IMPORT_LEASE_OR_SOURCE_INVALID';
+  end if;
+  return v_user;
+end $_$;
+
+ALTER FUNCTION "private"."tidas_import_guard_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid") OWNER TO "postgres";
+
+REVOKE ALL ON FUNCTION "private"."tidas_import_guard_v2"("p_worker_job_id" "uuid", "p_lease_token" "uuid", "p_source_artifact_id" "uuid") FROM PUBLIC;

--- a/supabase/workspace/schemas/private/tables/lca_package_artifacts/table.sql
+++ b/supabase/workspace/schemas/private/tables/lca_package_artifacts/table.sql
@@ -14,8 +14,8 @@ CREATE TABLE IF NOT EXISTS "private"."lca_package_artifacts" (
     "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "worker_job_id" "uuid",
-    CONSTRAINT "lca_package_artifacts_format_chk" CHECK (("artifact_format" = ANY (ARRAY['tidas-package-zip:v1'::"text", 'tidas-package-export-report:v1'::"text", 'tidas-package-import-report:v1'::"text"]))),
-    CONSTRAINT "lca_package_artifacts_kind_chk" CHECK (("artifact_kind" = ANY (ARRAY['import_source'::"text", 'export_zip'::"text", 'export_report'::"text", 'import_report'::"text"]))),
+    CONSTRAINT "lca_package_artifacts_format_chk" CHECK (("artifact_format" = ANY (ARRAY['tidas-package-zip:v1'::"text", 'tidas-package-export-report:v1'::"text", 'tidas-package-import-report:v1'::"text", 'tidas-package-import-report:v2'::"text", 'tidas-package-import-details:v2'::"text"]))),
+    CONSTRAINT "lca_package_artifacts_kind_chk" CHECK (("artifact_kind" = ANY (ARRAY['import_source'::"text", 'export_zip'::"text", 'export_report'::"text", 'import_report'::"text", 'import_details'::"text"]))),
     CONSTRAINT "lca_package_artifacts_size_chk" CHECK ((("artifact_byte_size" IS NULL) OR ("artifact_byte_size" >= 0))),
     CONSTRAINT "lca_package_artifacts_status_chk" CHECK (("status" = ANY (ARRAY['pending'::"text", 'ready'::"text", 'failed'::"text", 'deleted'::"text"]))),
     CONSTRAINT "lca_package_artifacts_url_chk" CHECK (("length"("btrim"("artifact_url")) > 0))

--- a/supabase/workspace/schemas/private/tables/tidas_import_groups_v2/table.sql
+++ b/supabase/workspace/schemas/private/tables/tidas_import_groups_v2/table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "private"."tidas_import_groups_v2" (
+    "worker_job_id" "uuid" NOT NULL,
+    "root_table" "text" NOT NULL,
+    "root_id" "uuid" NOT NULL,
+    "root_version" "text" NOT NULL,
+    "entries_sha256" "text" NOT NULL,
+    "receipt" "jsonb" NOT NULL,
+    "committed_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "tidas_import_groups_v2_receipt_check" CHECK (("jsonb_typeof"("receipt") = 'object'::"text")),
+    CONSTRAINT "tidas_import_groups_v2_root_table_check" CHECK (("root_table" = ANY (ARRAY['processes'::"text", 'lifecyclemodels'::"text"]))),
+    CONSTRAINT "tidas_import_groups_v2_root_version_check" CHECK (("root_version" ~ '^[0-9]{2}\.[0-9]{2}\.[0-9]{3}$'::"text"))
+);
+
+ALTER TABLE "private"."tidas_import_groups_v2" OWNER TO "postgres";
+
+ALTER TABLE ONLY "private"."tidas_import_groups_v2"
+    ADD CONSTRAINT "tidas_import_groups_v2_pkey" PRIMARY KEY ("worker_job_id", "root_table", "root_id", "root_version");
+
+ALTER TABLE ONLY "private"."tidas_import_groups_v2"
+    ADD CONSTRAINT "tidas_import_groups_v2_worker_job_id_fkey" FOREIGN KEY ("worker_job_id") REFERENCES "private"."tidas_import_plans_v2"("worker_job_id");
+
+ALTER TABLE "private"."tidas_import_groups_v2" ENABLE ROW LEVEL SECURITY;

--- a/supabase/workspace/schemas/private/tables/tidas_import_plans_v2/table.sql
+++ b/supabase/workspace/schemas/private/tables/tidas_import_plans_v2/table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "private"."tidas_import_plans_v2" (
+    "worker_job_id" "uuid" NOT NULL,
+    "source_artifact_id" "uuid" NOT NULL,
+    "source_sha256" "text" NOT NULL,
+    "plan_sha256" "text" NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "tidas_import_plans_v2_plan_sha256_check" CHECK (("plan_sha256" ~ '^[0-9a-f]{64}$'::"text")),
+    CONSTRAINT "tidas_import_plans_v2_source_sha256_check" CHECK (("source_sha256" ~ '^[0-9a-f]{64}$'::"text"))
+);
+
+ALTER TABLE "private"."tidas_import_plans_v2" OWNER TO "postgres";
+
+ALTER TABLE ONLY "private"."tidas_import_plans_v2"
+    ADD CONSTRAINT "tidas_import_plans_v2_pkey" PRIMARY KEY ("worker_job_id");
+
+ALTER TABLE ONLY "private"."tidas_import_plans_v2"
+    ADD CONSTRAINT "tidas_import_plans_v2_source_artifact_id_fkey" FOREIGN KEY ("source_artifact_id") REFERENCES "private"."lca_package_artifacts"("id");
+
+ALTER TABLE ONLY "private"."tidas_import_plans_v2"
+    ADD CONSTRAINT "tidas_import_plans_v2_worker_job_id_fkey" FOREIGN KEY ("worker_job_id") REFERENCES "private"."worker_jobs"("id");
+
+ALTER TABLE "private"."tidas_import_plans_v2" ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Change
Allow valid Process/Model reference groups to import independently. Add service-only v2 policy admission, atomic exact-key insert-or-skip transactions, lease fencing, immutable plan binding, durable group receipts and owner-scoped progress. Existing rows are never overwritten. Regenerate the five-schema and public/api type snapshots.

## Validation
Blank isolated migration replay through 20260909121000; 19 partial-import pgTAP cases; four OAuth/API/schema suites; concurrent duplicate insert/skip experiment; schema generation repeated without drift. The repository pre-push Docpact gate passed.

## Rollout
Targets dev. Hosted Preview/Dev checks remain pending. Coordinate with Worker #283, Edge #411 and Next #1046 before enabling the new flow. Preserve v1 jobs. Required promotion and workspace integration remain tracked in https://github.com/tiangong-lca/workspace/issues/1077.

Closes https://github.com/tiangong-lca/database-engine/issues/634

Closes tiangong-lca/database-engine#634
